### PR TITLE
feat: improve search with scope toggle (current part / all parts)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     commit-message:
       prefix: "deps"
     groups:
-      react:
+      all-dependencies:
         patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
+          - "*"

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -96,13 +96,13 @@ export default function PlayPage() {
   };
 
   const loadAllMarkdownContent = async (config: SessionConfig) => {
-    const documents: Array<{ file: FileReference; content: string }> = [];
+    const documents: Array<{ file: FileReference; content: string; partId: string; partName: string }> = [];
 
     for (const part of config.parts) {
       if (part.planFile) {
         try {
           const content = await fileSystemManager.readTextFile(part.planFile.path);
-          documents.push({ file: part.planFile, content });
+          documents.push({ file: part.planFile, content, partId: part.id, partName: part.name });
         } catch (err) {
           console.error(`Error loading plan for ${part.name}:`, err);
         }
@@ -111,7 +111,7 @@ export default function PlayPage() {
       for (const doc of part.supportDocs) {
         try {
           const content = await fileSystemManager.readTextFile(doc.path);
-          documents.push({ file: doc, content });
+          documents.push({ file: doc, content, partId: part.id, partName: part.name });
         } catch (err) {
           console.error(`Error loading doc ${doc.name}:`, err);
         }
@@ -424,6 +424,8 @@ export default function PlayPage() {
                 <SearchDialog
                   searchManager={searchManager}
                   onResultClick={handleSearchResultClick}
+                  currentPartId={currentPartId}
+                  currentPartName={currentPart?.name ?? null}
                 />
               </div>
 

--- a/components/play/SearchDialog.tsx
+++ b/components/play/SearchDialog.tsx
@@ -8,16 +8,21 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Search, FileText } from 'lucide-react';
 
+type SearchScope = 'current' | 'all';
+
 interface SearchDialogProps {
   searchManager: SearchManager | null;
   onResultClick: (filePath: string) => void;
+  currentPartId: string | null;
+  currentPartName: string | null;
 }
 
-export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps) {
+export function SearchDialog({ searchManager, onResultClick, currentPartId, currentPartName }: SearchDialogProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [scope, setScope] = useState<SearchScope>('current');
 
   useEffect(() => {
     if (!query.trim() || !searchManager) {
@@ -27,13 +32,14 @@ export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps
 
     setIsSearching(true);
     const timeoutId = setTimeout(() => {
-      const searchResults = searchManager.search(query);
+      const filterPartId = scope === 'current' ? (currentPartId ?? undefined) : undefined;
+      const searchResults = searchManager.search(query, 10, filterPartId);
       setResults(searchResults);
       setIsSearching(false);
     }, 300); // Debounce search
 
     return () => clearTimeout(timeoutId);
-  }, [query, searchManager]);
+  }, [query, searchManager, scope, currentPartId]);
 
   useEffect(() => {
     // Keyboard shortcut: Cmd/Ctrl + K
@@ -70,13 +76,38 @@ export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps
           <DialogTitle>Search Documents</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
-          <Input
-            placeholder="Search plans, NPCs, monsters, maps..."
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="w-full"
-            autoFocus
-          />
+          <div className="flex gap-2">
+            <Input
+              placeholder="Search plans, NPCs, monsters, maps..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="flex-1"
+              autoFocus
+            />
+          </div>
+
+          <div className="flex items-center gap-1 rounded-lg border p-1 w-fit">
+            <button
+              onClick={() => setScope('current')}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                scope === 'current'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Current Part{currentPartName ? ` (${currentPartName})` : ''}
+            </button>
+            <button
+              onClick={() => setScope('all')}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                scope === 'all'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              All Parts
+            </button>
+          </div>
 
           {isSearching && (
             <p className="text-sm text-muted-foreground text-center py-4">
@@ -86,7 +117,17 @@ export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps
 
           {!isSearching && query && results.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-4">
-              No results found for "{query}"
+              No results found for &quot;{query}&quot;
+              {scope === 'current' && (
+                <span className="block mt-1">
+                  <button
+                    onClick={() => setScope('all')}
+                    className="text-primary hover:underline"
+                  >
+                    Try searching all parts
+                  </button>
+                </span>
+              )}
             </p>
           )}
 
@@ -102,7 +143,18 @@ export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps
                     <div className="flex items-start gap-3">
                       <FileText className="h-4 w-4 mt-1 text-muted-foreground flex-shrink-0" />
                       <div className="flex-1 min-w-0">
-                        <p className="font-medium truncate">{result.name}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium truncate">{result.name}</p>
+                          {scope === 'all' && (
+                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium flex-shrink-0 ${
+                              result.partId === currentPartId
+                                ? 'bg-primary/10 text-primary'
+                                : 'bg-muted text-muted-foreground'
+                            }`}>
+                              {result.partName}
+                            </span>
+                          )}
+                        </div>
                         <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
                           {result.context}
                         </p>
@@ -116,7 +168,7 @@ export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps
 
           {!query && (
             <div className="text-sm text-muted-foreground text-center py-8">
-              <p>Type to search through all your campaign documents</p>
+              <p>Type to search through your campaign documents</p>
               <p className="mt-2 text-xs">Plans • NPCs • Monsters • Maps • FAQs</p>
             </div>
           )}
@@ -125,4 +177,3 @@ export function SearchDialog({ searchManager, onResultClick }: SearchDialogProps
     </Dialog>
   );
 }
-

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -6,17 +6,19 @@ export interface SearchResult {
   name: string; // file name
   score: number;
   context: string; // snippet of text around the match
+  partId: string;
+  partName: string;
 }
 
 export class SearchManager {
   private index: lunr.Index | null = null;
-  private documents: Map<string, { name: string; content: string }> = new Map();
+  private documents: Map<string, { name: string; content: string; partId: string; partName: string }> = new Map();
 
   /**
    * Indexes markdown documents for search
    */
   async indexDocuments(
-    documents: Array<{ file: FileReference; content: string }>
+    documents: Array<{ file: FileReference; content: string; partId: string; partName: string }>
   ) {
     this.documents.clear();
 
@@ -24,6 +26,8 @@ export class SearchManager {
       this.documents.set(doc.file.path, {
         name: doc.file.name,
         content: doc.content,
+        partId: doc.partId,
+        partName: doc.partName,
       });
     });
 
@@ -43,9 +47,9 @@ export class SearchManager {
   }
 
   /**
-   * Searches the indexed documents
+   * Searches the indexed documents, optionally filtered by part
    */
-  search(query: string, maxResults: number = 10): SearchResult[] {
+  search(query: string, maxResults: number = 10, filterPartId?: string): SearchResult[] {
     if (!this.index || !query.trim()) {
       return [];
     }
@@ -53,21 +57,25 @@ export class SearchManager {
     try {
       const results = this.index.search(query);
 
-      return results.slice(0, maxResults).map(result => {
-        const doc = this.documents.get(result.ref);
-        if (!doc) {
-          return null;
-        }
+      return results
+        .map(result => {
+          const doc = this.documents.get(result.ref);
+          if (!doc) return null;
+          if (filterPartId && doc.partId !== filterPartId) return null;
 
-        const context = this.extractContext(doc.content, query);
+          const context = this.extractContext(doc.content, query);
 
-        return {
-          ref: result.ref,
-          name: doc.name,
-          score: result.score,
-          context,
-        };
-      }).filter((r): r is SearchResult => r !== null);
+          return {
+            ref: result.ref,
+            name: doc.name,
+            score: result.score,
+            context,
+            partId: doc.partId,
+            partName: doc.partName,
+          };
+        })
+        .filter((r): r is SearchResult => r !== null)
+        .slice(0, maxResults);
     } catch (error) {
       console.error('Search error:', error);
       return [];


### PR DESCRIPTION
## Summary
- **Search scope toggle**: Added "Current Part" / "All Parts" toggle in the search dialog, defaulting to current part. Users can now choose to search only within their active part or across all campaign parts.
- **Part badges on results**: When searching "All Parts", each result displays a badge showing which part it belongs to, with the current part highlighted differently for quick identification.
- **Smart fallback**: When no results are found in the current part, a clickable prompt suggests searching all parts instead.
- **Dependabot grouping**: Updated dependabot config to group all dependency updates into a single daily PR using a wildcard pattern.

Closes #34

## Test plan
- [ ] Open the search dialog (Cmd/Ctrl+K) and verify the scope toggle appears below the search input
- [ ] Search with "Current Part" selected — only results from the active part should appear
- [ ] Switch to "All Parts" — results from all parts should appear with part name badges
- [ ] Verify clicking a result from another part navigates to that part and correct tab
- [ ] Verify the "Try searching all parts" link appears when no results found in current part
- [ ] Verify the dependabot.yml groups all dependencies with the `*` pattern