### PR TITLE
feat: World Mode — worldbuilding-first GM operating system

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ttrpg-dev",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ yarn-error.log*
 next-env.d.ts
 
 test-results
+# machine-local preview seed (GM campaign content — never commit)
+public/__mundo_seed.json

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,3 +132,12 @@ body[data-scroll-locked] {
   overflow: hidden !important;
   padding-right: 0 !important;
 }
+
+
+/* Player-safe projection: while a fullscreen image is shown to the table
+   (components/world/FullscreenImage.tsx sets html[data-projecting]), hide
+   GM-only sonner toasts, which render at z-index 999999999 — above the
+   z-[200] fullscreen overlay — and would otherwise leak onto the screen. */
+html[data-projecting] [data-sonner-toaster] {
+  display: none !important;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,6 +70,7 @@ export default function SetupPage() {
       name: `Part ${config.parts.length + 1}`,
       planFile: null,
       images: [],
+      battlemaps: [],
       supportDocs: [],
       bgmPlaylist: [],
       eventPlaylists: [],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,8 @@ import { SessionConfig, Part, PathDef } from '@/types';
 import { FileSystemManager, SUPPORTED_IMAGE_EXTENSIONS, SUPPORTED_AUDIO_EXTENSIONS } from '@/lib/fileSystem';
 import { exportConfig, importConfig, createEmptyConfig } from '@/lib/configManager';
 import { scanSessionFolder, getExpectedStructure } from '@/lib/sessionScanner';
+import { hasWorld } from '@/lib/world/worldScanner';
+import { rememberDirHandle } from '@/lib/dirHandle';
 import { PartEditor } from '@/components/setup/PartEditor';
 import { PathManager } from '@/components/setup/PathManager';
 import {
@@ -20,7 +22,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
-import { FolderOpen, Plus, Edit2, Trash2, Download, Upload, Play, AlertCircle, Wand2, HelpCircle } from 'lucide-react';
+import { FolderOpen, Plus, Edit2, Trash2, Download, Upload, Play, AlertCircle, Wand2, HelpCircle, Globe } from 'lucide-react';
 
 export default function SetupPage() {
   const router = useRouter();
@@ -32,6 +34,7 @@ export default function SetupPage() {
   const [newPCName, setNewPCName] = useState('');
   const [showStructureHelp, setShowStructureHelp] = useState(false);
   const [isAutoDetecting, setIsAutoDetecting] = useState(false);
+  const [worldDetected, setWorldDetected] = useState(false);
 
   useEffect(() => {
     setIsSupported(FileSystemManager.isSupported());
@@ -45,6 +48,12 @@ export default function SetupPage() {
         ...config,
         folderName: handle.name,
       });
+      // World mode probe: mundo/mundo.md present -> offer "Entrar al mundo".
+      try {
+        setWorldDetected(await hasWorld(handle));
+      } catch {
+        setWorldDetected(false);
+      }
     } catch (error) {
       if ((error as Error).name === 'AbortError') {
         console.log('Folder selection cancelled by user');
@@ -137,6 +146,7 @@ export default function SetupPage() {
     if (importedConfig) {
       setConfig(importedConfig);
       setFolderSelected(false);
+      setWorldDetected(false);
       alert('Configuration imported successfully. Please select your campaign folder to continue.');
     }
   };
@@ -186,6 +196,13 @@ export default function SetupPage() {
       ...config,
       playerCharacters: config.playerCharacters.filter((_, i) => i !== index),
     });
+  };
+
+  const handleEnterWorld = async () => {
+    const handle = fileSystemManager.getDirectoryHandle();
+    if (!handle) return;
+    await rememberDirHandle(handle);
+    router.push('/world');
   };
 
   const handleStartSession = () => {
@@ -256,6 +273,28 @@ export default function SetupPage() {
             </div>
           </CardContent>
         </Card>
+
+        {/* World Mode (shown when the selected folder contains mundo/mundo.md) */}
+        {worldDetected && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Globe className="h-5 w-5 text-muted-foreground" />
+                Mundo detectado
+              </CardTitle>
+              <CardDescription>
+                La carpeta contiene <code className="bg-muted px-1 rounded">mundo/mundo.md</code> —
+                puedes abrir el visor del mundo
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={handleEnterWorld}>
+                <Globe className="h-4 w-4 mr-2" />
+                Entrar al mundo
+              </Button>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Configuration Management */}
         <Card>

--- a/app/world/layout.tsx
+++ b/app/world/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Mundo',
+};
+
+export default function WorldLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -272,6 +272,8 @@ import {
   deriveLeadActionability,
 } from '@/lib/world/worldScanner';
 import { buildCondContext } from '@/lib/world/conditions';
+import { affordancesFor } from '@/lib/world/shops';
+import type { NodeAffordances } from '@/lib/world/shops';
 import { applicableTables, drawEvent, eventSeenCounts } from '@/lib/world/eventEngine';
 import {
   computeTravelPlan,
@@ -1898,6 +1900,25 @@ export default function WorldPage() {
     [dominantFactionByNode]
   );
 
+  /**
+   * Semantic map-node affordances (shop / info) per entity id, so the GM can
+   * scan a Plano/system and tell storefronts from info spots at a glance. Only
+   * reveal on conocido/visitado nodes — desconocido/rumoreado stay opaque so
+   * the map never leaks what the party hasn't discovered.
+   */
+  const nodeIconsFor = useCallback(
+    (id: string): NodeAffordances | undefined => {
+      if (!model) return undefined;
+      const entity = model.entidades.get(id);
+      if (!entity || (entity.conocimiento !== 'conocido' && entity.conocimiento !== 'visitado')) {
+        return undefined;
+      }
+      const affordances = affordancesFor(model, id);
+      return affordances.shop || affordances.info ? affordances : undefined;
+    },
+    [model]
+  );
+
   // ── Party readout (live store fields; hydrate seeds them from the file) ──
 
   /**
@@ -2667,6 +2688,7 @@ export default function WorldPage() {
                     partyLocationId={partyMapNodeId}
                     leadsBadgeCounts={leadsBadgeCounts}
                     factionColor={factionColor}
+                    nodeIconsFor={nodeIconsFor}
                     showUnknown={showUnknown}
                     onSelect={selectEntity}
                     onDrillIn={enterEntity}
@@ -2680,6 +2702,7 @@ export default function WorldPage() {
                     partyLocationId={partyMapNodeId}
                     leadsBadgeCounts={leadsBadgeCounts}
                     factionColor={factionColor}
+                    nodeIconsFor={nodeIconsFor}
                     showUnknown={showUnknown}
                     onSelect={selectEntity}
                     onDrillIn={enterEntity}
@@ -2693,6 +2716,7 @@ export default function WorldPage() {
                     partyLocationId={partyMapNodeId}
                     leadsBadgeCounts={leadsBadgeCounts}
                     factionColor={factionColor}
+                    nodeIconsFor={nodeIconsFor}
                     showUnknown={showUnknown}
                     onSelect={selectEntity}
                     onDrillIn={enterEntity}

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -1,0 +1,459 @@
+'use client';
+
+/**
+ * /world — read-only world viewer (M1).
+ *
+ * Folder entry paths (all end in the same open-and-scan path):
+ *   - stored handle still granted  -> scan immediately on mount
+ *   - stored handle needs a gesture -> "Reconectar carpeta" button
+ *   - nothing stored               -> "Seleccionar carpeta de campaña" button
+ *   - e2e seam: window.__ttrpgWorldTest.openFromOPFS() feeds the OPFS root
+ *     handle through the same path (contract in e2e/helpers/opfs.ts)
+ *
+ * The page root always carries data-world-status={idle|scanning|ready|error}.
+ */
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { FileSystemManager } from '@/lib/fileSystem';
+import { loadStoredDirHandle, reconnectDirHandle, rememberDirHandle } from '@/lib/dirHandle';
+import { useUiStore, useWorldStore } from '@/lib/world/stores';
+import { StarMap } from '@/components/world/StarMap';
+import type { MapViewport } from '@/components/world/StarMap';
+import { SectorView, WORLD_SCALE } from '@/components/world/SectorView';
+import { EntityPanel } from '@/components/world/EntityPanel';
+import type { EntityPanelEntity, EntityPanelLead } from '@/components/world/EntityPanel';
+import { DiagnosticsPanel } from '@/components/world/DiagnosticsPanel';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { FactionPresence, PlaceEntity, WorldModel } from '@/types/world';
+import { FolderOpen, Globe, RefreshCw, TriangleAlert } from 'lucide-react';
+
+interface TtrpgWorldTestHook {
+  openFromOPFS: () => Promise<void>;
+}
+
+type WorldTestWindow = Window & { __ttrpgWorldTest?: TtrpgWorldTestHook };
+
+/** How the page lets the user open a folder while no world is loaded. */
+type EntryMode = 'checking' | 'select' | 'reconnect';
+
+/** Small stable palette for faction rings, picked by hashing the faction id. */
+const FACTION_PALETTE = [
+  '#f59e0b', // amber
+  '#38bdf8', // sky
+  '#a78bfa', // violet
+  '#34d399', // emerald
+  '#fb7185', // rose
+  '#facc15', // yellow
+] as const;
+
+const NIVEL_RANK: Record<FactionPresence['nivel'], number> = {
+  dominante: 3,
+  fuerte: 2,
+  presente: 1,
+  encubierta: 0,
+};
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+/** [id, parent, grandparent, ...] following `en:` up to the sector root (cycle-guarded). */
+function ancestryChain(model: WorldModel, startId: string): string[] {
+  const chain: string[] = [];
+  const seen = new Set<string>();
+  let id: string | undefined = startId;
+  while (id && !seen.has(id)) {
+    seen.add(id);
+    chain.push(id);
+    const entity = model.entidades.get(id) as Partial<PlaceEntity> | undefined;
+    id = entity?.en;
+  }
+  return chain;
+}
+
+export default function WorldPage() {
+  const status = useWorldStore((s) => s.status);
+  const model = useWorldStore((s) => s.model);
+  const scanProgress = useWorldStore((s) => s.scanProgress);
+  const worldError = useWorldStore((s) => s.error);
+
+  const selectedEntityId = useUiStore((s) => s.selectedEntityId);
+  const showUnknown = useUiStore((s) => s.showUnknown);
+  const mapCollapsed = useUiStore((s) => s.mapCollapsed);
+  const uiActions = useUiStore((s) => s.actions);
+
+  const [entry, setEntry] = useState<EntryMode>('checking');
+  const [pendingHandle, setPendingHandle] = useState<FileSystemDirectoryHandle | null>(null);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const [viewport, setViewport] = useState<MapViewport | undefined>(undefined);
+
+  const mapWrapRef = useRef<HTMLDivElement>(null);
+  const fittedModelRef = useRef<WorldModel | null>(null);
+
+  /** The single open-and-scan path: picker, reconnect and the OPFS test hook all land here. */
+  const openWorld = useCallback(async (handle: FileSystemDirectoryHandle) => {
+    await useWorldStore.getState().actions.scan(handle);
+  }, []);
+
+  // Stored-handle bootstrap: granted -> scan now; prompt -> offer reconnect.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const stored = await loadStoredDirHandle();
+      if (cancelled) return;
+      if (stored.status === 'granted') {
+        setEntry('select');
+        void openWorld(stored.handle);
+      } else if (stored.status === 'prompt') {
+        setPendingHandle(stored.handle);
+        setEntry('reconnect');
+      } else {
+        setEntry('select');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [openWorld]);
+
+  // e2e OPFS seam (contract: e2e/helpers/opfs.ts). Playwright cannot drive
+  // showDirectoryPicker; OPFS provides a real handle without prompts.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const testWindow = window as WorldTestWindow;
+    testWindow.__ttrpgWorldTest = {
+      openFromOPFS: async () => {
+        const handle = await navigator.storage.getDirectory();
+        await openWorld(handle);
+      },
+    };
+    return () => {
+      delete testWindow.__ttrpgWorldTest;
+    };
+  }, [openWorld]);
+
+  const handleSelectFolder = useCallback(async () => {
+    try {
+      const manager = new FileSystemManager();
+      const handle = await manager.selectFolder('read');
+      await rememberDirHandle(handle);
+      setPendingHandle(null);
+      setEntry('select');
+      await openWorld(handle);
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') return;
+      console.error('Error selecting campaign folder:', error);
+    }
+  }, [openWorld]);
+
+  const handleReconnect = useCallback(async () => {
+    if (!pendingHandle) return;
+    const handle = await reconnectDirHandle(pendingHandle);
+    if (!handle) return; // permission denied — keep offering the button
+    setPendingHandle(null);
+    setEntry('select');
+    await openWorld(handle);
+  }, [pendingHandle, openWorld]);
+
+  // ── Derived map data ──────────────────────────────────────────────────────
+
+  /** Deep-space lugares: own coordinates, no parent — sector-tier nodes. */
+  const deepSpace = useMemo(
+    () => (model ? model.lugares.filter((lugar) => !lugar.en && lugar.coordenadas) : []),
+    [model]
+  );
+
+  /**
+   * Actionable-leads badge counts. A pista counts at its `donde` AND at every
+   * ancestor up the `en:` chain, so sector-tier nodes (sistemas / deep-space
+   * roots) surface leads that live at their inner places.
+   */
+  const leadsBadgeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!model) return counts;
+    for (const pista of model.pistas) {
+      if (pista.accionable === false || !pista.donde) continue;
+      for (const nodeId of ancestryChain(model, pista.donde)) {
+        counts.set(nodeId, (counts.get(nodeId) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [model]);
+
+  /**
+   * Strongest faction presence per node. Presence lives on places; it also
+   * propagates up the `en:` chain so systems inherit a ring from their places.
+   */
+  const dominantFactionByNode = useMemo(() => {
+    const best = new Map<string, { faccion: string; rank: number }>();
+    if (!model) return best;
+    for (const lugar of model.lugares) {
+      for (const presence of lugar.facciones) {
+        const rank = NIVEL_RANK[presence.nivel] ?? 0;
+        for (const nodeId of ancestryChain(model, lugar.id)) {
+          const current = best.get(nodeId);
+          if (!current || rank > current.rank) {
+            best.set(nodeId, { faccion: presence.faccion, rank });
+          }
+        }
+      }
+    }
+    return best;
+  }, [model]);
+
+  const factionColor = useCallback(
+    (id: string): string | undefined => {
+      const dominant = dominantFactionByNode.get(id);
+      if (!dominant) return undefined;
+      return FACTION_PALETTE[hashString(dominant.faccion) % FACTION_PALETTE.length];
+    },
+    [dominantFactionByNode]
+  );
+
+  // ── Selection panel data ──────────────────────────────────────────────────
+
+  const selectedEntity = useMemo(
+    () => (model && selectedEntityId ? model.entidades.get(selectedEntityId) : undefined),
+    [model, selectedEntityId]
+  );
+
+  const childNames = useMemo(() => {
+    if (!model || !selectedEntity) return [];
+    return (model.childrenOf.get(selectedEntity.id) ?? []).map(
+      (childId) => model.entidades.get(childId)?.nombre ?? childId
+    );
+  }, [model, selectedEntity]);
+
+  const factionNames = useMemo(() => {
+    if (!model || !selectedEntity) return [];
+    const presencias = (selectedEntity as Partial<PlaceEntity>).facciones ?? [];
+    return presencias.map((p) => model.entidades.get(p.faccion)?.nombre ?? p.faccion);
+  }, [model, selectedEntity]);
+
+  const panelLeads = useMemo<EntityPanelLead[]>(() => {
+    if (!model || !selectedEntity) return [];
+    return model.pistas
+      .filter((pista) => pista.donde === selectedEntity.id)
+      .map((pista) => ({
+        id: pista.id,
+        nombre: pista.nombre,
+        estadoPista: pista.estadoPista,
+        accionable: pista.accionable,
+      }));
+  }, [model, selectedEntity]);
+
+  // ── Fit-to-content initial viewport (once per scanned model) ─────────────
+  useLayoutEffect(() => {
+    if (status !== 'ready' || !model || fittedModelRef.current === model) return;
+    // While collapsed the wrapper is the slim chip, not the map — defer the
+    // fit until the map is expanded (mapCollapsed persists across navigations).
+    if (mapCollapsed) return;
+    const el = mapWrapRef.current;
+    if (!el) return;
+    const width = el.clientWidth;
+    const height = el.clientHeight;
+    if (width === 0 || height === 0) return;
+    fittedModelRef.current = model;
+
+    const points = [
+      ...model.sistemas.map((s) => s.coordenadas),
+      ...deepSpace.flatMap((l) => (l.coordenadas ? [l.coordenadas] : [])),
+    ];
+    if (points.length === 0) {
+      setViewport({ x: width / 2, y: height / 2, k: 1 });
+      return;
+    }
+    const xs = points.map((p) => p.x * WORLD_SCALE);
+    const ys = points.map((p) => p.y * WORLD_SCALE);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const PADDING = 90;
+    const k = Math.min(
+      1.5,
+      Math.max(
+        0.3,
+        Math.min(
+          (width - PADDING * 2) / Math.max(maxX - minX, 1),
+          (height - PADDING * 2) / Math.max(maxY - minY, 1)
+        )
+      )
+    );
+    setViewport({
+      x: width / 2 - ((minX + maxX) / 2) * k,
+      y: height / 2 - ((minY + maxY) / 2) * k,
+      k,
+    });
+  }, [status, model, deepSpace, mapCollapsed]);
+
+  const handleCopyReport = useCallback(() => {
+    const current = useWorldStore.getState().model;
+    if (!current) return;
+    const errores = current.problemas.filter((p) => p.nivel === 'error').length;
+    const avisos = current.problemas.length - errores;
+    const report = [
+      `Diagnóstico del mundo: ${current.manifest.nombre}`,
+      `${errores} ${errores === 1 ? 'error' : 'errores'} · ${avisos} ${avisos === 1 ? 'aviso' : 'avisos'}`,
+      '',
+      ...current.problemas.map((p) => `[${p.nivel.toUpperCase()}] ${p.archivo} — ${p.mensaje}`),
+    ].join('\n');
+    navigator.clipboard.writeText(report).catch((error) => {
+      console.error('No se pudo copiar el informe:', error);
+    });
+  }, []);
+
+  const erroresCount = model?.problemas.filter((p) => p.nivel === 'error').length ?? 0;
+
+  return (
+    <div data-world-status={status} className="flex h-screen flex-col bg-background">
+      {status === 'ready' && model ? (
+        <>
+          <header className="flex items-center gap-3 border-b px-4 py-2">
+            <Globe className="size-5 text-muted-foreground" aria-hidden />
+            <h1 className="text-lg font-semibold">{model.manifest.nombre || 'Mundo'}</h1>
+            <div className="ml-auto flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setDiagnosticsOpen((open) => !open)}
+                aria-pressed={diagnosticsOpen}
+              >
+                <TriangleAlert
+                  className={
+                    erroresCount > 0
+                      ? 'text-destructive'
+                      : model.problemas.length > 0
+                        ? 'text-amber-500'
+                        : 'text-muted-foreground'
+                  }
+                />
+                Diagnóstico
+                <Badge variant={erroresCount > 0 ? 'destructive' : 'secondary'}>
+                  {model.problemas.length}
+                </Badge>
+              </Button>
+            </div>
+          </header>
+
+          <main className="flex min-h-0 flex-1 gap-3 p-3">
+            <div
+              ref={mapWrapRef}
+              className={mapCollapsed ? 'min-w-0 flex-1 self-start' : 'relative min-h-0 min-w-0 flex-1'}
+            >
+              <StarMap
+                viewport={viewport}
+                onViewportChange={setViewport}
+                breadcrumb={[{ label: model.manifest.nombre || 'Sector' }]}
+                showUnknown={showUnknown}
+                onToggleUnknown={() => uiActions.setShowUnknown(!showUnknown)}
+                collapsed={mapCollapsed}
+                onToggleCollapsed={() => uiActions.setMapCollapsed(!mapCollapsed)}
+              >
+                <SectorView
+                  sistemas={model.sistemas}
+                  deepSpace={deepSpace}
+                  selectedId={selectedEntityId}
+                  partyLocationId={null /* M2: read from estado/grupo.md */}
+                  leadsBadgeCounts={leadsBadgeCounts}
+                  factionColor={factionColor}
+                  showUnknown={showUnknown}
+                  onSelect={(id) => uiActions.selectEntity(id)}
+                  /* M2 adds tier navigation; until then drill-in (dblclick) just selects. */
+                  onDrillIn={(id) => uiActions.selectEntity(id)}
+                />
+              </StarMap>
+            </div>
+
+            {(diagnosticsOpen || selectedEntity) && (
+              <aside className="flex min-h-0 w-96 shrink-0 flex-col gap-3">
+                {diagnosticsOpen && (
+                  <div className="min-h-0 flex-1">
+                    <DiagnosticsPanel problemas={model.problemas} onCopyReport={handleCopyReport} />
+                  </div>
+                )}
+                {selectedEntity && (
+                  <div className="min-h-0 flex-1">
+                    <EntityPanel
+                      entity={selectedEntity as EntityPanelEntity}
+                      childNames={childNames}
+                      factionNames={factionNames}
+                      leads={panelLeads}
+                      onClose={() => uiActions.selectEntity(null)}
+                    />
+                  </div>
+                )}
+              </aside>
+            )}
+          </main>
+        </>
+      ) : (
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
+          <Globe className="size-10 text-muted-foreground" aria-hidden />
+          <h1 className="text-2xl font-semibold">Mundo</h1>
+
+          {status === 'scanning' ? (
+            <>
+              <div className="h-2 w-64 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full bg-primary transition-[width]"
+                  style={{
+                    width: `${scanProgress.total > 0 ? Math.round((scanProgress.done / scanProgress.total) * 100) : 0}%`,
+                  }}
+                />
+              </div>
+              <p className="text-sm text-muted-foreground" role="status">
+                Explorando el mundo… {scanProgress.done}/{scanProgress.total || '…'}
+              </p>
+            </>
+          ) : status === 'error' ? (
+            <>
+              <p className="max-w-md text-center text-sm text-destructive">{worldError}</p>
+              <Button onClick={handleSelectFolder}>
+                <FolderOpen />
+                Seleccionar carpeta de campaña
+              </Button>
+            </>
+          ) : entry === 'checking' ? (
+            <p className="text-sm text-muted-foreground" role="status">
+              Comprobando la carpeta guardada…
+            </p>
+          ) : entry === 'reconnect' ? (
+            <>
+              <p className="max-w-md text-center text-sm text-muted-foreground">
+                Hay una carpeta de campaña guardada. Reconéctala para abrir el mundo sin volver a
+                elegirla.
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                <Button onClick={handleReconnect}>
+                  <RefreshCw />
+                  Reconectar carpeta
+                </Button>
+                <Button variant="outline" onClick={handleSelectFolder}>
+                  <FolderOpen />
+                  Seleccionar otra carpeta
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="max-w-md text-center text-sm text-muted-foreground">
+                Selecciona la carpeta de campaña que contiene{' '}
+                <code className="rounded bg-muted px-1">mundo/mundo.md</code>.
+              </p>
+              <Button onClick={handleSelectFolder}>
+                <FolderOpen />
+                Seleccionar carpeta de campaña
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -1556,14 +1556,17 @@ export default function WorldPage() {
   /**
    * One `:::efecto` line -> one journal entry via makeEntry against CURRENT
    * party state. Grammar per plan Part A (module doc "Event :::efecto lines");
-   * unparseable/unknown effects degrade to a nota entry.
+   * unparseable/unknown effects degrade to a nota entry. Shared by the
+   * EventDrawer (drawn-event effects) AND the ActRunner ("Efectos del acto" —
+   * an act's own state-transitions declared as :::efecto). Returns true when
+   * the entry was logged so callers can track their own applied indexes;
+   * false when nothing was journaled (no model / rejected log).
    */
-  const handleApplyEffect = useCallback(
-    (effect: EventEffect) => {
+  const applyEffectCore = useCallback(
+    (effect: EventEffect): boolean => {
       const currentModel = useWorldStore.getState().model;
       const store = usePartyStore.getState();
-      const draw = eventDraw;
-      if (!currentModel || !draw) return;
+      if (!currentModel) return false;
 
       const { main, comentario } = splitEffectValue(effect.value);
       let entry: JournalEntry | null = null;
@@ -1654,19 +1657,33 @@ export default function WorldPage() {
           fallbackNota();
       }
 
-      if (!entry || !store.actions.log(entry)) return;
+      if (!entry || !store.actions.log(entry)) return false;
       after?.();
       // Covers every effect type: creditos/medidor numbers, pista estados and
       // sabe knowledge (donde-conocido gating) all feed accionable.
       rederiveLeads();
+      if (warn) toast.warning(mensaje);
+      else toast.success(mensaje);
+      return true;
+    },
+    [rederiveLeads]
+  );
+
+  /**
+   * EventDrawer wrapper: applies a DRAWN event's effect, then marks its index
+   * in the drawn event's efectos as applied (checks off + disables its button).
+   */
+  const handleApplyEffect = useCallback(
+    (effect: EventEffect) => {
+      const draw = eventDraw;
+      if (!draw) return;
+      if (!applyEffectCore(effect)) return;
       const index = draw.event.efectos.indexOf(effect);
       if (index >= 0) {
         setEventApplied((prev) => (prev.includes(index) ? prev : [...prev, index]));
       }
-      if (warn) toast.warning(mensaje);
-      else toast.success(mensaje);
     },
-    [eventDraw, rederiveLeads]
+    [eventDraw, applyEffectCore]
   );
 
   // ── M5: ActRunner (scripted acts at a playable place) ────────────────────
@@ -3137,6 +3154,8 @@ export default function WorldPage() {
               fsm={worldFs}
               onClose={handleCloseActRunner}
               onActChange={handleActChange}
+              onApplyEffect={applyEffectCore}
+              sessionActive={session.active}
             />
           )}
 

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -127,6 +127,24 @@
  *     medidor desconocido <nombre>") + warning toast instead of silently
  *     creating an invisible gauge no widget renders.
  *
+ * WORLD-LEVEL MUSIC (mundo/musica/ — generic ambient/travel beds OUTSIDE
+ * places):
+ *   - One page-level AudioManager exists while status is ready AND
+ *     model.musica carries at least one track (BGM rotation from the folder
+ *     root + event playlists from subfolders — see worldScanner). It binds to
+ *     the worldStore fs manager and is disposed (fade-to-silence, then
+ *     cleanup — same pattern as ActRunner's unmount) whenever the model or fs
+ *     changes or the page unmounts.
+ *   - The WorldAudioDock (bottom-left, above the QuickLogBar) mounts the
+ *     EXISTING play AudioControls behind a music toggle button; zero tracks =
+ *     no manager = no dock at all (silence is fine, no hint rendered).
+ *   - ACTRUNNER HANDOFF: opening a place's runner ducks the world audio OUT
+ *     (fade + pause) so the act music owns the room; closing it resumes the
+ *     world audio ONLY if it was playing when the runner opened
+ *     (worldAudioWasPlayingRef). The dock stays mounted but hidden meanwhile,
+ *     so its open/closed state survives the round-trip. No double audio: the
+ *     duck starts the instant the overlay mounts.
+ *
  * SCAN-OVERLAY ASYMMETRY (M4 decision — documented, not a bug):
  *   worldScanner.overlayUnprocessedJournals re-derives ONLY knowledge (sabe)
  *   and location knowledge (llegada) from journals with procesado: false.
@@ -141,6 +159,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Toaster, toast } from 'sonner';
 import { FileSystemManager } from '@/lib/fileSystem';
+import { AudioManager } from '@/lib/audioManager';
 import { loadStoredDirHandle, reconnectDirHandle, rememberDirHandle } from '@/lib/dirHandle';
 import {
   clearSessionMirror,
@@ -208,6 +227,7 @@ import { TravelDialog } from '@/components/world/TravelDialog';
 import { TravelStepper } from '@/components/world/TravelStepper';
 import { RoutePreview } from '@/components/world/RoutePreview';
 import { ActRunner } from '@/components/world/ActRunner';
+import { WorldAudioDock } from '@/components/world/WorldAudioDock';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -352,6 +372,54 @@ function diasLabel(dias: number): string {
   return dias === 1 ? '1 día' : `${dias} días`;
 }
 
+// ── World-level audio fades (mirrors ActRunner's close-fade pattern) ─────────
+
+const WORLD_AUDIO_FADE_MS = 800;
+const WORLD_AUDIO_FADE_INTERVAL_MS = 50;
+
+/**
+ * Runs a volume ramp detached from React (the interval may outlive the render
+ * that started it). Returns the interval id so callers can cancel a fade that
+ * a newer one supersedes (fast runner open/close would otherwise leave two
+ * intervals fighting over the volume knob).
+ */
+function rampWorldVolume(
+  audio: AudioManager,
+  volumeAt: (progress: number) => number,
+  onDone: () => void
+): ReturnType<typeof setInterval> {
+  const steps = Math.ceil(WORLD_AUDIO_FADE_MS / WORLD_AUDIO_FADE_INTERVAL_MS);
+  let step = 0;
+  const interval = setInterval(() => {
+    step++;
+    audio.setVolume(volumeAt(Math.min(1, step / steps)));
+    if (step >= steps) {
+      clearInterval(interval);
+      onDone();
+    }
+  }, WORLD_AUDIO_FADE_INTERVAL_MS);
+  return interval;
+}
+
+/**
+ * Disposal fade for the world AudioManager: volume to silence, THEN release
+ * the element (cleanup pauses + revokes the object URL). Same contract as the
+ * ActRunner's fadeOutAndCleanup — a model change or page unmount never cuts
+ * the music hard. Silent/paused audio is released immediately.
+ */
+function fadeOutAndCleanupWorldAudio(audio: AudioManager): void {
+  const startVolume = audio.getVolume();
+  if (!audio.isPlaying() || startVolume <= 0) {
+    audio.cleanup();
+    return;
+  }
+  rampWorldVolume(
+    audio,
+    (progress) => startVolume * (1 - progress),
+    () => audio.cleanup()
+  );
+}
+
 export default function WorldPage() {
   const status = useWorldStore((s) => s.status);
   const model = useWorldStore((s) => s.model);
@@ -417,6 +485,15 @@ export default function WorldPage() {
   // GM is currently on (for the "Acto cerrado" nota — see module doc M5).
   const [actPlaceId, setActPlaceId] = useState<string | null>(null);
   const actPartNameRef = useRef<string | null>(null);
+  // World-level music (module doc "WORLD-LEVEL MUSIC"): page-owned manager +
+  // the handoff bookkeeping. wasPlaying is a ref (not state): it only matters
+  // at the open/close instants and must never trigger a render.
+  const [worldAudio, setWorldAudio] = useState<AudioManager | null>(null);
+  const worldAudioWasPlayingRef = useRef(false);
+  /** Live duck/restore ramp — cancelled before a newer ramp takes over. */
+  const worldAudioRampRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /** GM-set volume captured at duck time; restore resumes at this level. */
+  const worldAudioVolumeRef = useRef(0);
   /** Contexto + place anchor of the current drawer opening (redraw reuses them). */
   const eventSourceRef = useRef<{ contexto: 'viaje' | 'estancia'; anchorId: string | null }>({
     contexto: 'estancia',
@@ -1303,6 +1380,80 @@ export default function WorldPage() {
   const handleActChange = useCallback((actName: string) => {
     actPartNameRef.current = actName;
   }, []);
+
+  // ── World-level music (mundo/musica/ — module doc "WORLD-LEVEL MUSIC") ────
+
+  /** Mirrors the render condition of the ActRunner overlay below. */
+  const actRunnerOpen = actRunnerPlace !== null && worldFs !== null;
+
+  // One AudioManager per ready model WITH tracks, bound to the worldStore fs
+  // (same constructor/lifecycle contract as the ActRunner's per-opening
+  // manager). Cleanup fades to silence detached from React, so re-scans and
+  // navigation never cut the music hard. Zero tracks = no manager = no dock.
+  useEffect(() => {
+    if (status !== 'ready' || !model || !worldFs) return;
+    const { bgm, eventPlaylists } = model.musica;
+    const trackCount =
+      bgm.length + eventPlaylists.reduce((total, playlist) => total + playlist.tracks.length, 0);
+    if (trackCount === 0) return;
+    const manager = new AudioManager(worldFs);
+    manager.loadBGM(bgm);
+    manager.loadEventPlaylists(eventPlaylists);
+    setWorldAudio(manager);
+    return () => {
+      worldAudioWasPlayingRef.current = false;
+      setWorldAudio(null);
+      fadeOutAndCleanupWorldAudio(manager);
+    };
+  }, [status, model, worldFs]);
+
+  const cancelWorldAudioRamp = useCallback(() => {
+    if (worldAudioRampRef.current !== null) {
+      clearInterval(worldAudioRampRef.current);
+      worldAudioRampRef.current = null;
+    }
+  }, []);
+
+  // ACTRUNNER HANDOFF: duck the world audio OUT when the runner mounts (fade
+  // to silence, pause, restore the volume knob for later) and bring it back
+  // when the runner unmounts — ONLY if it was playing at open time. Runs on
+  // the same commit that mounts/unmounts the overlay, so the act music never
+  // plays on top of an un-ducked world bed.
+  useEffect(() => {
+    if (!worldAudio) return;
+    // A fast open→close→open supersedes the previous ramp; when one was
+    // in-flight, getVolume() is mid-fade — the GM's real level lives in
+    // worldAudioVolumeRef (captured when the first duck started).
+    const rampWasActive = worldAudioRampRef.current !== null;
+    cancelWorldAudioRamp();
+    if (actRunnerOpen) {
+      worldAudioWasPlayingRef.current = worldAudio.isPlaying();
+      if (!worldAudioWasPlayingRef.current) return;
+      const fadeFrom = worldAudio.getVolume();
+      if (!rampWasActive) worldAudioVolumeRef.current = fadeFrom;
+      worldAudioRampRef.current = rampWorldVolume(
+        worldAudio,
+        (progress) => fadeFrom * (1 - progress),
+        () => {
+          worldAudioRampRef.current = null;
+          worldAudio.pause();
+          worldAudio.setVolume(worldAudioVolumeRef.current);
+        }
+      );
+    } else if (worldAudioWasPlayingRef.current) {
+      worldAudioWasPlayingRef.current = false;
+      const targetVolume = worldAudioVolumeRef.current;
+      worldAudio.setVolume(0);
+      void worldAudio.resume();
+      worldAudioRampRef.current = rampWorldVolume(
+        worldAudio,
+        (progress) => targetVolume * progress,
+        () => {
+          worldAudioRampRef.current = null;
+        }
+      );
+    }
+  }, [actRunnerOpen, worldAudio, cancelWorldAudioRamp]);
 
   const endSummaryPreview = useMemo(() => {
     if (!session.active) return undefined;
@@ -2214,6 +2365,17 @@ export default function WorldPage() {
             appliedEffects={eventApplied}
             canRedraw={eventDraw !== null && eventDrawCount < 2}
           />
+
+          {/* World music dock: exists only while the manager does (>=1 track);
+              concealed (state kept) while the ActRunner owns the room. */}
+          {worldAudio && (
+            <WorldAudioDock
+              audioManager={worldAudio}
+              bgm={model.musica.bgm}
+              eventPlaylists={model.musica.eventPlaylists}
+              concealed={actRunnerOpen}
+            />
+          )}
 
           {actRunnerPlace?.playable && worldFs && (
             <ActRunner

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -319,7 +319,7 @@ import type {
   WorldEvent,
   WorldModel,
 } from '@/types/world';
-import { FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, Swords, TriangleAlert } from 'lucide-react';
+import { Eye, FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, Swords, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -1425,6 +1425,32 @@ export default function WorldPage() {
   }, [handleEventOutcome]);
 
   /**
+   * REVELAR: raise a desconocido/rumoreado entity to `conocido` (logs `sabe:`),
+   * so it becomes a Mover destination and its pistas can derive accionable.
+   * The GM uses this during the acto2 Archivo beat to "light" the ghost nodes.
+   * Session-gated (it must be journaled to survive a rescan).
+   */
+  const handleReveal = useCallback(
+    (id: string) => {
+      const currentModel = useWorldStore.getState().model;
+      if (!currentModel) return;
+      const entity = currentModel.entidades.get(id);
+      if (!entity) return;
+      const from = entity.conocimiento;
+      if (from === 'conocido' || from === 'visitado') return;
+      if (!usePartyStore.getState().actions.log(makeEntry.sabe(id, from, 'conocido'))) {
+        toast.error('Inicia sesión para revelar');
+        return;
+      }
+      bumpConocimientoInMemory(entity, 'conocido');
+      touchModel();
+      rederiveLeads();
+      toast.success(`Revelado: ${entity.nombre}`);
+    },
+    [touchModel, rederiveLeads]
+  );
+
+  /**
    * Optional Eventos-tab shortcut: resolve a parked event WITHOUT reopening the
    * drawer (journals `resuelto` for that id, dropping it from ongoing).
    */
@@ -2017,6 +2043,13 @@ export default function WorldPage() {
     return selectedEntity.tipo === 'sistema' || isPlace(selectedEntity);
   }, [model, selectedEntity, ubicacion, travel]);
 
+  /** A selected entity the GM can still "reveal" (not yet conocido/visitado). */
+  const canRevealSelected = Boolean(
+    selectedEntity &&
+      selectedEntity.conocimiento !== 'conocido' &&
+      selectedEntity.conocimiento !== 'visitado'
+  );
+
   /**
    * Event-context place anchor mid-travel: origin until the sector leg
    * completes, then the destination (module doc REGION OF ROUTE).
@@ -2542,8 +2575,21 @@ export default function WorldPage() {
                         }
                         onClose={() => uiActions.selectEntity(null)}
                         actions={
-                          canTravelToSelected || selectedPlayable ? (
+                          canTravelToSelected || selectedPlayable || canRevealSelected ? (
                             <>
+                              {canRevealSelected && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  data-reveal
+                                  onClick={() => handleReveal(selectedEntity!.id)}
+                                  className="min-h-11"
+                                  title="Marcar como conocido (el grupo ahora sabe de este sitio)"
+                                >
+                                  <Eye />
+                                  Revelar
+                                </Button>
+                              )}
                               {selectedPlayable && (
                                 <Button
                                   size="sm"

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -78,6 +78,53 @@
  *   - rederiveLeads(): every pista/medidor/creditos/llegada/sabe mutation (and
  *     undo) re-runs deriveLeadActionability over ALL pistas with a live
  *     CondContext, then bumps modelRev.
+ *
+ * M5 ActRunner wiring (plan Part B "Cockpit" — scripted acts):
+ *   - "Jugar" appears in the EntityPanel actions and on SiteList rows when the
+ *     entity carries `playable` (a ready SessionConfig scanned from its
+ *     lugares/<id>/ folder, paths prefixed mundo/lugares/<id>/). The button
+ *     mounts the fullscreen ActRunner overlay (data-act-runner) over the
+ *     cockpit, fed with the worldStore fs manager.
+ *   - JOURNALING: opening with an active session logs a nota
+ *     "Acto iniciado: <partName> @ <placeName>" (first visible part); closing
+ *     logs "Acto cerrado: ..." with the part the GM actually ended on
+ *     (tracked via onActChange in a ref — part switches inside the runner are
+ *     not journaled themselves). No session = the runner just opens: viewing
+ *     prep is legit without recording.
+ *   - Closing unmounts the overlay; the runner's own unmount effect fades the
+ *     audio out and releases it (see components/world/ActRunner.tsx).
+ *
+ * M5 polish — UI persistence + efecto hardening:
+ *   - The uiStore slice (tier/focus/siteList/selection/panelTab/mapCollapsed/
+ *     showUnknown) mirrors to sessionStorage (key world.ui.v1, see
+ *     lib/world/stores.ts) so a reload lands where the GM was. ?e= deep-link
+ *     navigation is SKIPPED when the restored selection already equals the
+ *     param: the URL is rewritten from the live selection, so after a reload
+ *     it merely duplicates the persisted slice and recomputing the tier
+ *     target would stomp the restored placement — a pasted/shared link (no
+ *     matching slice) still navigates. Stale persisted ids after a re-scan
+ *     degrade like stale store ids always did (invalid focus -> sector tier,
+ *     missing selection -> empty panel).
+ *   - Map viewports: StarMap commits the transform once per FINISHED gesture
+ *     (pointer released / wheel settled) through onViewportChange; the page
+ *     remembers that commit per tier key ('sector' | 'system:<id>') in the
+ *     same persisted slice, and the fit-to-content effect prefers a
+ *     remembered viewport over computing a fit. Mid-gesture transforms stay
+ *     in StarMap's refs — ephemeral by design.
+ *   - medidor `:::efecto` hardening (M4 TODO): a gauge name missing from
+ *     manifest.medidores degrades to a nota entry ("Efecto no aplicado:
+ *     medidor desconocido <nombre>") + warning toast instead of silently
+ *     creating an invisible gauge no widget renders.
+ *
+ * SCAN-OVERLAY ASYMMETRY (M4 decision — documented, not a bug):
+ *   worldScanner.overlayUnprocessedJournals re-derives ONLY knowledge (sabe)
+ *   and location knowledge (llegada) from journals with procesado: false.
+ *   Pista estado transitions are intentionally NOT overlaid: a pista moved
+ *   live during a session REVERTS to its file estado on reload until the
+ *   agent maintenance loop processes the journal — so PROTOCOLO.md (M6) must
+ *   instruct the agent to process pista entries promptly after each session.
+ *   Whether the scanner should also overlay pista transitions is an M6
+ *   decision; do not "fix" it here.
  */
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -148,6 +195,7 @@ import type { EventOutcome } from '@/components/world/EventDrawer';
 import { TravelDialog } from '@/components/world/TravelDialog';
 import { TravelStepper } from '@/components/world/TravelStepper';
 import { RoutePreview } from '@/components/world/RoutePreview';
+import { ActRunner } from '@/components/world/ActRunner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -167,7 +215,7 @@ import type {
   WorldEvent,
   WorldModel,
 } from '@/types/world';
-import { FolderOpen, Globe, Lock, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
+import { FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -295,6 +343,7 @@ function diasLabel(dias: number): string {
 export default function WorldPage() {
   const status = useWorldStore((s) => s.status);
   const model = useWorldStore((s) => s.model);
+  const worldFs = useWorldStore((s) => s.fs);
   const scanProgress = useWorldStore((s) => s.scanProgress);
   const worldError = useWorldStore((s) => s.error);
 
@@ -345,6 +394,10 @@ export default function WorldPage() {
   );
   const [eventApplied, setEventApplied] = useState<number[]>([]);
   const [eventDrawCount, setEventDrawCount] = useState(0);
+  // M5: place whose ActRunner overlay is open (null = closed) + the part the
+  // GM is currently on (for the "Acto cerrado" nota — see module doc M5).
+  const [actPlaceId, setActPlaceId] = useState<string | null>(null);
+  const actPartNameRef = useRef<string | null>(null);
   /** Contexto + place anchor of the current drawer opening (redraw reuses them). */
   const eventSourceRef = useRef<{ contexto: 'viaje' | 'estancia'; anchorId: string | null }>({
     contexto: 'estancia',
@@ -988,12 +1041,15 @@ export default function WorldPage() {
       const { main, comentario } = splitEffectValue(effect.value);
       let entry: JournalEntry | null = null;
       let mensaje = '';
+      /** True when the effect degraded to a nota — surfaced as a warning toast. */
+      let warn = false;
       /** In-memory model mutation to run only after log() accepts the entry. */
       let after: (() => void) | undefined;
 
       const fallbackNota = () => {
         entry = makeEntry.nota(`${effect.key}: ${effect.value}`);
         mensaje = 'Efecto no interpretable — anotado como nota';
+        warn = true;
       };
 
       switch (effect.key) {
@@ -1018,6 +1074,14 @@ export default function WorldPage() {
             break;
           }
           const nombre = match[1];
+          // M5 hardening: a gauge outside manifest.medidores would mutate a
+          // value no widget renders — degrade to a visible nota instead.
+          if (!currentModel.manifest.medidores.includes(nombre)) {
+            entry = makeEntry.nota(`Efecto no aplicado: medidor desconocido ${nombre}`);
+            mensaje = `Medidor desconocido «${nombre}» — anotado como nota`;
+            warn = true;
+            break;
+          }
           const from = store.medidores[nombre] ?? 0;
           const to = Math.max(0, Math.min(5, from + Number(match[2])));
           entry = makeEntry.medidor(nombre, from, to, comentario);
@@ -1072,10 +1136,55 @@ export default function WorldPage() {
       if (index >= 0) {
         setEventApplied((prev) => (prev.includes(index) ? prev : [...prev, index]));
       }
-      toast.success(mensaje);
+      if (warn) toast.warning(mensaje);
+      else toast.success(mensaje);
     },
     [eventDraw, rederiveLeads]
   );
+
+  // ── M5: ActRunner (scripted acts at a playable place) ────────────────────
+
+  /** The place whose runner is open; resolves live so a re-scan closes a stale id. */
+  const actRunnerPlace = useMemo(() => {
+    if (!model || !actPlaceId) return null;
+    const entity = model.entidades.get(actPlaceId);
+    return isPlace(entity) && entity.playable ? entity : null;
+  }, [model, actPlaceId]);
+
+  const handleOpenActRunner = useCallback((id: string) => {
+    const currentModel = useWorldStore.getState().model;
+    const entity = currentModel?.entidades.get(id);
+    if (!isPlace(entity) || !entity.playable) return;
+    // First VISIBLE part (same trunk/active-path rule as the runner) — the
+    // raw parts[0] could sit on a non-active path and misname the nota.
+    const playable = entity.playable;
+    const firstPart = playable.parts.find(
+      (p) => p.pathId == null || p.pathId === (playable.activePathId ?? null)
+    );
+    actPartNameRef.current = firstPart?.name ?? null;
+    setActPlaceId(id);
+    // Journal only under an active session — viewing prep needs no recording.
+    const store = usePartyStore.getState();
+    if (store.session.active && firstPart) {
+      store.actions.log(makeEntry.nota(`Acto iniciado: ${firstPart.name} @ ${entity.nombre}`));
+    }
+  }, []);
+
+  const handleCloseActRunner = useCallback(() => {
+    const place = actRunnerPlace;
+    const partName = actPartNameRef.current;
+    setActPlaceId(null);
+    actPartNameRef.current = null;
+    const store = usePartyStore.getState();
+    if (place && partName && store.session.active) {
+      store.actions.log(makeEntry.nota(`Acto cerrado: ${partName} @ ${place.nombre}`));
+    }
+  }, [actRunnerPlace]);
+
+  /** Keeps the closing nota naming the act the GM actually ended on. */
+  const handleActChange = useCallback((actName: string) => {
+    actPartNameRef.current = actName;
+  }, []);
 
   const endSummaryPreview = useMemo(() => {
     if (!session.active) return undefined;
@@ -1282,6 +1391,12 @@ export default function WorldPage() {
     );
   }, [model, selectedEntity]);
 
+  /** M5: the selection when it is a playable place (offers "Jugar"). */
+  const selectedPlayable = useMemo(
+    () => (isPlace(selectedEntity) && selectedEntity.playable ? selectedEntity : null),
+    [selectedEntity]
+  );
+
   const childNames = useMemo(() => {
     if (!model || !selectedEntity) return [];
     return (model.childrenOf.get(selectedEntity.id) ?? []).map(
@@ -1378,11 +1493,18 @@ export default function WorldPage() {
   // Model is immutable-after-scan, so the index never staleses within a scan.
   const searchIndex = useMemo(() => (model ? buildWorldSearchIndex(model) : null), [model]);
 
-  // Deep-link init: consume ?e= once, after the first successful scan.
+  // Deep-link init: consume ?e= once, after the first successful scan. When
+  // the persisted uiStore slice already restored this exact selection the
+  // navigation is skipped — recomputing the tier target would stomp the
+  // restored placement (module doc "M5 polish").
   useEffect(() => {
     if (status !== 'ready' || !model || deepLinkDoneRef.current) return;
     deepLinkDoneRef.current = true;
-    if (initialDeepLink && model.entidades.has(initialDeepLink)) {
+    if (
+      initialDeepLink &&
+      model.entidades.has(initialDeepLink) &&
+      useUiStore.getState().selectedEntityId !== initialDeepLink
+    ) {
       navigateToEntity(initialDeepLink);
     }
   }, [status, model, initialDeepLink, navigateToEntity]);
@@ -1394,6 +1516,24 @@ export default function WorldPage() {
     writeEntityToUrl(selectedEntityId);
   }, [status, selectedEntityId]);
 
+  /**
+   * M5: remembers the finished-gesture viewport under its tier key so pan/zoom
+   * survives tier round-trips AND reloads (persisted uiStore slice). The tier
+   * key is derived from the store with the same sistema validation the render
+   * path uses, so a stale focus commits under 'sector' — matching what the
+   * user actually saw.
+   */
+  const handleViewportCommit = useCallback((next: MapViewport) => {
+    setViewport(next);
+    const currentModel = useWorldStore.getState().model;
+    const ui = useUiStore.getState();
+    const isSystem =
+      ui.tier === 'system' &&
+      ui.focusSystemId !== null &&
+      currentModel?.entidades.get(ui.focusSystemId)?.tipo === 'sistema';
+    ui.actions.rememberViewport(isSystem ? `system:${ui.focusSystemId}` : 'sector', next);
+  }, []);
+
   // ── Fit-to-content viewport (per model AND per spatial tier) ─────────────
   useLayoutEffect(() => {
     if (status !== 'ready' || !model) return;
@@ -1403,6 +1543,14 @@ export default function WorldPage() {
     const focus = focusSistema?.id ?? null;
     const fitted = fittedRef.current;
     if (fitted.model === model && fitted.tier === activeTier && fitted.focus === focus) return;
+    // A remembered viewport for this tier (persisted gesture commit) beats
+    // the computed fit: the GM returns to where they left the map.
+    const remembered = useUiStore.getState().viewports[focus ? `system:${focus}` : 'sector'];
+    if (remembered) {
+      fittedRef.current = { model, tier: activeTier, focus };
+      setViewport({ ...remembered });
+      return;
+    }
     const el = mapWrapRef.current;
     if (!el) return;
     const width = el.clientWidth;
@@ -1512,6 +1660,7 @@ export default function WorldPage() {
                 size="sm"
                 onClick={() => setDiagnosticsOpen((open) => !open)}
                 aria-pressed={diagnosticsOpen}
+                className="min-h-11"
               >
                 <TriangleAlert
                   className={
@@ -1571,6 +1720,7 @@ export default function WorldPage() {
                 variant="outline"
                 data-session-lock-close
                 onClick={handleMarkLockClosed}
+                className="min-h-11"
               >
                 Marcar como cerrada
               </Button>
@@ -1597,7 +1747,7 @@ export default function WorldPage() {
             >
               <StarMap
                 viewport={viewport}
-                onViewportChange={setViewport}
+                onViewportChange={handleViewportCommit}
                 breadcrumb={breadcrumb}
                 showUnknown={showUnknown}
                 onToggleUnknown={() => uiActions.setShowUnknown(!showUnknown)}
@@ -1657,7 +1807,8 @@ export default function WorldPage() {
                     data-panel-tab={tab}
                     aria-selected={panelTab === tab}
                     onClick={() => uiActions.setPanelTab(tab)}
-                    className={`flex-1 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                    // min-h-11 = 44px tap target (M5 sweep).
+                    className={`min-h-11 flex-1 rounded-md px-2 py-1.5 text-sm transition-colors ${
                       panelTab === tab
                         ? 'bg-background font-medium shadow-sm'
                         : 'text-muted-foreground hover:text-foreground'
@@ -1679,6 +1830,7 @@ export default function WorldPage() {
                         partyLocationId={siteListPartyId}
                         onSelect={selectEntity}
                         onBack={() => uiActions.closeSiteList()}
+                        onPlay={handleOpenActRunner}
                       />
                     </div>
                   )}
@@ -1695,15 +1847,32 @@ export default function WorldPage() {
                         }
                         onClose={() => uiActions.selectEntity(null)}
                         actions={
-                          canTravelToSelected ? (
-                            <Button
-                              size="sm"
-                              data-travel-here
-                              onClick={handleOpenTravelDialog}
-                            >
-                              <Rocket />
-                              Viajar aquí
-                            </Button>
+                          canTravelToSelected || selectedPlayable ? (
+                            <>
+                              {canTravelToSelected && (
+                                <Button
+                                  size="sm"
+                                  data-travel-here
+                                  onClick={handleOpenTravelDialog}
+                                  className="min-h-11"
+                                >
+                                  <Rocket />
+                                  Viajar aquí
+                                </Button>
+                              )}
+                              {selectedPlayable && (
+                                <Button
+                                  size="sm"
+                                  variant="secondary"
+                                  data-play-act
+                                  onClick={() => handleOpenActRunner(selectedPlayable.id)}
+                                  className="min-h-11"
+                                >
+                                  <Play />
+                                  Jugar
+                                </Button>
+                              )}
+                            </>
                           ) : undefined
                         }
                       />
@@ -1806,6 +1975,16 @@ export default function WorldPage() {
             appliedEffects={eventApplied}
             canRedraw={eventDraw !== null && eventDrawCount < 2}
           />
+
+          {actRunnerPlace?.playable && worldFs && (
+            <ActRunner
+              config={actRunnerPlace.playable}
+              placeName={actRunnerPlace.nombre}
+              fsm={worldFs}
+              onClose={handleCloseActRunner}
+              onActChange={handleActChange}
+            />
+          )}
         </>
       ) : (
         <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -145,6 +145,35 @@
  *     so its open/closed state survives the round-trip. No double audio: the
  *     duck starts the instant the overlay mounts.
  *
+ * M6 GM surfaces — entity images, pnj dossier, pista detail:
+ *   - PROFILE IMAGES: `mundo/imagenes/<entity_id>.<ext>` attaches
+ *     WorldEntityBase.imagen at scan time (worldScanner.scanEntityImages).
+ *     The page owns ONE object-URL cache keyed by path
+ *     (entityImageUrlCacheRef), resolved lazily through worldFs.getFileURL —
+ *     revoked whenever the model/fs changes and on unmount (the ActRunner
+ *     imageUrlCache pattern, including its revoke-on-cleanup fix). The
+ *     EntityPanel banner and PnjCard portrait open the PLAYER-SAFE
+ *     FullscreenImage viewer (solid black, the image and NOTHING else — the
+ *     GM projects it to players); ActRunner image tabs now use the same
+ *     viewer because play's ImageViewer overlays the filename, a GM-only
+ *     leak on the shared screen (play mode keeps ImageViewer unchanged).
+ *   - PNJ SURFACE: a place's panel lists the pnjs whose ubicacion is the
+ *     place ("Personajes"; unmet ones — conocimiento desconocido — carry a
+ *     muted hint). DESIGN DECISION: clicking one selects the pnj through the
+ *     EXISTING selectedEntityId (no parallel selectedPnjId state) — pnjs ARE
+ *     entities in the entidades map and tierTargetFor returns null for them,
+ *     so selection leaves the map untouched, nothing extra needs clearing on
+ *     tab/entity changes, and search results / ?e= deep links land on the
+ *     same PnjCard for free. The render branch swaps EntityPanel for PnjCard
+ *     whenever the selection resolves to a pnj; its back button navigates to
+ *     the pnj's ubicacion (or just clears the selection when it dangles).
+ *   - PISTA DETAIL: row-body clicks inside LeadsBoard open a LeadDetail view
+ *     (estado/donde/plazo chips, human-readable requisitos, recompensa and
+ *     the pista BODY — previously invisible here). The open-detail state is
+ *     LOCAL to LeadsBoard: leaving the Pistas tab (or selecting an entity,
+ *     which flips panelTab) unmounts the board and clears it — no page
+ *     wiring needed.
+ *
  * SCAN-OVERLAY ASYMMETRY (M4 decision — documented, not a bug):
  *   worldScanner.overlayUnprocessedJournals re-derives ONLY knowledge (sabe)
  *   and location knowledge (llegada) from journals with procesado: false.
@@ -207,12 +236,19 @@ import {
 } from '@/lib/world/worldNav';
 import { StarMap, useMapScale } from '@/components/world/StarMap';
 import type { BreadcrumbItem, MapViewport } from '@/components/world/StarMap';
+import type { FileReference } from '@/types';
 import { SectorView, WORLD_SCALE } from '@/components/world/SectorView';
 import { SystemView, systemFitRadius } from '@/components/world/SystemView';
 import { SiteList } from '@/components/world/SiteList';
 import { PartyStatusBar } from '@/components/world/PartyStatusBar';
 import { EntityPanel } from '@/components/world/EntityPanel';
-import type { EntityPanelEntity, EntityPanelLead } from '@/components/world/EntityPanel';
+import type {
+  EntityPanelEntity,
+  EntityPanelLead,
+  EntityPanelPersonaje,
+} from '@/components/world/EntityPanel';
+import { PnjCard } from '@/components/world/PnjCard';
+import { FullscreenImage } from '@/components/world/FullscreenImage';
 import { DiagnosticsPanel } from '@/components/world/DiagnosticsPanel';
 import { WorldSearchDialog } from '@/components/world/WorldSearchDialog';
 import { QuickLogBar } from '@/components/world/QuickLogBar';
@@ -481,6 +517,9 @@ export default function WorldPage() {
   );
   const [eventApplied, setEventApplied] = useState<number[]>([]);
   const [eventDrawCount, setEventDrawCount] = useState(0);
+  // M6: resolved object URL currently zoomed in the player-safe fullscreen
+  // viewer (null = closed). The URL belongs to the page-owned image cache.
+  const [zoomedImageUrl, setZoomedImageUrl] = useState<string | null>(null);
   // M5: place whose ActRunner overlay is open (null = closed) + the part the
   // GM is currently on (for the "Acto cerrado" nota — see module doc M5).
   const [actPlaceId, setActPlaceId] = useState<string | null>(null);
@@ -518,6 +557,38 @@ export default function WorldPage() {
     );
     setModelRev((rev) => rev + 1);
   }, []);
+
+  /**
+   * M6: object URLs for entity profile images, keyed by path — one cache per
+   * page lifetime, resolved lazily via worldFs.getFileURL (same pattern as
+   * the ActRunner's imageUrlCache). Revoked when the model or fs changes and
+   * on unmount (the effect below), so stale blobs never leak across scans.
+   */
+  const entityImageUrlCacheRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    void model;
+    void worldFs;
+    const cache = entityImageUrlCacheRef.current;
+    return () => {
+      cache.forEach((url) => URL.revokeObjectURL(url));
+      cache.clear();
+      // A zoomed URL from the previous model is dead after the revoke.
+      setZoomedImageUrl(null);
+    };
+  }, [model, worldFs]);
+
+  /** Resolve-and-cache an entity image object URL (fs read at call time). */
+  const loadEntityImageUrl = useCallback(async (ref: FileReference): Promise<string> => {
+    const cached = entityImageUrlCacheRef.current.get(ref.path);
+    if (cached !== undefined) return cached;
+    const fsm = useWorldStore.getState().fs;
+    if (!fsm) throw new Error('No hay carpeta de campaña abierta');
+    const url = await fsm.getFileURL(ref.path);
+    entityImageUrlCacheRef.current.set(ref.path, url);
+    return url;
+  }, []);
+
+  const handleImageZoom = useCallback((url: string) => setZoomedImageUrl(url), []);
 
   const mapWrapRef = useRef<HTMLDivElement>(null);
   const fittedRef = useRef<{
@@ -1693,6 +1764,48 @@ export default function WorldPage() {
     );
   }, [model, selectedEntity]);
 
+  /**
+   * M6: the selection when it is a pnj — the panel renders a PnjCard instead
+   * of the EntityPanel. Membership in model.pnjs is the guard (the scanner's
+   * kind is authoritative; `tipo` is an open string).
+   */
+  const selectedPnj = useMemo(
+    () =>
+      model && selectedEntityId
+        ? (model.pnjs.find((pnj) => pnj.id === selectedEntityId) ?? null)
+        : null,
+    [model, selectedEntityId]
+  );
+
+  /**
+   * M6: pnjs located AT the selected entity (Personajes section). GM-only
+   * panel, so ALL of them list — the unmet ones (conocimiento desconocido)
+   * just carry a muted hint.
+   */
+  const panelPersonajes = useMemo<EntityPanelPersonaje[]>(() => {
+    void modelRev; // llegada/sabe bump conocimiento in place
+    if (!model || !selectedEntity) return [];
+    return model.pnjs
+      .filter((pnj) => pnj.ubicacion === selectedEntity.id)
+      .map((pnj) => ({
+        id: pnj.id,
+        nombre: pnj.nombre,
+        rol: pnj.rol,
+        desconocido: pnj.conocimiento === 'desconocido',
+      }));
+  }, [model, selectedEntity, modelRev]);
+
+  /** PnjCard back: to the pnj's ubicacion place (or clear a dangling one). */
+  const handlePnjBack = useCallback(() => {
+    const currentModel = useWorldStore.getState().model;
+    const pnj = selectedPnj;
+    if (pnj?.ubicacion && currentModel?.entidades.has(pnj.ubicacion)) {
+      navigateToEntity(pnj.ubicacion);
+    } else {
+      uiActions.selectEntity(null);
+    }
+  }, [selectedPnj, navigateToEntity, uiActions]);
+
   /** M5: the selection when it is a playable place (offers "Jugar"). */
   const selectedPlayable = useMemo(
     () => (isPlace(selectedEntity) && selectedEntity.playable ? selectedEntity : null),
@@ -2206,10 +2319,29 @@ export default function WorldPage() {
                       />
                     </div>
                   )}
+                  {/* M6: a pnj selection renders its dossier card instead of
+                      the generic panel (selection route documented in the
+                      module doc "PNJ SURFACE"). */}
+                  {selectedPnj && (
+                    <div className="min-h-0 flex-1">
+                      <PnjCard
+                        pnj={selectedPnj}
+                        faccionNombre={
+                          selectedPnj.faccion
+                            ? (model.entidades.get(selectedPnj.faccion)?.nombre ??
+                              selectedPnj.faccion)
+                            : undefined
+                        }
+                        loadImageUrl={loadEntityImageUrl}
+                        onImageZoom={handleImageZoom}
+                        onBack={handlePnjBack}
+                      />
+                    </div>
+                  )}
                   {/* When the SiteList's lugar IS the selection (the common
                       case right after "Entrar") the panel would duplicate the
                       list's own header card — skip it (UX audit P1-2a). */}
-                  {selectedEntity && selectedEntity.id !== siteListPlace?.id && (
+                  {!selectedPnj && selectedEntity && selectedEntity.id !== siteListPlace?.id && (
                     <div className="min-h-0 flex-1">
                       <EntityPanel
                         entity={selectedEntity as EntityPanelEntity}
@@ -2218,6 +2350,10 @@ export default function WorldPage() {
                         leads={panelLeads}
                         interiorLeads={interiorLeads}
                         isCurrentLocation={selectedEntity.id === ubicacion}
+                        personajes={panelPersonajes}
+                        onSelectPnj={selectEntity}
+                        loadImageUrl={loadEntityImageUrl}
+                        onImageZoom={handleImageZoom}
                         onDrillIn={
                           selectedIsContainer ? () => enterEntity(selectedEntity.id) : undefined
                         }
@@ -2385,6 +2521,12 @@ export default function WorldPage() {
               onClose={handleCloseActRunner}
               onActChange={handleActChange}
             />
+          )}
+
+          {/* M6: player-safe fullscreen for entity images (z above everything;
+              the URL lives in the page cache — never revoked here). */}
+          {zoomedImageUrl && (
+            <FullscreenImage imageUrl={zoomedImageUrl} onClose={() => setZoomedImageUrl(null)} />
           )}
         </>
       ) : (

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -324,6 +324,9 @@ import type { MoverDialogLugar } from '@/components/world/MoverDialog';
 import { JournalPanel } from '@/components/world/JournalPanel';
 import { SessionRecoveryBanner } from '@/components/world/SessionRecoveryBanner';
 import { LeadsBoard } from '@/components/world/LeadsBoard';
+import { HilosBoard } from '@/components/world/HilosBoard';
+import { ThreadLayer } from '@/components/world/ThreadLayer';
+import { tramaThreadNodes, TRAMA_ROL_COLOR } from '@/lib/world/threads';
 import { EventDrawer } from '@/components/world/EventDrawer';
 import type { EventOutcome } from '@/components/world/EventDrawer';
 import { EventosPanel } from '@/components/world/EventosPanel';
@@ -551,6 +554,7 @@ export default function WorldPage() {
   const showUnknown = useUiStore((s) => s.showUnknown);
   const mapCollapsed = useUiStore((s) => s.mapCollapsed);
   const panelTab = useUiStore((s) => s.panelTab);
+  const focusTramaId = useUiStore((s) => s.focusTramaId);
   const uiActions = useUiStore((s) => s.actions);
 
   // Live party fields — hydrated from estado/grupo.md, mutated only via log().
@@ -2286,6 +2290,22 @@ export default function WorldPage() {
     };
   }, [model, ubicacion, selectedEntity, canTravelToSelected, medidores, diaMundo, travel, modelRev]);
 
+  /**
+   * Hilos ("story threads") overlay: the focused trama's sector-root nodes +
+   * rol color. Sector tier only (the web lives on the sector map, like
+   * routePreview); a stale focusTramaId (trama gone after a re-scan) resolves
+   * to empty nodes and paints nothing. Null hides the overlay entirely.
+   */
+  const threadOverlay = useMemo<{ nodes: { id: string; x: number; y: number }[]; color: string; label: string } | null>(() => {
+    void modelRev;
+    if (!model || !focusTramaId || tier !== 'sector') return null;
+    const trama = model.tramas.find((t) => t.id === focusTramaId);
+    if (!trama) return null;
+    const { nodes } = tramaThreadNodes(model, focusTramaId);
+    if (nodes.length === 0) return null;
+    return { nodes, color: TRAMA_ROL_COLOR[trama.rol], label: trama.nombre };
+  }, [model, focusTramaId, tier, modelRev]);
+
   // ── Search & deep link ────────────────────────────────────────────────────
 
   // Model is immutable-after-scan, so the index never staleses within a scan.
@@ -2721,6 +2741,15 @@ export default function WorldPage() {
                     onSelect={selectEntity}
                     onDrillIn={enterEntity}
                     routes={<RouteLayer data={routePreview} />}
+                    threads={
+                      threadOverlay && (
+                        <ThreadLayer
+                          nodes={threadOverlay.nodes}
+                          color={threadOverlay.color}
+                          label={threadOverlay.label}
+                        />
+                      )
+                    }
                   />
                 )}
               </StarMap>
@@ -2742,6 +2771,7 @@ export default function WorldPage() {
                   [
                     ['entidad', 'Entidad'],
                     ['pistas', 'Pistas'],
+                    ['hilos', 'Hilos'],
                     ['diario', 'Diario'],
                   ] as const
                 ).map(([tab, label]) => (
@@ -2934,6 +2964,17 @@ export default function WorldPage() {
                       if (pista) handlePistaTransition(pista, to);
                     }}
                     onSelectPlace={navigateToEntity}
+                    placeNombre={(id) => model.entidades.get(id)?.nombre}
+                  />
+                </div>
+              )}
+
+              {panelTab === 'hilos' && (
+                <div className="min-h-0 flex-1">
+                  <HilosBoard
+                    tramas={model.tramas}
+                    focusTramaId={focusTramaId}
+                    onFocusTrama={(id) => uiActions.focusTrama(id)}
                     placeNombre={(id) => model.entidades.get(id)?.nombre}
                   />
                 </div>

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -1836,6 +1836,30 @@ export default function WorldPage() {
             <h1 className="text-lg font-semibold">{model.manifest.nombre || 'Mundo'}</h1>
             <div className="ml-auto flex items-center gap-2">
               <WorldSearchDialog index={searchIndex} onResultSelect={navigateToEntity} />
+              {/* Manual rescan: the app never watches the filesystem (no FS Access
+                  watch API), so after the maintenance agent edits mundo/ — or after
+                  an app update changes the scanner — the GM refreshes here instead
+                  of hunting for a full page reload. Disabled mid-session: a rescan
+                  rebuilds the model and would visually revert live pista changes. */}
+              <Button
+                variant="outline"
+                size="sm"
+                className="min-h-11"
+                disabled={session.active || worldFs === null}
+                title={
+                  session.active
+                    ? 'Termina la sesión para recargar el mundo'
+                    : 'Vuelve a escanear la carpeta mundo/'
+                }
+                aria-label="Recargar mundo"
+                onClick={() => {
+                  const handle = worldFs?.getDirectoryHandle();
+                  if (handle) void openWorld(handle);
+                }}
+              >
+                <RefreshCw />
+                Recargar
+              </Button>
               <Button
                 variant="outline"
                 size="sm"

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -3156,6 +3156,14 @@ export default function WorldPage() {
               onActChange={handleActChange}
               onApplyEffect={applyEffectCore}
               sessionActive={session.active}
+              creditos={creditos}
+              medidores={medidores}
+              medidorNames={model.manifest.medidores}
+              onCreditos={handleCreditos}
+              onMedidor={handleMedidor}
+              shops={model.tiendas.get(actRunnerPlace.id) ?? []}
+              onBuy={handleBuy}
+              resolveName={(id) => model.entidades.get(id)?.nombre ?? id}
             />
           )}
 

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -290,6 +290,7 @@ import { readEntityFromUrl, writeEntityToUrl } from '@/lib/world/deepLink';
 import {
   ancestryChain,
   childNodeWithin,
+  placeHasPlano,
   sectorNodeFor,
   tierTargetFor,
 } from '@/lib/world/worldNav';
@@ -298,6 +299,7 @@ import type { BreadcrumbItem, MapViewport } from '@/components/world/StarMap';
 import type { FileReference } from '@/types';
 import { SectorView, WORLD_SCALE } from '@/components/world/SectorView';
 import { SystemView, systemFitRadius } from '@/components/world/SystemView';
+import { PlaceView, placeFitRadius } from '@/components/world/PlaceView';
 import { SiteList } from '@/components/world/SiteList';
 import { PartyStatusBar } from '@/components/world/PartyStatusBar';
 import { EntityPanel } from '@/components/world/EntityPanel';
@@ -539,6 +541,7 @@ export default function WorldPage() {
 
   const tier = useUiStore((s) => s.tier);
   const focusSystemId = useUiStore((s) => s.focusSystemId);
+  const focusPlaceId = useUiStore((s) => s.focusPlaceId);
   const siteListId = useUiStore((s) => s.siteListId);
   const selectedEntityId = useUiStore((s) => s.selectedEntityId);
   const showUnknown = useUiStore((s) => s.showUnknown);
@@ -687,7 +690,7 @@ export default function WorldPage() {
   const mapWrapRef = useRef<HTMLDivElement>(null);
   const fittedRef = useRef<{
     model: WorldModel | null;
-    tier: 'sector' | 'system';
+    tier: 'sector' | 'system' | 'place';
     focus: string | null;
   }>({ model: null, tier: 'sector', focus: null });
   const deepLinkDoneRef = useRef(false);
@@ -782,7 +785,10 @@ export default function WorldPage() {
     actions.setPanelTab('entidad');
     const target = tierTargetFor(currentModel, id);
     if (!target) return; // non-spatial entity — selection is enough
-    if (target.tier === 'system' && target.focusSystemId) {
+    if (target.tier === 'place' && target.focusPlaceId && target.focusSystemId) {
+      // A POI: open the parent place's spatial Plano with the POI selected.
+      actions.focusPlace(target.focusPlaceId, target.focusSystemId);
+    } else if (target.tier === 'system' && target.focusSystemId) {
       actions.focusSystem(target.focusSystemId);
     } else {
       actions.backToSector();
@@ -790,7 +796,13 @@ export default function WorldPage() {
     if (target.siteListId) actions.openSiteList(target.siteListId);
   }, []);
 
-  /** Drill INTO an entity (dblclick / Entrar): sistema -> system tier; place with children -> its SiteList. */
+  /**
+   * Drill INTO an entity (dblclick / Entrar):
+   *   - sistema                         -> system tier
+   *   - place with >=1 poi-coord child  -> spatial Plano (place tier)
+   *   - place with children, none poi   -> non-spatial SiteList (fallback)
+   *   - POI / leaf (no children)        -> select only (already done above)
+   */
   const enterEntity = useCallback((id: string) => {
     const currentModel = useWorldStore.getState().model;
     const actions = useUiStore.getState().actions;
@@ -803,16 +815,26 @@ export default function WorldPage() {
       actions.focusSystem(id);
       return;
     }
-    if ((currentModel.childrenOf.get(id)?.length ?? 0) > 0) {
-      // Make sure the spatial tier behind the list matches the place first.
-      const target = tierTargetFor(currentModel, id);
-      if (target?.tier === 'system' && target.focusSystemId) {
-        actions.focusSystem(target.focusSystemId);
-      } else if (target) {
-        actions.backToSector();
-      }
-      actions.openSiteList(id);
+    if ((currentModel.childrenOf.get(id)?.length ?? 0) === 0) return; // leaf/POI: selection is enough
+    // The place's own map placement fixes the sistema backdrop behind it.
+    const target = tierTargetFor(currentModel, id);
+    if (placeHasPlano(currentModel, id) && target?.focusSystemId) {
+      // Spatial Plano: pin the place AND its parent sistema.
+      actions.focusPlace(id, target.focusSystemId);
+      return;
     }
+    // SiteList fallback: match the spatial tier behind the list first so the
+    // list floats over the right backdrop (never jumping the map all the way
+    // out to sector). A POI with non-poi children has a 'place' target: keep
+    // its parent's Plano behind the list.
+    if (target?.tier === 'place' && target.focusPlaceId && target.focusSystemId) {
+      actions.focusPlace(target.focusPlaceId, target.focusSystemId);
+    } else if (target?.tier === 'system' && target.focusSystemId) {
+      actions.focusSystem(target.focusSystemId);
+    } else if (target) {
+      actions.backToSector();
+    }
+    actions.openSiteList(id);
   }, []);
 
   /** Plain selection (map/list click): also brings the Entidad tab forward. */
@@ -1778,14 +1800,31 @@ export default function WorldPage() {
 
   // ── Derived map data ──────────────────────────────────────────────────────
 
-  /** Focused sistema at the system tier; a stale/invalid focus degrades to the sector tier. */
+  /**
+   * Focused place at the 'place' tier (spatial Plano); a stale/missing/invalid
+   * focusPlaceId degrades to the system (or sector) tier — never a blank map.
+   */
+  const focusPlace = useMemo(() => {
+    if (!model || tier !== 'place' || !focusPlaceId) return null;
+    const entity = model.entidades.get(focusPlaceId);
+    return isPlace(entity) ? entity : null;
+  }, [model, tier, focusPlaceId]);
+
+  /**
+   * Focused sistema at the system OR place tier; a stale/invalid focus degrades
+   * to the sector tier. At the place tier it is the Plano's backdrop sistema
+   * (kept for the breadcrumb and the system-tier fallback).
+   */
   const focusSistema = useMemo(() => {
-    if (!model || tier !== 'system' || !focusSystemId) return null;
+    if (!model || (tier !== 'system' && tier !== 'place') || !focusSystemId) return null;
     const entity = model.entidades.get(focusSystemId);
     return entity && entity.tipo === 'sistema' ? (entity as SystemEntity) : null;
   }, [model, tier, focusSystemId]);
 
-  const activeTier: 'sector' | 'system' = focusSistema ? 'system' : 'sector';
+  // A place tier that failed to resolve its place degrades: to system if the
+  // backdrop sistema is valid, else sector (mirrors the persistence degrade).
+  const activeTier: 'sector' | 'system' | 'place' =
+    tier === 'place' && focusPlace ? 'place' : focusSistema ? 'system' : 'sector';
 
   /** Direct children of the focused sistema (childrenOf is orbita-sorted). */
   const systemChildren = useMemo(() => {
@@ -1794,6 +1833,14 @@ export default function WorldPage() {
       .map((id) => model.entidades.get(id))
       .filter(isPlace);
   }, [model, focusSistema]);
+
+  /** Direct children of the focused place (POIs + any unplaced children). */
+  const placeChildren = useMemo(() => {
+    if (!model || !focusPlace) return [];
+    return (model.childrenOf.get(focusPlace.id) ?? [])
+      .map((id) => model.entidades.get(id))
+      .filter(isPlace);
+  }, [model, focusPlace]);
 
   /** Deep-space lugares: own coordinates, no parent — sector-tier nodes. */
   const deepSpace = useMemo(
@@ -1916,11 +1963,15 @@ export default function WorldPage() {
    */
   const partyMapNodeId = useMemo(() => {
     if (!model || !ubicacion) return null;
+    if (activeTier === 'place' && focusPlace) {
+      // Plano: marker on the focused place itself or its direct POI child.
+      return childNodeWithin(model, ubicacion, focusPlace.id);
+    }
     if (activeTier === 'system' && focusSistema) {
       return childNodeWithin(model, ubicacion, focusSistema.id);
     }
     return sectorNodeFor(model, ubicacion);
-  }, [model, ubicacion, activeTier, focusSistema]);
+  }, [model, ubicacion, activeTier, focusSistema, focusPlace]);
 
   // ── M3: Mover candidates + recents ────────────────────────────────────────
 
@@ -2245,11 +2296,24 @@ export default function WorldPage() {
     setViewport(next);
     const currentModel = useWorldStore.getState().model;
     const ui = useUiStore.getState();
-    const isSystem =
-      ui.tier === 'system' &&
+    // Place tier (valid Plano) keys under place:<id>; a valid focused sistema
+    // under system:<id>; anything else (stale focus) commits under 'sector',
+    // matching what the user actually saw.
+    let key = 'sector';
+    if (
+      ui.tier === 'place' &&
+      ui.focusPlaceId !== null &&
+      isPlace(currentModel?.entidades.get(ui.focusPlaceId))
+    ) {
+      key = `place:${ui.focusPlaceId}`;
+    } else if (
+      (ui.tier === 'system' || ui.tier === 'place') &&
       ui.focusSystemId !== null &&
-      currentModel?.entidades.get(ui.focusSystemId)?.tipo === 'sistema';
-    ui.actions.rememberViewport(isSystem ? `system:${ui.focusSystemId}` : 'sector', next);
+      currentModel?.entidades.get(ui.focusSystemId)?.tipo === 'sistema'
+    ) {
+      key = `system:${ui.focusSystemId}`;
+    }
+    ui.actions.rememberViewport(key, next);
   }, []);
 
   // ── Fit-to-content viewport (per model AND per spatial tier) ─────────────
@@ -2274,12 +2338,21 @@ export default function WorldPage() {
     // While collapsed the wrapper is the slim chip, not the map — defer the
     // fit until the map is expanded (mapCollapsed persists across navigations).
     if (mapCollapsed) return;
-    const focus = focusSistema?.id ?? null;
+    // `focus` scopes the fit AND the viewport key: the place at the Plano
+    // tier, otherwise the focused sistema.
+    const focus =
+      activeTier === 'place' ? (focusPlace?.id ?? null) : (focusSistema?.id ?? null);
+    const viewportKey =
+      activeTier === 'place' && focusPlace
+        ? `place:${focusPlace.id}`
+        : focus
+          ? `system:${focus}`
+          : 'sector';
     const fitted = fittedRef.current;
     if (fitted.model === model && fitted.tier === activeTier && fitted.focus === focus) return;
     // A remembered viewport for this tier (persisted gesture commit) beats
     // the computed fit: the GM returns to where they left the map.
-    const remembered = useUiStore.getState().viewports[focus ? `system:${focus}` : 'sector'];
+    const remembered = useUiStore.getState().viewports[viewportKey];
     if (remembered) {
       fittedRef.current = { model, tier: activeTier, focus };
       setViewport({ ...remembered });
@@ -2293,6 +2366,15 @@ export default function WorldPage() {
     // the ResizeObserver retry recomputes with real dimensions.
     if (width < 50 || height < 50) return;
     fittedRef.current = { model, tier: activeTier, focus };
+
+    if (activeTier === 'place' && focusPlace) {
+      // Plano views are centered on (0,0), POIs out to placeFitRadius.
+      const radius = placeFitRadius(placeChildren);
+      const PADDING = 60;
+      const k = Math.min(1.5, Math.max(0.3, (Math.min(width, height) / 2 - PADDING) / radius));
+      setViewport({ x: width / 2, y: height / 2, k });
+      return;
+    }
 
     if (activeTier === 'system' && focusSistema) {
       // System views are centered on (0,0) with rings out to systemFitRadius.
@@ -2333,7 +2415,18 @@ export default function WorldPage() {
       y: height / 2 - ((minY + maxY) / 2) * k,
       k,
     });
-  }, [status, model, activeTier, focusSistema, systemChildren, deepSpace, mapCollapsed, mapSizeRev]);
+  }, [
+    status,
+    model,
+    activeTier,
+    focusSistema,
+    focusPlace,
+    systemChildren,
+    placeChildren,
+    deepSpace,
+    mapCollapsed,
+    mapSizeRev,
+  ]);
 
   // ── Map breadcrumb (Sector / Sistema / Lugar) with clickable pops ────────
   const breadcrumb = useMemo<BreadcrumbItem[]>(() => {
@@ -2344,17 +2437,25 @@ export default function WorldPage() {
       label: model.manifest.nombre || 'Sector',
       onClick: atRoot ? undefined : () => uiActions.backToSector(),
     });
-    if (activeTier === 'system' && focusSistema) {
-      items.push({
-        label: focusSistema.nombre,
-        onClick: siteListPlace ? () => uiActions.closeSiteList() : undefined,
-      });
+    // At the Plano tier the sistema crumb pops back to the system view; at the
+    // system tier it closes an open SiteList (or is inert at the system root).
+    if ((activeTier === 'system' || activeTier === 'place') && focusSistema) {
+      const onClick =
+        activeTier === 'place'
+          ? () => uiActions.backToSystem()
+          : siteListPlace
+            ? () => uiActions.closeSiteList()
+            : undefined;
+      items.push({ label: focusSistema.nombre, onClick });
+    }
+    if (activeTier === 'place' && focusPlace) {
+      items.push({ label: focusPlace.nombre });
     }
     if (siteListPlace) {
       items.push({ label: siteListPlace.nombre });
     }
     return items;
-  }, [model, activeTier, focusSistema, siteListPlace, uiActions]);
+  }, [model, activeTier, focusSistema, focusPlace, siteListPlace, uiActions]);
 
   const handleCopyReport = useCallback(() => {
     const current = useWorldStore.getState().model;
@@ -2550,7 +2651,20 @@ export default function WorldPage() {
                 collapsed={mapCollapsed}
                 onToggleCollapsed={() => uiActions.setMapCollapsed(!mapCollapsed)}
               >
-                {activeTier === 'system' && focusSistema ? (
+                {activeTier === 'place' && focusPlace ? (
+                  <PlaceView
+                    place={focusPlace}
+                    children={placeChildren}
+                    selectedId={selectedEntityId}
+                    partyLocationId={partyMapNodeId}
+                    leadsBadgeCounts={leadsBadgeCounts}
+                    factionColor={factionColor}
+                    showUnknown={showUnknown}
+                    onSelect={selectEntity}
+                    onDrillIn={enterEntity}
+                    onBack={() => uiActions.backToSystem()}
+                  />
+                ) : activeTier === 'system' && focusSistema ? (
                   <SystemView
                     sistema={focusSistema}
                     children={systemChildren}

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 /**
- * /world — world viewer (M1) + drill-in, party readout, search & deep link (M2).
+ * /world — world viewer (M1) + drill-in, party readout, search & deep link
+ * (M2) + session recorder cockpit (M3).
  *
  * Folder entry paths (all end in the same open-and-scan path):
  *   - stored handle still granted  -> scan immediately on mount
@@ -15,19 +16,60 @@
  * M2 tier wiring:
  *   - sector -> system: dblclick a sistema node (or Entrar in its panel).
  *   - system -> SiteList: dblclick a place with children (or Entrar). The
- *     SiteList renders as a right-panel card next to the EntityPanel (like
- *     DiagnosticsPanel) while the map stays on its spatial tier behind it —
- *     tier 3 is non-spatial by design (plan Part B), so an SVG takeover
- *     would only hide context. Back pops SiteList -> system -> sector.
+ *     SiteList renders as a right-panel card next to the EntityPanel while
+ *     the map stays on its spatial tier behind it — tier 3 is non-spatial by
+ *     design (plan Part B). Back pops SiteList -> system -> sector.
  *   - Search (Cmd/Ctrl+K) and ?e= deep links navigate via tierTargetFor().
  *   - Tier changes recompute a fit-to-content viewport (instant, no tween).
+ *
+ * M3 recorder wiring (plan Part B "Write path" + "Cockpit"):
+ *   - "Iniciar sesión" requests readwrite on the mundo/ handle (one prompt,
+ *     gesture-scoped), builds the JournalWriter (write surface enforced in
+ *     the writer: mundo/diario/ + mundo/estado/ only) and arms partyStore.
+ *   - partyStore.log() is the single mutation entry point; every quick-log
+ *     action here builds the entry via makeEntry and fires a sonner toast.
+ *   - Live in-session world changes (llegada knowledge bumps, pista estado)
+ *     mutate the scanned model IN MEMORY via the scanner's own helpers
+ *     (applyLlegadaConocimiento / deriveLeadActionability) and re-render
+ *     through the `modelRev` counter — knowledge never lowers, so an undone
+ *     llegada keeps its bump (same semantics as the scan-time journal
+ *     overlay); an undone pista transition IS reverted. Files re-derive from
+ *     the unprocessed journal on reload.
+ *   - Crash mirror: partyStore's SessionMirror (sessionStorage) -> recovery
+ *     banner; `sesion_activa: true` without a mirror -> stale-lock notice
+ *     (plan Part A anti-conflict protocol).
  */
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Toaster, toast } from 'sonner';
 import { FileSystemManager } from '@/lib/fileSystem';
 import { loadStoredDirHandle, reconnectDirHandle, rememberDirHandle } from '@/lib/dirHandle';
-import { useUiStore, useWorldStore } from '@/lib/world/stores';
-import { formatFecha } from '@/lib/world/partyState';
+import {
+  clearSessionMirror,
+  readSessionMirror,
+  usePartyStore,
+  useUiStore,
+  useWorldStore,
+} from '@/lib/world/stores';
+import type { SessionMirror } from '@/lib/world/stores';
+import { formatFecha, serializePartyState } from '@/lib/world/partyState';
+import { JournalWriter } from '@/lib/world/journalWriter';
+import {
+  makeEntry,
+  parseInicioFinPayload,
+  parseLlegadaPayload,
+  parsePistaPayload,
+} from '@/lib/world/logEntries';
+import {
+  applyLlegadaConocimiento,
+  deriveLeadActionability,
+} from '@/lib/world/worldScanner';
+import {
+  ENTITY_DIRS,
+  ESTADOS_PISTA,
+  PARTY_STATE_FILE,
+  WORLD_DIR,
+} from '@/lib/world/constants';
 import { buildWorldSearchIndex } from '@/lib/world/worldSearch';
 import { readEntityFromUrl, writeEntityToUrl } from '@/lib/world/deepLink';
 import {
@@ -46,17 +88,25 @@ import { EntityPanel } from '@/components/world/EntityPanel';
 import type { EntityPanelEntity, EntityPanelLead } from '@/components/world/EntityPanel';
 import { DiagnosticsPanel } from '@/components/world/DiagnosticsPanel';
 import { WorldSearchDialog } from '@/components/world/WorldSearchDialog';
+import { QuickLogBar } from '@/components/world/QuickLogBar';
+import { MoverDialog } from '@/components/world/MoverDialog';
+import type { MoverDialogLugar } from '@/components/world/MoverDialog';
+import { JournalPanel } from '@/components/world/JournalPanel';
+import { SessionRecoveryBanner } from '@/components/world/SessionRecoveryBanner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 import type {
   FactionPresence,
+  JournalDay,
   Lead,
+  PartyState,
   PlaceEntity,
   SystemEntity,
   WorldEntityBase,
   WorldModel,
 } from '@/types/world';
-import { FolderOpen, Globe, RefreshCw, TriangleAlert } from 'lucide-react';
+import { FolderOpen, Globe, Lock, RefreshCw, Star, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -66,6 +116,9 @@ type WorldTestWindow = Window & { __ttrpgWorldTest?: TtrpgWorldTestHook };
 
 /** How the page lets the user open a folder while no world is loaded. */
 type EntryMode = 'checking' | 'select' | 'reconnect';
+
+/** The only estado path the app ever writes (inside the allowed surface). */
+const ESTADO_PATH = `${WORLD_DIR}/${ENTITY_DIRS.estado}/${PARTY_STATE_FILE}`;
 
 /** Small stable palette for faction rings, picked by hashing the faction id. */
 const FACTION_PALETTE = [
@@ -83,6 +136,24 @@ const NIVEL_RANK: Record<FactionPresence['nivel'], number> = {
   presente: 1,
   encubierta: 0,
 };
+
+const MEDIDOR_LABELS: Record<string, string> = {
+  viveres: 'Víveres',
+  combustible: 'Combustible',
+  nave: 'Nave',
+};
+
+function medidorLabel(nombre: string): string {
+  return MEDIDOR_LABELS[nombre] ?? nombre.charAt(0).toUpperCase() + nombre.slice(1);
+}
+
+/** Local YYYY-MM-DD (journal fecha_real is the GM's wall-clock day). */
+function localToday(now = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
 
 function hashString(value: string): number {
   let hash = 0;
@@ -118,7 +189,16 @@ export default function WorldPage() {
   const selectedEntityId = useUiStore((s) => s.selectedEntityId);
   const showUnknown = useUiStore((s) => s.showUnknown);
   const mapCollapsed = useUiStore((s) => s.mapCollapsed);
+  const panelTab = useUiStore((s) => s.panelTab);
   const uiActions = useUiStore((s) => s.actions);
+
+  // Live party fields — hydrated from estado/grupo.md, mutated only via log().
+  const diaMundo = usePartyStore((s) => s.diaMundo);
+  const ubicacion = usePartyStore((s) => s.ubicacion);
+  const rumbo = usePartyStore((s) => s.rumbo);
+  const creditos = usePartyStore((s) => s.creditos);
+  const medidores = usePartyStore((s) => s.medidores);
+  const session = usePartyStore((s) => s.session);
 
   const [entry, setEntry] = useState<EntryMode>('checking');
   const [pendingHandle, setPendingHandle] = useState<FileSystemDirectoryHandle | null>(null);
@@ -127,6 +207,17 @@ export default function WorldPage() {
   // ?e= read once at first render, BEFORE the URL-writing effect can clear it.
   const [initialDeepLink] = useState(() => readEntityFromUrl());
 
+  // M3 cockpit state.
+  const [moverOpen, setMoverOpen] = useState(false);
+  const [pendingMirror, setPendingMirror] = useState<SessionMirror | null>(null);
+  const [lockDismissed, setLockDismissed] = useState(false);
+  const [sesionNum, setSesionNum] = useState<number | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  // The scanned model is mutated in place for live overlays (knowledge bumps,
+  // pista transitions); bumping this counter re-renders the derived views.
+  const [modelRev, setModelRev] = useState(0);
+  const touchModel = useCallback(() => setModelRev((rev) => rev + 1), []);
+
   const mapWrapRef = useRef<HTMLDivElement>(null);
   const fittedRef = useRef<{
     model: WorldModel | null;
@@ -134,10 +225,16 @@ export default function WorldPage() {
     focus: string | null;
   }>({ model: null, tier: 'sector', focus: null });
   const deepLinkDoneRef = useRef(false);
+  const journalWriterRef = useRef<JournalWriter | null>(null);
+  /** Journals created in THIS app lifetime (model.diario is scan-frozen) — keeps sesion numbering fresh. */
+  const extraDiarioRef = useRef<JournalDay[]>([]);
 
   /** The single open-and-scan path: picker, reconnect and the OPFS test hook all land here. */
   const openWorld = useCallback(async (handle: FileSystemDirectoryHandle) => {
     await useWorldStore.getState().actions.scan(handle);
+    const scanned = useWorldStore.getState().model;
+    // Hydrate the live party fields from estado/grupo.md (no-op mid-session).
+    if (scanned) usePartyStore.getState().actions.hydrate(scanned);
   }, []);
 
   // Stored-handle bootstrap: granted -> scan now; prompt -> offer reconnect.
@@ -208,6 +305,7 @@ export default function WorldPage() {
     const actions = useUiStore.getState().actions;
     if (!currentModel || !currentModel.entidades.has(id)) return;
     actions.selectEntity(id);
+    actions.setPanelTab('entidad');
     const target = tierTargetFor(currentModel, id);
     if (!target) return; // non-spatial entity — selection is enough
     if (target.tier === 'system' && target.focusSystemId) {
@@ -226,6 +324,7 @@ export default function WorldPage() {
     const entity = currentModel.entidades.get(id);
     if (!entity) return;
     actions.selectEntity(id);
+    actions.setPanelTab('entidad');
     if (entity.tipo === 'sistema') {
       actions.focusSystem(id);
       return;
@@ -241,6 +340,293 @@ export default function WorldPage() {
       actions.openSiteList(id);
     }
   }, []);
+
+  /** Plain selection (map/list click): also brings the Entidad tab forward. */
+  const selectEntity = useCallback(
+    (id: string | null) => {
+      uiActions.selectEntity(id);
+      if (id !== null) uiActions.setPanelTab('entidad');
+    },
+    [uiActions]
+  );
+
+  // ── M3: session lifecycle ─────────────────────────────────────────────────
+
+  /**
+   * Readwrite on the mundo/ handle, requested from a user gesture (one
+   * prompt). OPFS handles report 'granted' from queryPermission, so e2e never
+   * prompts.
+   */
+  const ensureWriteAccess = useCallback(async (): Promise<boolean> => {
+    const fsm = useWorldStore.getState().fs;
+    const root = fsm?.getDirectoryHandle();
+    if (!fsm || !root) return false;
+    try {
+      const mundoHandle = await root.getDirectoryHandle(WORLD_DIR);
+      // Handles without the permission API (e.g. OPFS on some engines) are
+      // always writable — Chromium's OPFS reports 'granted' anyway.
+      if (typeof mundoHandle.queryPermission !== 'function') return true;
+      if ((await fsm.queryWritePermission(mundoHandle)) === 'granted') return true;
+      return (await fsm.requestWritePermission(mundoHandle)) === 'granted';
+    } catch (error) {
+      console.error('No se pudo obtener permiso de escritura sobre mundo/:', error);
+      return false;
+    }
+  }, []);
+
+  /**
+   * Wires the partyStore deps ONCE per page lifetime: a JournalWriter over
+   * fs.writeTextFile (surface-checked inside the writer) plus the estado
+   * closure bound to the constant ESTADO_PATH — the app writes nowhere else.
+   * The fs manager is resolved at call time so a re-scan never leaves the
+   * writer holding a stale handle.
+   */
+  const wireSessionDeps = useCallback((): JournalWriter => {
+    if (!journalWriterRef.current) {
+      const writeFile = (path: string, content: string): Promise<void> => {
+        const fsm = useWorldStore.getState().fs;
+        if (!fsm) return Promise.reject(new Error('No hay carpeta de campaña abierta'));
+        return fsm.writeTextFile(path, content);
+      };
+      const writer = new JournalWriter({ writeFile });
+      journalWriterRef.current = writer;
+      usePartyStore.getState().actions.setDeps({
+        writeEstado: (text) => writeFile(ESTADO_PATH, text),
+        journal: writer,
+        now: () => new Date(),
+      });
+    }
+    return journalWriterRef.current;
+  }, []);
+
+  const handleStartSession = useCallback(async () => {
+    const currentModel = useWorldStore.getState().model;
+    if (!currentModel) return;
+    if (!(await ensureWriteAccess())) {
+      toast.error('Permisos de escritura denegados — no se pudo iniciar la sesión');
+      return;
+    }
+    wireSessionDeps();
+    const day = usePartyStore
+      .getState()
+      .actions.startSession([...currentModel.diario, ...extraDiarioRef.current], localToday());
+    if (!day) {
+      toast.error('No se pudo iniciar la sesión');
+      return;
+    }
+    extraDiarioRef.current.push(day);
+    setSesionNum(day.sesion);
+    toast.success(`Sesión ${day.sesion} iniciada`);
+  }, [ensureWriteAccess, wireSessionDeps]);
+
+  const handleEndSession = useCallback(async () => {
+    const summary = await usePartyStore.getState().actions.endSession();
+    if (!summary) {
+      toast.error('No se pudo cerrar la sesión — revisa los permisos de escritura y reintenta');
+      return;
+    }
+    // Keep the scanned estado coherent with the closed session (in memory:
+    // the forced estado write already persisted sesion_activa: false).
+    const currentModel = useWorldStore.getState().model;
+    if (currentModel?.estadoGrupo) currentModel.estadoGrupo.sesionActiva = false;
+    const totalMin = Math.floor(summary.durationMs / 60000);
+    const viajes = summary.counts.llegada ?? 0;
+    const pistasCount = summary.counts.pista ?? 0;
+    const net = summary.netCreditos;
+    toast.success(
+      `Sesión ${sesionNum ?? '—'} terminada — ${Math.floor(totalMin / 60)}h ${totalMin % 60}m · ` +
+        `${viajes} ${viajes === 1 ? 'viaje' : 'viajes'} · ${net >= 0 ? '+' : ''}${net} cr · ` +
+        `${pistasCount} ${pistasCount === 1 ? 'pista' : 'pistas'}`
+    );
+  }, [sesionNum]);
+
+  /** Denied writes need a fresh gesture-scoped permission before retrying. */
+  const handleRetryWrites = useCallback(async () => {
+    if (!(await ensureWriteAccess())) {
+      toast.error('Permisos de escritura denegados');
+      return;
+    }
+    usePartyStore.getState().actions.retryWrites();
+  }, [ensureWriteAccess]);
+
+  // Elapsed-session ticker: 1s interval only while a session runs.
+  useEffect(() => {
+    if (!session.active) return;
+    setNowMs(Date.now());
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [session.active]);
+
+  const sessionElapsedMs =
+    session.active && session.startedAt !== null ? Math.max(0, nowMs - session.startedAt) : 0;
+
+  // Flush the debounced estado write on pagehide/tab-hide while ready.
+  useEffect(() => {
+    if (status !== 'ready') return;
+    return usePartyStore.getState().actions.bindLifecycleFlush();
+  }, [status]);
+
+  // ── M3: crash recovery + stale estado lock ────────────────────────────────
+
+  useEffect(() => {
+    if (status !== 'ready' || !model) return;
+    if (usePartyStore.getState().session.active) return;
+    setPendingMirror(readSessionMirror());
+    setLockDismissed(false);
+  }, [status, model]);
+
+  // A live session owns (and keeps refreshing) the mirror — no banner then,
+  // and none after the session ends (endSession clears the mirror).
+  useEffect(() => {
+    if (session.active) setPendingMirror(null);
+  }, [session.active]);
+
+  const handleRecoverSession = useCallback(async () => {
+    const mirror = pendingMirror;
+    const currentModel = useWorldStore.getState().model;
+    if (!mirror || !currentModel) return;
+    if (!(await ensureWriteAccess())) {
+      toast.error('Permisos de escritura denegados — no se pudo recuperar la sesión');
+      return;
+    }
+    wireSessionDeps();
+    usePartyStore.getState().actions.recoverSession(mirror, currentModel);
+    setSesionNum(mirror.sesion);
+    setPendingMirror(null);
+    toast.success(`Sesión ${mirror.sesion} recuperada`);
+  }, [pendingMirror, ensureWriteAccess, wireSessionDeps]);
+
+  const handleDiscardMirror = useCallback(() => {
+    clearSessionMirror();
+    setPendingMirror(null);
+  }, []);
+
+  /**
+   * Plan Part A anti-conflict protocol: `sesion_activa: true` on disk with no
+   * mirror = a crashed session on another device (or an unflushed lock) — the
+   * agent refuses maintenance until the GM clears it.
+   */
+  const staleLockVisible =
+    status === 'ready' &&
+    !!model?.estadoGrupo?.sesionActiva &&
+    !session.active &&
+    pendingMirror === null &&
+    !lockDismissed;
+
+  const handleMarkLockClosed = useCallback(async () => {
+    const currentModel = useWorldStore.getState().model;
+    const fsm = useWorldStore.getState().fs;
+    const estado = currentModel?.estadoGrupo;
+    if (!estado || !fsm) return;
+    if (!(await ensureWriteAccess())) {
+      toast.error('Permisos de escritura denegados');
+      return;
+    }
+    try {
+      await fsm.writeTextFile(
+        ESTADO_PATH,
+        serializePartyState({ ...estado, sesionActiva: false }, new Date().toISOString())
+      );
+      estado.sesionActiva = false;
+      setLockDismissed(true);
+      toast.success('Sesión marcada como cerrada en estado/grupo.md');
+    } catch (error) {
+      console.error('No se pudo cerrar el bloqueo de sesión:', error);
+      toast.error('No se pudo escribir estado/grupo.md');
+    }
+  }, [ensureWriteAccess]);
+
+  // ── M3: quick-log actions (partyStore.log is the single mutation point) ───
+
+  const handleCreditos = useCallback((delta: number) => {
+    if (delta === 0) return;
+    const logged = usePartyStore
+      .getState()
+      .actions.log(delta < 0 ? makeEntry.gasto(-delta) : makeEntry.ganancia(delta));
+    if (!logged) return;
+    toast.success(`${delta > 0 ? '+' : ''}${delta} créditos anotados`);
+  }, []);
+
+  const handleMedidor = useCallback((nombre: string, to: number) => {
+    const store = usePartyStore.getState();
+    const from = store.medidores[nombre] ?? 0;
+    if (from === to) return;
+    if (!store.actions.log(makeEntry.medidor(nombre, from, to))) return;
+    toast.success(`${medidorLabel(nombre)} ${from} → ${to}`);
+  }, []);
+
+  const handleNota = useCallback((text: string) => {
+    if (!usePartyStore.getState().actions.log(makeEntry.nota(text))) return;
+    toast.success('Nota registrada');
+  }, []);
+
+  const handleMove = useCallback(
+    (id: string) => {
+      const currentModel = useWorldStore.getState().model;
+      const store = usePartyStore.getState();
+      if (!currentModel) return;
+      if (!store.actions.log(makeEntry.llegada(id, store.diaMundo))) return;
+      // In-memory knowledge bump — reuses the scanner's journal-overlay rule
+      // (applyLlegadaConocimiento): destination ≥ visitado, `en:` ancestors
+      // ≥ conocido. The files are updated later by the agent from the journal.
+      applyLlegadaConocimiento(currentModel, id);
+      touchModel();
+      navigateToEntity(id);
+      toast.success(`Llegada: ${currentModel.entidades.get(id)?.nombre ?? id}`);
+    },
+    [navigateToEntity, touchModel]
+  );
+
+  const handlePistaTransition = useCallback(
+    (pista: Lead, to: Lead['estadoPista']) => {
+      const currentModel = useWorldStore.getState().model;
+      if (!currentModel) return;
+      const from = pista.estadoPista;
+      if (!usePartyStore.getState().actions.log(makeEntry.pista(pista.id, from, to))) return;
+      pista.estadoPista = to;
+      deriveLeadActionability(currentModel.entidades, [pista], []);
+      touchModel();
+      toast.success(`Pista «${pista.nombre}»: ${from.replace('_', ' ')} → ${to.replace('_', ' ')}`);
+    },
+    [touchModel]
+  );
+
+  const handleUndo = useCallback(() => {
+    const currentModel = useWorldStore.getState().model;
+    const removed = usePartyStore.getState().actions.undoLast();
+    if (!removed) return;
+    // Party fields revert via snapshot replay inside the store. The pista
+    // overlay is reverted here; knowledge bumps from an undone llegada stay
+    // raised on purpose (knowledge never lowers — scanner semantics).
+    if (removed.tipo === 'pista' && currentModel) {
+      const parsed = parsePistaPayload(removed.payload);
+      const pista = parsed ? currentModel.pistas.find((p) => p.id === parsed.id) : undefined;
+      if (
+        pista &&
+        parsed &&
+        (ESTADOS_PISTA as readonly string[]).includes(parsed.from)
+      ) {
+        pista.estadoPista = parsed.from as Lead['estadoPista'];
+        deriveLeadActionability(currentModel.entidades, [pista], []);
+        touchModel();
+      }
+    }
+    toast.success(`Última entrada deshecha (${removed.tipo})`);
+  }, [touchModel]);
+
+  const endSummaryPreview = useMemo(() => {
+    if (!session.active) return undefined;
+    let viajes = 0;
+    let pistasCount = 0;
+    let net = 0;
+    for (const e of session.entries) {
+      if (e.tipo === 'llegada') viajes++;
+      else if (e.tipo === 'pista') pistasCount++;
+      else if (e.tipo === 'gasto') net -= Number(e.payload) || 0;
+      else if (e.tipo === 'ganancia') net += Number(e.payload) || 0;
+    }
+    return `${session.entries.length} registros · ${viajes} viajes · ${net >= 0 ? '+' : ''}${net} cr · ${pistasCount} pistas`;
+  }, [session]);
 
   // ── Derived map data ──────────────────────────────────────────────────────
 
@@ -273,6 +659,7 @@ export default function WorldPage() {
    * roots) surface leads that live at their inner places.
    */
   const leadsBadgeCounts = useMemo(() => {
+    void modelRev; // live pista transitions mutate accionable in place
     const counts = new Map<string, number>();
     if (!model) return counts;
     for (const pista of model.pistas) {
@@ -282,7 +669,7 @@ export default function WorldPage() {
       }
     }
     return counts;
-  }, [model]);
+  }, [model, modelRev]);
 
   /**
    * Strongest faction presence per node. Presence lives on places; it also
@@ -314,14 +701,26 @@ export default function WorldPage() {
     [dominantFactionByNode]
   );
 
-  // ── Party readout ─────────────────────────────────────────────────────────
+  // ── Party readout (live store fields; hydrate seeds them from the file) ──
 
-  const estadoGrupo = model?.estadoGrupo ?? null;
-  const ubicacion = estadoGrupo?.ubicacion ?? null;
+  /** Live PartyState view for the status bar; null keeps the M2 absent-file hint. */
+  const estadoBar = useMemo<PartyState | null>(() => {
+    if (!model?.estadoGrupo) return null;
+    return {
+      sesionActiva: session.active,
+      diaMundo,
+      ubicacion,
+      rumbo,
+      creditos,
+      medidores,
+      bodyMd: '',
+      filePath: model.estadoGrupo.filePath,
+    };
+  }, [model, session.active, diaMundo, ubicacion, rumbo, creditos, medidores]);
 
   const fecha = useMemo(
-    () => (model ? formatFecha(estadoGrupo?.diaMundo ?? 1, model.manifest) : ''),
-    [model, estadoGrupo]
+    () => (model ? formatFecha(diaMundo, model.manifest) : ''),
+    [model, diaMundo]
   );
 
   /** Root -> current breadcrumb chain for the party bar (dangling ids keep their raw id as label). */
@@ -345,6 +744,29 @@ export default function WorldPage() {
     return sectorNodeFor(model, ubicacion);
   }, [model, ubicacion, activeTier, focusSistema]);
 
+  // ── M3: Mover candidates + recents ────────────────────────────────────────
+
+  const moverLugares = useMemo<MoverDialogLugar[]>(() => {
+    void modelRev; // llegada bumps conocimiento in place
+    if (!model) return [];
+    return [...model.sistemas, ...model.lugares]
+      .filter((e) => e.conocimiento !== 'desconocido')
+      .map((e) => ({ id: e.id, nombre: e.nombre, tipo: e.tipo, conocimiento: e.conocimiento }));
+  }, [model, modelRev]);
+
+  /** Most-recent-first destination ids from this session's llegada/inicio entries. */
+  const recentMoveIds = useMemo(() => {
+    const ids: string[] = [];
+    for (let i = session.entries.length - 1; i >= 0; i--) {
+      const e = session.entries[i];
+      let id: string | null = null;
+      if (e.tipo === 'llegada') id = parseLlegadaPayload(e.payload)?.lugarId ?? null;
+      else if (e.tipo === 'inicio') id = parseInicioFinPayload(e.payload)?.lugarId ?? null;
+      if (id && id !== 'desconocida' && !ids.includes(id)) ids.push(id);
+    }
+    return ids;
+  }, [session.entries]);
+
   // ── SiteList (non-spatial tier 3) ─────────────────────────────────────────
 
   const siteListPlace = useMemo(() => {
@@ -366,6 +788,7 @@ export default function WorldPage() {
    * nearest listed site so the star lands on a visible row.
    */
   const siteListLeads = useMemo(() => {
+    void modelRev;
     if (!model || !siteListPlace) return [];
     const siteIds = new Set(siteListSites.map((site) => site.id));
     return model.pistas.flatMap((pista) => {
@@ -374,7 +797,7 @@ export default function WorldPage() {
       const rolledUp = childNodeWithin(model, pista.donde, siteListPlace.id);
       return rolledUp && rolledUp !== siteListPlace.id ? [{ ...pista, donde: rolledUp }] : [];
     });
-  }, [model, siteListPlace, siteListSites]);
+  }, [model, siteListPlace, siteListSites, modelRev]);
 
   const siteListPartyId = useMemo(() => {
     if (!model || !ubicacion || !siteListPlace) return null;
@@ -410,14 +833,16 @@ export default function WorldPage() {
   }, [model, selectedEntity]);
 
   const panelLeads = useMemo<EntityPanelLead[]>(() => {
+    void modelRev;
     if (!model || !selectedEntity) return [];
     return model.pistas
       .filter((pista) => pista.donde === selectedEntity.id)
       .map(toPanelLead);
-  }, [model, selectedEntity]);
+  }, [model, selectedEntity, modelRev]);
 
   /** Descendant pistas for containers — the panel-side match of the map badge roll-up. */
   const interiorLeads = useMemo<EntityPanelLead[]>(() => {
+    void modelRev;
     if (!model || !selectedEntity || !selectedIsContainer) return [];
     return model.pistas
       .filter(
@@ -427,7 +852,7 @@ export default function WorldPage() {
           ancestryChain(model, pista.donde).includes(selectedEntity.id)
       )
       .map(toPanelLead);
-  }, [model, selectedEntity, selectedIsContainer]);
+  }, [model, selectedEntity, selectedIsContainer, modelRev]);
 
   // ── Search & deep link ────────────────────────────────────────────────────
 
@@ -546,8 +971,11 @@ export default function WorldPage() {
 
   const erroresCount = model?.problemas.filter((p) => p.nivel === 'error').length ?? 0;
 
+  const canUndo = session.active && session.entries.length > 1;
+
   return (
     <div data-world-status={status} className="flex h-screen flex-col bg-background">
+      <Toaster position="top-center" richColors />
       {status === 'ready' && model ? (
         <>
           <header className="flex items-center gap-3 border-b px-4 py-2">
@@ -579,12 +1007,51 @@ export default function WorldPage() {
           </header>
 
           <PartyStatusBar
-            estado={estadoGrupo}
+            estado={estadoBar}
             fecha={fecha}
             locationName={ubicacion}
             locationPath={locationPath}
             onLocationClick={navigateToEntity}
+            medidorNames={model.manifest.medidores}
+            sessionActive={session.active}
+            onStartSession={handleStartSession}
+            onEndSession={handleEndSession}
+            sessionElapsedMs={sessionElapsedMs}
+            writeStatus={session.writeStatus}
+            onRetryWrites={handleRetryWrites}
+            endSummaryPreview={endSummaryPreview}
           />
+
+          <SessionRecoveryBanner
+            visible={pendingMirror !== null && !session.active}
+            journalName={pendingMirror?.journalPath.split('/').pop() ?? ''}
+            onRecover={handleRecoverSession}
+            onDiscard={handleDiscardMirror}
+          />
+
+          {staleLockVisible && (
+            <div
+              data-session-lock
+              role="alert"
+              className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-amber-500/40 bg-amber-500/15 px-3 py-2"
+            >
+              <Lock className="size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />
+              <p className="min-w-0 flex-1 text-sm">
+                Bloqueo de sesión: <code className="rounded bg-muted px-1">estado/grupo.md</code>{' '}
+                tiene <code className="rounded bg-muted px-1">sesion_activa: true</code> sin sesión
+                en curso (posible cierre inesperado en otro dispositivo).
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                data-session-lock-close
+                onClick={handleMarkLockClosed}
+              >
+                Marcar como cerrada
+              </Button>
+            </div>
+          )}
 
           <main className="flex min-h-0 flex-1 gap-3 p-3">
             <div
@@ -609,7 +1076,7 @@ export default function WorldPage() {
                     leadsBadgeCounts={leadsBadgeCounts}
                     factionColor={factionColor}
                     showUnknown={showUnknown}
-                    onSelect={(id) => uiActions.selectEntity(id)}
+                    onSelect={selectEntity}
                     onDrillIn={enterEntity}
                     onBack={() => uiActions.backToSector()}
                   />
@@ -622,50 +1089,132 @@ export default function WorldPage() {
                     leadsBadgeCounts={leadsBadgeCounts}
                     factionColor={factionColor}
                     showUnknown={showUnknown}
-                    onSelect={(id) => uiActions.selectEntity(id)}
+                    onSelect={selectEntity}
                     onDrillIn={enterEntity}
                   />
                 )}
               </StarMap>
             </div>
 
-            {(diagnosticsOpen || selectedEntity || siteListPlace) && (
-              <aside className="flex min-h-0 w-96 shrink-0 flex-col gap-3">
-                {diagnosticsOpen && (
-                  <div className="min-h-0 flex-1">
-                    <DiagnosticsPanel problemas={model.problemas} onCopyReport={handleCopyReport} />
-                  </div>
-                )}
-                {siteListPlace && (
-                  <div className="min-h-0 flex-1">
-                    <SiteList
-                      lugar={siteListPlace}
-                      sites={siteListSites}
-                      leads={siteListLeads}
-                      partyLocationId={siteListPartyId}
-                      onSelect={(id) => uiActions.selectEntity(id)}
-                      onBack={() => uiActions.closeSiteList()}
-                    />
-                  </div>
-                )}
-                {selectedEntity && (
-                  <div className="min-h-0 flex-1">
-                    <EntityPanel
-                      entity={selectedEntity as EntityPanelEntity}
-                      childNames={childNames}
-                      factionNames={factionNames}
-                      leads={panelLeads}
-                      interiorLeads={interiorLeads}
-                      onDrillIn={
-                        selectedIsContainer ? () => enterEntity(selectedEntity.id) : undefined
-                      }
-                      onClose={() => uiActions.selectEntity(null)}
-                    />
-                  </div>
-                )}
-              </aside>
-            )}
+            <aside className="flex min-h-0 w-96 shrink-0 flex-col gap-2">
+              {diagnosticsOpen && (
+                <div className="min-h-0 flex-1">
+                  <DiagnosticsPanel problemas={model.problemas} onCopyReport={handleCopyReport} />
+                </div>
+              )}
+
+              {/* Right-panel tabs: Entidad / Pistas / Diario (plan Part B cockpit). */}
+              <div role="tablist" aria-label="Panel lateral" className="flex shrink-0 gap-1 rounded-lg border bg-muted/40 p-1">
+                {(
+                  [
+                    ['entidad', 'Entidad'],
+                    ['pistas', 'Pistas'],
+                    ['diario', 'Diario'],
+                  ] as const
+                ).map(([tab, label]) => (
+                  <button
+                    key={tab}
+                    type="button"
+                    role="tab"
+                    data-panel-tab={tab}
+                    aria-selected={panelTab === tab}
+                    onClick={() => uiActions.setPanelTab(tab)}
+                    className={`flex-1 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                      panelTab === tab
+                        ? 'bg-background font-medium shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {panelTab === 'entidad' && (
+                <>
+                  {siteListPlace && (
+                    <div className="min-h-0 flex-1">
+                      <SiteList
+                        lugar={siteListPlace}
+                        sites={siteListSites}
+                        leads={siteListLeads}
+                        partyLocationId={siteListPartyId}
+                        onSelect={selectEntity}
+                        onBack={() => uiActions.closeSiteList()}
+                      />
+                    </div>
+                  )}
+                  {selectedEntity && (
+                    <div className="min-h-0 flex-1">
+                      <EntityPanel
+                        entity={selectedEntity as EntityPanelEntity}
+                        childNames={childNames}
+                        factionNames={factionNames}
+                        leads={panelLeads}
+                        interiorLeads={interiorLeads}
+                        onDrillIn={
+                          selectedIsContainer ? () => enterEntity(selectedEntity.id) : undefined
+                        }
+                        onClose={() => uiActions.selectEntity(null)}
+                      />
+                    </div>
+                  )}
+                  {!siteListPlace && !selectedEntity && (
+                    <Card className="flex flex-1 items-center justify-center py-8">
+                      <p className="px-4 text-center text-sm text-muted-foreground">
+                        Selecciona una entidad en el mapa o con la búsqueda.
+                      </p>
+                    </Card>
+                  )}
+                </>
+              )}
+
+              {panelTab === 'pistas' && (
+                <div className="min-h-0 flex-1">
+                  <LeadsListCard
+                    pistas={model.pistas}
+                    modelRev={modelRev}
+                    sessionActive={session.active}
+                    onTransition={handlePistaTransition}
+                    onNavigate={navigateToEntity}
+                  />
+                </div>
+              )}
+
+              {panelTab === 'diario' && (
+                <Card className="min-h-0 flex-1 gap-0 overflow-hidden py-0">
+                  <JournalPanel
+                    entries={session.entries}
+                    canUndo={canUndo}
+                    onUndo={handleUndo}
+                    sessionActive={session.active}
+                    startedAt={session.startedAt}
+                  />
+                </Card>
+              )}
+            </aside>
           </main>
+
+          <QuickLogBar
+            enabled={session.active}
+            creditos={creditos}
+            medidores={medidores}
+            medidorNames={model.manifest.medidores}
+            onMover={() => setMoverOpen(true)}
+            onCreditos={handleCreditos}
+            onMedidor={handleMedidor}
+            onPista={() => uiActions.setPanelTab('pistas')}
+            onNota={handleNota}
+          />
+
+          <MoverDialog
+            open={moverOpen}
+            onOpenChange={setMoverOpen}
+            lugares={moverLugares}
+            recentIds={recentMoveIds}
+            currentId={ubicacion}
+            onMove={handleMove}
+          />
         </>
       ) : (
         <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
@@ -730,5 +1279,136 @@ export default function WorldPage() {
         </div>
       )}
     </div>
+  );
+}
+
+// ── Pistas tab (M3 placeholder — the full LeadsBoard arrives in M4) ─────────
+
+/** Allowed one-tap estado transitions per current estado (plan Part A workflow). */
+const PISTA_TRANSITIONS: Record<Lead['estadoPista'], Lead['estadoPista'][]> = {
+  rumor: ['activa'],
+  activa: ['en_curso', 'fallida'],
+  en_curso: ['resuelta', 'fallida'],
+  resuelta: [],
+  fallida: [],
+};
+
+const PISTA_ESTADO_LABEL: Record<Lead['estadoPista'], string> = {
+  rumor: 'Rumor',
+  activa: 'Activa',
+  en_curso: 'En curso',
+  resuelta: 'Resuelta',
+  fallida: 'Fallida',
+};
+
+const PISTA_ESTADO_ORDER: Record<Lead['estadoPista'], number> = {
+  activa: 0,
+  en_curso: 1,
+  rumor: 2,
+  resuelta: 3,
+  fallida: 4,
+};
+
+interface LeadsListCardProps {
+  pistas: Lead[];
+  /** Re-render key: pista estado/accionable are mutated in place on the model. */
+  modelRev: number;
+  sessionActive: boolean;
+  onTransition: (pista: Lead, to: Lead['estadoPista']) => void;
+  onNavigate: (id: string) => void;
+}
+
+function LeadsListCard({ pistas, modelRev, sessionActive, onTransition, onNavigate }: LeadsListCardProps) {
+  const sorted = useMemo(() => {
+    void modelRev;
+    return [...pistas].sort((a, b) => {
+      const accA = a.accionable === true ? 0 : 1;
+      const accB = b.accionable === true ? 0 : 1;
+      if (accA !== accB) return accA - accB;
+      const orderDelta = PISTA_ESTADO_ORDER[a.estadoPista] - PISTA_ESTADO_ORDER[b.estadoPista];
+      if (orderDelta !== 0) return orderDelta;
+      return a.nombre.localeCompare(b.nombre, 'es');
+    });
+  }, [pistas, modelRev]);
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-leads-panel>
+      <div className="border-b px-3 py-2">
+        <p className="text-sm font-medium">Pistas</p>
+        <p className="text-xs text-muted-foreground">Tablero completo en M4</p>
+      </div>
+      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
+        {sorted.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">Sin pistas.</p>
+        ) : (
+          sorted.map((pista) => (
+            <div
+              key={pista.id}
+              data-lead-id={pista.id}
+              data-lead-estado={pista.estadoPista}
+              className="rounded-md border px-3 py-2"
+            >
+              <div className="flex items-start gap-2">
+                {pista.accionable === true && (
+                  <Star
+                    className="mt-0.5 size-4 shrink-0 fill-amber-400 text-amber-400"
+                    aria-label="Accionable"
+                  />
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="break-words text-sm font-medium">{pista.nombre}</p>
+                  {pista.donde && (
+                    <button
+                      type="button"
+                      onClick={() => onNavigate(pista.donde!)}
+                      className="text-xs text-muted-foreground hover:underline"
+                    >
+                      @ {pista.donde}
+                    </button>
+                  )}
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-1">
+                  <Badge
+                    variant={
+                      pista.estadoPista === 'resuelta' || pista.estadoPista === 'fallida'
+                        ? 'outline'
+                        : 'secondary'
+                    }
+                  >
+                    {PISTA_ESTADO_LABEL[pista.estadoPista]}
+                  </Badge>
+                  {pista.accionable === 'manual' && (
+                    <Badge variant="outline" className="text-muted-foreground">
+                      según GM
+                    </Badge>
+                  )}
+                </div>
+              </div>
+              {PISTA_TRANSITIONS[pista.estadoPista].length > 0 && (
+                <div className="mt-1.5 flex flex-wrap justify-end gap-1">
+                  {PISTA_TRANSITIONS[pista.estadoPista].map((to) => (
+                    <Button
+                      key={to}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      data-lead-transition={to}
+                      disabled={!sessionActive}
+                      title={sessionActive ? undefined : 'Inicia sesión para registrar'}
+                      onClick={() => onTransition(pista, to)}
+                      className={`h-6 px-2 text-xs ${
+                        to === 'fallida' ? 'border-destructive/40 text-destructive' : ''
+                      }`}
+                    >
+                      {PISTA_ESTADO_LABEL[to]}
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
   );
 }

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -211,7 +211,7 @@ import {
   deriveLeadActionability,
 } from '@/lib/world/worldScanner';
 import { buildCondContext } from '@/lib/world/conditions';
-import { applicableTables, drawEvent } from '@/lib/world/eventEngine';
+import { applicableTables, drawEvent, eventSeenCounts } from '@/lib/world/eventEngine';
 import {
   computeTravelPlan,
   sectorLegEndDay,
@@ -1025,18 +1025,38 @@ export default function WorldPage() {
 
   // ── M4: event drawer (openers first — the travel deficit hook uses them) ──
 
-  /** Weighted draw over the tables applicable at `anchorId` for `contexto`. */
+  /**
+   * Weighted draw over the tables applicable at `anchorId` for `contexto`,
+   * honoring the once-only/decay history model. The seen tally spans BOTH the
+   * live session (partyStore evento entries) AND every scanned diario journal
+   * (evento entries) — so a unico event fired in a prior, not-yet-maintained
+   * session does not refire even before its journal is processed. `extraSeen`
+   * bumps ids beyond that tally: the redraw passes the id just shown so it is
+   * excluded/decayed and the second draw differs when the pool allows.
+   */
   const drawFromTables = useCallback(
     (
       contexto: 'viaje' | 'estancia',
-      anchorId: string | null
+      anchorId: string | null,
+      extraSeen: string[] = []
     ): { table: EventTable; event: WorldEvent } | null => {
       const currentModel = useWorldStore.getState().model;
       if (!currentModel) return null;
       const party = usePartyStore.getState();
       const ctx = buildCondContext(currentModel, party, anchorId);
       const tables = applicableTables(currentModel.tablas, contexto, ctx.regionActual);
-      return drawEvent(tables, ctx, Math.random);
+      const eventoPayloads: string[] = [];
+      for (const entry of party.session.entries) {
+        if (entry.tipo === 'evento') eventoPayloads.push(entry.payload);
+      }
+      for (const journal of currentModel.diario) {
+        for (const entry of journal.entradas) {
+          if (entry.tipo === 'evento') eventoPayloads.push(entry.payload);
+        }
+      }
+      eventoPayloads.push(...extraSeen);
+      const seenCounts = eventSeenCounts(eventoPayloads);
+      return drawEvent(tables, ctx, Math.random, seenCounts);
     },
     []
   );
@@ -1262,13 +1282,18 @@ export default function WorldPage() {
 
   // ── M4: event drawer (draw lifecycle) ─────────────────────────────────────
 
-  /** Otra tirada: one redraw per opening, journals nothing by itself. */
+  /**
+   * Otra tirada: one redraw per opening, journals nothing by itself. The event
+   * just shown this opening is added to the seen tally so the redraw excludes
+   * (unico) or decays (non-unico) it — a different draw when the pool allows.
+   */
   const handleEventRedraw = useCallback(() => {
     const { contexto, anchorId } = eventSourceRef.current;
-    setEventDraw(drawFromTables(contexto, anchorId));
+    const shownId = eventDraw ? `${eventDraw.table.id}#${eventDraw.event.id}` : null;
+    setEventDraw(drawFromTables(contexto, anchorId, shownId ? [shownId] : []));
     setEventApplied([]);
     setEventDrawCount((count) => count + 1);
-  }, [drawFromTables]);
+  }, [drawFromTables, eventDraw]);
 
   const handleEventOutcome = useCallback(
     (outcome: EventOutcome, nota?: string) => {
@@ -2502,16 +2527,17 @@ export default function WorldPage() {
             canRedraw={eventDraw !== null && eventDrawCount < 2}
           />
 
-          {/* World music dock: exists only while the manager does (>=1 track);
-              concealed (state kept) while the ActRunner owns the room. */}
-          {worldAudio && (
-            <WorldAudioDock
-              audioManager={worldAudio}
-              bgm={model.musica.bgm}
-              eventPlaylists={model.musica.eventPlaylists}
-              concealed={actRunnerOpen}
-            />
-          )}
+          {/* World music dock: ALWAYS present in the ready state so an empty
+              mundo/musica/ reads as "no music yet" (empty-state panel) rather
+              than a missing control. The manager is null until there is at
+              least one track (no AudioManager for an empty folder). Concealed
+              (state kept) while the ActRunner owns the room. */}
+          <WorldAudioDock
+            audioManager={worldAudio}
+            bgm={model.musica.bgm}
+            eventPlaylists={model.musica.eventPlaylists}
+            concealed={actRunnerOpen}
+          />
 
           {actRunnerPlace?.playable && worldFs && (
             <ActRunner

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -174,6 +174,39 @@
  *     which flips panelTab) unmounts the board and clears it — no page
  *     wiring needed.
  *
+ * ONGOING EVENTS ("En curso" — feature 1):
+ *   - A drawn event's outcome journals an `evento` entry whose comentario is
+ *     the resolution. The new "En curso" outcome parks it with comentario
+ *     EXACTLY "en curso" (no nota) instead of closing the thread; the drawer
+ *     still closes. handleEventOutcome branches on en_curso for this.
+ *   - The ongoing list is DERIVED (never stored): deriveOngoing(session.entries,
+ *     model.tablas) keeps the latest comentario per evento id — "en curso" =>
+ *     ongoing, anything else => resolved/dropped — and resolves each to a live
+ *     WorldEvent (ids missing from the model are skipped). It rebuilds after
+ *     crash recovery because the session entries are restored. The Eventos tab
+ *     shows the list (count badge = ongoingEvents.length); reopenEvent re-arms
+ *     the drawer on that WorldEvent (estancia @ current ubicacion, redraw off)
+ *     so the GM applies more efectos or picks a final outcome (dropping it).
+ *
+ * COCKPIT COMBAT (feature 2):
+ *   - Combat can break out from a world event, so the EXISTING play
+ *     InitiativeTracker (components/play, UNMODIFIED) is mounted on the cockpit,
+ *     fed the party roster (partyStore.personajes, hydrated from
+ *     estado/grupo.md `personajes:` and round-tripped by serializePartyState so
+ *     a session write never drops it) with pcStats={[]}.
+ *   - DOUBLE-MOUNT GUARD: the ActRunner already mounts its OWN InitiativeTracker
+ *     on the SAME localStorage key (initiativeTrackerState — intentional
+ *     cockpit<->act combat continuity) and renders as a fullscreen overlay OVER
+ *     the cockpit, so the cockpit tracker mounts ONLY while actRunnerPlace ===
+ *     null. (The pre-existing /play page also shares that key — out of scope.)
+ *   - "Abrir combate" in the EventDrawer bridges event -> combat: it parks the
+ *     draw en_curso (fight lands in the ongoing list), reveals the tracker and
+ *     closes the drawer. A cockpit "Combate" button (data-combat-open) reveals
+ *     the tracker so the GM can find it. LIMITATION: the tracker owns its
+ *     expanded/pinned state internally and exposes NO open prop, so neither the
+ *     button nor onOpenCombat can force the panel open — they MOUNT the tracker,
+ *     which self-shows its left-edge pull-tab; the GM expands it from there.
+ *
  * SCAN-OVERLAY ASYMMETRY (M4 decision — documented, not a bug):
  *   worldScanner.overlayUnprocessedJournals re-derives ONLY knowledge (sabe)
  *   and location knowledge (llegada) from journals with procesado: false.
@@ -259,6 +292,9 @@ import { SessionRecoveryBanner } from '@/components/world/SessionRecoveryBanner'
 import { LeadsBoard } from '@/components/world/LeadsBoard';
 import { EventDrawer } from '@/components/world/EventDrawer';
 import type { EventOutcome } from '@/components/world/EventDrawer';
+import { EventosPanel } from '@/components/world/EventosPanel';
+import { deriveOngoing, EN_CURSO_COMENTARIO } from '@/lib/world/ongoingEvents';
+import { InitiativeTracker } from '@/components/play/InitiativeTracker';
 import { TravelDialog } from '@/components/world/TravelDialog';
 import { TravelStepper } from '@/components/world/TravelStepper';
 import { RoutePreview } from '@/components/world/RoutePreview';
@@ -283,7 +319,7 @@ import type {
   WorldEvent,
   WorldModel,
 } from '@/types/world';
-import { FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
+import { FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, Swords, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -478,6 +514,7 @@ export default function WorldPage() {
   const rumbo = usePartyStore((s) => s.rumbo);
   const creditos = usePartyStore((s) => s.creditos);
   const medidores = usePartyStore((s) => s.medidores);
+  const personajes = usePartyStore((s) => s.personajes);
   const session = usePartyStore((s) => s.session);
 
   const [entry, setEntry] = useState<EntryMode>('checking');
@@ -517,6 +554,11 @@ export default function WorldPage() {
   );
   const [eventApplied, setEventApplied] = useState<number[]>([]);
   const [eventDrawCount, setEventDrawCount] = useState(0);
+  // Cockpit combat (feature 2): once revealed the left-edge InitiativeTracker
+  // is mounted. It self-hides until it has entries but always shows its own
+  // pull-tab once mounted; "Combate" flips this on (the tracker manages its own
+  // expanded/pinned state internally — the page cannot force it open via props).
+  const [combatOpen, setCombatOpen] = useState(false);
   // M6: resolved object URL currently zoomed in the player-safe fullscreen
   // viewer (null = closed). The URL belongs to the page-owned image cache.
   const [zoomedImageUrl, setZoomedImageUrl] = useState<string | null>(null);
@@ -1299,12 +1341,17 @@ export default function WorldPage() {
     (outcome: EventOutcome, nota?: string) => {
       const draw = eventDraw;
       if (!draw) return;
+      // en_curso PARKS the event as ongoing: comentario is EXACTLY "en curso"
+      // (the deriveOngoing contract) — no nota. The three closers journal their
+      // resolution and drop the event from the ongoing list.
       const comentario =
-        outcome === 'complicacion'
-          ? nota
-            ? `complicación: ${nota}`
-            : 'complicación'
-          : outcome;
+        outcome === 'en_curso'
+          ? EN_CURSO_COMENTARIO
+          : outcome === 'complicacion'
+            ? nota
+              ? `complicación: ${nota}`
+              : 'complicación'
+            : outcome;
       if (
         !usePartyStore
           .getState()
@@ -1316,6 +1363,50 @@ export default function WorldPage() {
     },
     [eventDraw]
   );
+
+  /**
+   * Feature 1 "En curso" — reopen a PARKED event from the Eventos tab. Finds
+   * the WorldEvent in the live model, re-anchors the drawer on the current
+   * location (estancia @ ubicacion) so redraws/effects use a live CondContext,
+   * resets applied effects, and opens the drawer. From there the GM applies
+   * more efectos or picks a final outcome (which drops it from ongoing).
+   * Redraw is disabled on a reopened event (it is a specific parked thread,
+   * not a fresh draw) via eventDrawCount = 2.
+   */
+  const reopenEvent = useCallback((tabla: string, id: string) => {
+    const currentModel = useWorldStore.getState().model;
+    const table = currentModel?.tablas.find((t) => t.id === tabla);
+    const event = table?.eventos.find((e) => e.id === id);
+    if (!table || !event) return;
+    const anchorId = usePartyStore.getState().ubicacion;
+    eventSourceRef.current = { contexto: 'estancia', anchorId };
+    setEventDraw({ table, event });
+    setEventApplied([]);
+    setEventDrawCount(2); // a reopened parked event never offers "Otra tirada"
+    setEventOpen(true);
+  }, []);
+
+  /**
+   * Feature 2 bridge — "Abrir combate": park the current draw en_curso (so the
+   * fight lands in the ongoing list), reveal the cockpit initiative affordance
+   * and close the drawer. Any event -> combat -> parked -> resolve later.
+   */
+  const handleOpenCombat = useCallback(() => {
+    handleEventOutcome('en_curso');
+    setCombatOpen(true);
+    setEventOpen(false);
+  }, [handleEventOutcome]);
+
+  /**
+   * Optional Eventos-tab shortcut: resolve a parked event WITHOUT reopening the
+   * drawer (journals `resuelto` for that id, dropping it from ongoing).
+   */
+  const handleResolveQuickOngoing = useCallback((tabla: string, id: string) => {
+    const currentModel = useWorldStore.getState().model;
+    const event = currentModel?.tablas.find((t) => t.id === tabla)?.eventos.find((e) => e.id === id);
+    if (!usePartyStore.getState().actions.log(makeEntry.evento(tabla, id, 'resuelto'))) return;
+    toast.success(`Evento «${event?.titulo ?? id}»: resuelto`);
+  }, []);
 
   /**
    * One `:::efecto` line -> one journal entry via makeEntry against CURRENT
@@ -1570,6 +1661,17 @@ export default function WorldPage() {
     );
   }, [session]);
 
+  /**
+   * Feature 1 — ONGOING (parked) events, derived purely from the live session
+   * journal: latest comentario per evento id; "en curso" => ongoing, any other
+   * state => resolved/dropped. Ids missing from the model are skipped. Rebuilds
+   * correctly after crash recovery (entries are restored into session).
+   */
+  const ongoingEvents = useMemo(
+    () => (model ? deriveOngoing(session.entries, model.tablas) : []),
+    [model, session.entries]
+  );
+
   // ── Derived map data ──────────────────────────────────────────────────────
 
   /** Focused sistema at the system tier; a stale/invalid focus degrades to the sector tier. */
@@ -1683,6 +1785,8 @@ export default function WorldPage() {
       rumbo,
       creditos,
       medidores,
+      // The status bar never renders the roster; [] satisfies the type.
+      personajes: [],
       bodyMd: '',
       filePath: model.estadoGrupo.filePath,
     };
@@ -2301,7 +2405,8 @@ export default function WorldPage() {
                   : 'flex min-h-0 w-96 shrink-0 flex-col gap-2'
               }
             >
-              {/* Right-panel tabs: Entidad / Pistas / Diario (plan Part B cockpit). */}
+              {/* Right-panel tabs: Entidad / Pistas / Diario / Eventos (plan
+                  Part B cockpit + feature 1). Eventos carries the ongoing count. */}
               <div role="tablist" aria-label="Panel lateral" className="flex shrink-0 gap-1 rounded-lg border bg-muted/40 p-1">
                 {(
                   [
@@ -2327,6 +2432,31 @@ export default function WorldPage() {
                     {label}
                   </button>
                 ))}
+                <button
+                  type="button"
+                  role="tab"
+                  data-panel-tab="eventos"
+                  aria-selected={panelTab === 'eventos'}
+                  onClick={() => uiActions.setPanelTab('eventos')}
+                  className={`min-h-11 flex-1 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                    panelTab === 'eventos'
+                      ? 'bg-background font-medium shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <span className="inline-flex items-center justify-center gap-1.5">
+                    Eventos
+                    {ongoingEvents.length > 0 && (
+                      <Badge
+                        variant="secondary"
+                        data-eventos-badge={ongoingEvents.length}
+                        className="h-4 min-w-4 justify-center px-1 text-[10px]"
+                      >
+                        {ongoingEvents.length}
+                      </Badge>
+                    )}
+                  </span>
+                </button>
               </div>
 
               {panelTab === 'entidad' && (
@@ -2462,6 +2592,18 @@ export default function WorldPage() {
                   />
                 </Card>
               )}
+
+              {panelTab === 'eventos' && (
+                <div className="flex min-h-0 flex-1 flex-col">
+                  <EventosPanel
+                    eventos={ongoingEvents}
+                    onReopen={reopenEvent}
+                    onResolveQuick={
+                      session.active ? handleResolveQuickOngoing : undefined
+                    }
+                  />
+                </div>
+              )}
             </aside>
           </main>
 
@@ -2522,6 +2664,7 @@ export default function WorldPage() {
             }
             onRedraw={handleEventRedraw}
             onOutcome={handleEventOutcome}
+            onOpenCombat={handleOpenCombat}
             onApplyEffect={handleApplyEffect}
             appliedEffects={eventApplied}
             canRedraw={eventDraw !== null && eventDrawCount < 2}
@@ -2547,6 +2690,50 @@ export default function WorldPage() {
               onClose={handleCloseActRunner}
               onActChange={handleActChange}
             />
+          )}
+
+          {/* Feature 2 — cockpit combat. The EXISTING play InitiativeTracker
+              (unmodified) is fed the party roster; it persists to localStorage
+              key initiativeTrackerState and renders its own left-edge
+              pinned/expanded panel with a pull-tab. Mounted only once the GM
+              reveals it (combatOpen) AND only while the ActRunner is CLOSED:
+              the ActRunner mounts its OWN InitiativeTracker on the same
+              localStorage key (intentional cockpit<->act combat continuity),
+              and it is a fullscreen overlay OVER the cockpit — rendering both
+              at once would double-mount the same key. See the module docstring
+              "COCKPIT COMBAT". */}
+          {combatOpen && actRunnerPlace === null && (
+            <InitiativeTracker playerCharacters={personajes} pcStats={[]} />
+          )}
+
+          {/* "Combate" affordance: a GM needs a way to FIND the tracker (it
+              self-hides until it has entries). This reveals/mounts it; the
+              tracker then owns its own left-edge pull-tab. LIMITATION: the
+              tracker manages its expanded/pinned state internally and exposes
+              no open prop, so this cannot force the panel open — it mounts the
+              tracker (which shows its pull-tab) and points the GM there. Hidden
+              while the ActRunner overlay owns the screen (it has its own
+              tracker). */}
+          {actRunnerPlace === null && (
+            <Button
+              type="button"
+              size="sm"
+              variant={combatOpen ? 'secondary' : 'outline'}
+              data-combat-open
+              aria-pressed={combatOpen}
+              onClick={() => setCombatOpen(true)}
+              title={
+                combatOpen
+                  ? 'Combate activo — el rastreador de iniciativa está en el borde izquierdo'
+                  : 'Abrir el rastreador de iniciativa (combate)'
+              }
+              // Bottom-RIGHT, clear of the bottom-left WorldAudioDock and the
+              // bottom-center toaster; above the QuickLogBar band.
+              className="fixed bottom-20 right-3 z-30 min-h-11 shadow-lg"
+            >
+              <Swords aria-hidden />
+              Combate
+            </Button>
           )}
 
           {/* M6: player-safe fullscreen for entity images (z above everything;

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -201,11 +201,11 @@
  *     null. (The pre-existing /play page also shares that key — out of scope.)
  *   - "Abrir combate" in the EventDrawer bridges event -> combat: it parks the
  *     draw en_curso (fight lands in the ongoing list), reveals the tracker and
- *     closes the drawer. A cockpit "Combate" button (data-combat-open) reveals
- *     the tracker so the GM can find it. LIMITATION: the tracker owns its
- *     expanded/pinned state internally and exposes NO open prop, so neither the
- *     button nor onOpenCombat can force the panel open — they MOUNT the tracker,
- *     which self-shows its left-edge pull-tab; the GM expands it from there.
+ *     closes the drawer. A cockpit "Combate" button (data-combat-open) mounts
+ *     the tracker AND force-opens the full panel via its openSignal prop (a
+ *     counter the button/onOpenCombat bump; the tracker expands on increment).
+ *     openSignal is world-only — /play passes nothing and keeps the tracker's
+ *     self-managed hover-to-expand behavior unchanged.
  *
  * SCAN-OVERLAY ASYMMETRY (M4 decision — documented, not a bug):
  *   worldScanner.overlayUnprocessedJournals re-derives ONLY knowledge (sabe)
@@ -555,10 +555,11 @@ export default function WorldPage() {
   const [eventApplied, setEventApplied] = useState<number[]>([]);
   const [eventDrawCount, setEventDrawCount] = useState(0);
   // Cockpit combat (feature 2): once revealed the left-edge InitiativeTracker
-  // is mounted. It self-hides until it has entries but always shows its own
-  // pull-tab once mounted; "Combate" flips this on (the tracker manages its own
-  // expanded/pinned state internally — the page cannot force it open via props).
+  // is mounted. "Combate" (and "Abrir combate" from an event) flip combatOpen
+  // on AND bump combatOpenSignal, which the tracker's openSignal prop uses to
+  // force the full panel open (not just the pull-tab).
   const [combatOpen, setCombatOpen] = useState(false);
+  const [combatOpenSignal, setCombatOpenSignal] = useState(0);
   // M6: resolved object URL currently zoomed in the player-safe fullscreen
   // viewer (null = closed). The URL belongs to the page-owned image cache.
   const [zoomedImageUrl, setZoomedImageUrl] = useState<string | null>(null);
@@ -647,6 +648,10 @@ export default function WorldPage() {
   const openWorld = useCallback(async (handle: FileSystemDirectoryHandle) => {
     await useWorldStore.getState().actions.scan(handle);
     const scanned = useWorldStore.getState().model;
+    // A fresh scan reloads model.diario from disk, so the in-tab session-number
+    // tracker is now obsolete — clear it (else a discarded session's JournalDay
+    // would keep inflating the next session's number after a rescan).
+    extraDiarioRef.current = [];
     // Hydrate the live party fields from estado/grupo.md (no-op mid-session).
     if (scanned) usePartyStore.getState().actions.hydrate(scanned);
   }, []);
@@ -812,6 +817,11 @@ export default function WorldPage() {
         writeEstado: (text) => writeFile(ESTADO_PATH, text),
         journal: writer,
         now: () => new Date(),
+        deleteFile: (path) => {
+          const current = useWorldStore.getState().fs;
+          if (!current) return Promise.reject(new Error('No hay carpeta de campaña abierta'));
+          return current.deleteFile(path);
+        },
       });
     }
     return journalWriterRef.current;
@@ -857,6 +867,22 @@ export default function WorldPage() {
         `${pistasCount} ${pistasCount === 1 ? 'pista' : 'pistas'}`
     );
   }, [sesionNum]);
+
+  /**
+   * DISCARD SESSION (test run): delete the session journal + roll estado back to
+   * the session-start snapshot, then rescan so in-memory knowledge/pista bumps
+   * revert and model.diario drops the deleted file. Leaves zero trace.
+   */
+  const handleDiscardSession = useCallback(async () => {
+    const { ok } = await usePartyStore.getState().actions.discardSession();
+    if (!ok) {
+      toast.error('No se pudo descartar la sesión');
+      return;
+    }
+    toast.success('Sesión de prueba descartada — sin cambios');
+    const handle = worldFs?.getDirectoryHandle();
+    if (handle) await openWorld(handle);
+  }, [worldFs, openWorld]);
 
   /** Denied writes need a fresh gesture-scoped permission before retrying. */
   const handleRetryWrites = useCallback(async () => {
@@ -1394,6 +1420,7 @@ export default function WorldPage() {
   const handleOpenCombat = useCallback(() => {
     handleEventOutcome('en_curso');
     setCombatOpen(true);
+    setCombatOpenSignal((n) => n + 1);
     setEventOpen(false);
   }, [handleEventOutcome]);
 
@@ -2288,6 +2315,7 @@ export default function WorldPage() {
             sessionActive={session.active}
             onStartSession={handleStartSession}
             onEndSession={handleEndSession}
+            onDiscardSession={handleDiscardSession}
             sessionElapsedMs={sessionElapsedMs}
             writeStatus={session.writeStatus}
             onRetryWrites={handleRetryWrites}
@@ -2703,17 +2731,16 @@ export default function WorldPage() {
               at once would double-mount the same key. See the module docstring
               "COCKPIT COMBAT". */}
           {combatOpen && actRunnerPlace === null && (
-            <InitiativeTracker playerCharacters={personajes} pcStats={[]} />
+            <InitiativeTracker
+              playerCharacters={personajes}
+              pcStats={[]}
+              openSignal={combatOpenSignal}
+            />
           )}
 
-          {/* "Combate" affordance: a GM needs a way to FIND the tracker (it
-              self-hides until it has entries). This reveals/mounts it; the
-              tracker then owns its own left-edge pull-tab. LIMITATION: the
-              tracker manages its expanded/pinned state internally and exposes
-              no open prop, so this cannot force the panel open — it mounts the
-              tracker (which shows its pull-tab) and points the GM there. Hidden
-              while the ActRunner overlay owns the screen (it has its own
-              tracker). */}
+          {/* "Combate" affordance: mounts the tracker AND force-opens it via
+              openSignal (the full panel, not just the pull-tab). Hidden while
+              the ActRunner overlay owns the screen (it has its own tracker). */}
           {actRunnerPlace === null && (
             <Button
               type="button"
@@ -2721,12 +2748,11 @@ export default function WorldPage() {
               variant={combatOpen ? 'secondary' : 'outline'}
               data-combat-open
               aria-pressed={combatOpen}
-              onClick={() => setCombatOpen(true)}
-              title={
-                combatOpen
-                  ? 'Combate activo — el rastreador de iniciativa está en el borde izquierdo'
-                  : 'Abrir el rastreador de iniciativa (combate)'
-              }
+              onClick={() => {
+                setCombatOpen(true);
+                setCombatOpenSignal((n) => n + 1);
+              }}
+              title="Abrir el rastreador de iniciativa (combate)"
               // Bottom-RIGHT, clear of the bottom-left WorldAudioDock and the
               // bottom-center toaster; above the QuickLogBar band.
               className="fixed bottom-20 right-3 z-30 min-h-11 shadow-lg"

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -3192,14 +3192,14 @@ export default function WorldPage() {
               rendering mundo/resumen.md through the existing MarkdownViewer. */}
           {model.resumen !== null && (
             <Dialog open={resumenOpen} onOpenChange={setResumenOpen}>
-              <DialogContent data-resumen-dialog className="max-h-[80vh] overflow-hidden sm:max-w-2xl">
+              <DialogContent data-resumen-dialog className="flex max-h-[80vh] flex-col overflow-hidden sm:max-w-2xl">
                 <DialogHeader>
                   <DialogTitle>Anteriormente…</DialogTitle>
                   <DialogDescription className="sr-only">
                     Resumen de la sesión anterior
                   </DialogDescription>
                 </DialogHeader>
-                <div className="min-h-0 overflow-y-auto">
+                <div className="max-h-[calc(80vh-5rem)] min-h-0 flex-1 overflow-y-auto">
                   <MarkdownViewer content={model.resumen} className="prose-sm" />
                 </div>
               </DialogContent>
@@ -3216,14 +3216,14 @@ export default function WorldPage() {
                 if (!open) setGuiaAbierta(null);
               }}
             >
-              <DialogContent data-guia-dialog className="max-h-[80vh] overflow-hidden sm:max-w-2xl">
+              <DialogContent data-guia-dialog className="flex max-h-[80vh] flex-col overflow-hidden sm:max-w-2xl">
                 <DialogHeader>
                   <DialogTitle>{guiaAbierta.titulo}</DialogTitle>
                   <DialogDescription className="sr-only">
                     Guía del GM: {guiaAbierta.titulo}
                   </DialogDescription>
                 </DialogHeader>
-                <div className="min-h-0 overflow-y-auto">
+                <div className="max-h-[calc(80vh-5rem)] min-h-0 flex-1 overflow-y-auto">
                   <MarkdownViewer content={guiaAbierta.content} className="prose-sm" />
                 </div>
               </DialogContent>

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -217,7 +217,9 @@
  *     (an effect), so a shop never lingers over the wrong place; a re-scan that
  *     drops the id closes the panel too (openShop resolves live from
  *     model.tiendas). Back clears selectedShopId -> the place panel returns.
- *   - onBuy is session-gated: it journals gasto(precio, `compra: <articulo>`),
+ *   - onBuy is session-gated: it journals gasto(precio, `compra: <articulo>`)
+ *     at the NEGOTIATED price (the comentario gains `(negociado, base <n>)` when
+ *     the GM edited it away from item.precio),
  *     decrements finite stock IN MEMORY (touchModel re-renders; unlimited stock
  *     = null never decrements — the market never runs out) and toasts
  *     `−<precio> cr · <articulo>` with an undo action. No session -> the log is
@@ -2121,18 +2123,24 @@ export default function WorldPage() {
    * session the log is rejected and the GM sees the hint.
    */
   const handleBuy = useCallback(
-    (item: ShopItem) => {
+    (item: ShopItem, precio: number) => {
       const store = usePartyStore.getState();
       if (!store.session.active) {
         toast.error('Inicia sesión para comprar');
         return;
       }
       if (item.stock === 0) return;
-      if (!store.actions.log(makeEntry.gasto(item.precio, `compra: ${item.articulo}`))) return;
+      // Guard against a NaN/negative negotiated price ever reaching the journal.
+      if (!Number.isFinite(precio) || precio < 0) return;
+      const comentario =
+        precio === item.precio
+          ? `compra: ${item.articulo}`
+          : `compra: ${item.articulo} (negociado, base ${item.precio})`;
+      if (!store.actions.log(makeEntry.gasto(precio, comentario))) return;
       if (item.stock !== null) item.stock -= 1;
       touchModel();
       rederiveLeads(); // creditos>=N requisitos track the live balance
-      toast.success(`−${item.precio} cr · ${item.articulo}`, { action: undoToastAction });
+      toast.success(`−${precio} cr · ${item.articulo}`, { action: undoToastAction });
     },
     [touchModel, rederiveLeads, undoToastAction]
   );
@@ -2951,7 +2959,6 @@ export default function WorldPage() {
             onMedidor={handleMedidor}
             onDescanso={handleDescanso}
             descansoDisabled={travel !== null}
-            onPista={() => uiActions.setPanelTab('pistas')}
             onEvento={() => openEventDrawer('estancia', usePartyStore.getState().ubicacion)}
             eventoDisabled={travel !== null}
             onNota={handleNota}

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * /world — read-only world viewer (M1).
+ * /world — world viewer (M1) + drill-in, party readout, search & deep link (M2).
  *
  * Folder entry paths (all end in the same open-and-scan path):
  *   - stored handle still granted  -> scan immediately on mount
@@ -11,21 +11,51 @@
  *     handle through the same path (contract in e2e/helpers/opfs.ts)
  *
  * The page root always carries data-world-status={idle|scanning|ready|error}.
+ *
+ * M2 tier wiring:
+ *   - sector -> system: dblclick a sistema node (or Entrar in its panel).
+ *   - system -> SiteList: dblclick a place with children (or Entrar). The
+ *     SiteList renders as a right-panel card next to the EntityPanel (like
+ *     DiagnosticsPanel) while the map stays on its spatial tier behind it —
+ *     tier 3 is non-spatial by design (plan Part B), so an SVG takeover
+ *     would only hide context. Back pops SiteList -> system -> sector.
+ *   - Search (Cmd/Ctrl+K) and ?e= deep links navigate via tierTargetFor().
+ *   - Tier changes recompute a fit-to-content viewport (instant, no tween).
  */
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { FileSystemManager } from '@/lib/fileSystem';
 import { loadStoredDirHandle, reconnectDirHandle, rememberDirHandle } from '@/lib/dirHandle';
 import { useUiStore, useWorldStore } from '@/lib/world/stores';
+import { formatFecha } from '@/lib/world/partyState';
+import { buildWorldSearchIndex } from '@/lib/world/worldSearch';
+import { readEntityFromUrl, writeEntityToUrl } from '@/lib/world/deepLink';
+import {
+  ancestryChain,
+  childNodeWithin,
+  sectorNodeFor,
+  tierTargetFor,
+} from '@/lib/world/worldNav';
 import { StarMap } from '@/components/world/StarMap';
-import type { MapViewport } from '@/components/world/StarMap';
+import type { BreadcrumbItem, MapViewport } from '@/components/world/StarMap';
 import { SectorView, WORLD_SCALE } from '@/components/world/SectorView';
+import { SystemView, systemFitRadius } from '@/components/world/SystemView';
+import { SiteList } from '@/components/world/SiteList';
+import { PartyStatusBar } from '@/components/world/PartyStatusBar';
 import { EntityPanel } from '@/components/world/EntityPanel';
 import type { EntityPanelEntity, EntityPanelLead } from '@/components/world/EntityPanel';
 import { DiagnosticsPanel } from '@/components/world/DiagnosticsPanel';
+import { WorldSearchDialog } from '@/components/world/WorldSearchDialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import type { FactionPresence, PlaceEntity, WorldModel } from '@/types/world';
+import type {
+  FactionPresence,
+  Lead,
+  PlaceEntity,
+  SystemEntity,
+  WorldEntityBase,
+  WorldModel,
+} from '@/types/world';
 import { FolderOpen, Globe, RefreshCw, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
@@ -62,18 +92,18 @@ function hashString(value: string): number {
   return Math.abs(hash);
 }
 
-/** [id, parent, grandparent, ...] following `en:` up to the sector root (cycle-guarded). */
-function ancestryChain(model: WorldModel, startId: string): string[] {
-  const chain: string[] = [];
-  const seen = new Set<string>();
-  let id: string | undefined = startId;
-  while (id && !seen.has(id)) {
-    seen.add(id);
-    chain.push(id);
-    const entity = model.entidades.get(id) as Partial<PlaceEntity> | undefined;
-    id = entity?.en;
-  }
-  return chain;
+/** Every scanned lugar carries `servicios` — cheap PlaceEntity type guard. */
+function isPlace(entity: WorldEntityBase | undefined): entity is PlaceEntity {
+  return entity !== undefined && 'servicios' in entity;
+}
+
+function toPanelLead(pista: Lead): EntityPanelLead {
+  return {
+    id: pista.id,
+    nombre: pista.nombre,
+    estadoPista: pista.estadoPista,
+    accionable: pista.accionable,
+  };
 }
 
 export default function WorldPage() {
@@ -82,6 +112,9 @@ export default function WorldPage() {
   const scanProgress = useWorldStore((s) => s.scanProgress);
   const worldError = useWorldStore((s) => s.error);
 
+  const tier = useUiStore((s) => s.tier);
+  const focusSystemId = useUiStore((s) => s.focusSystemId);
+  const siteListId = useUiStore((s) => s.siteListId);
   const selectedEntityId = useUiStore((s) => s.selectedEntityId);
   const showUnknown = useUiStore((s) => s.showUnknown);
   const mapCollapsed = useUiStore((s) => s.mapCollapsed);
@@ -91,9 +124,16 @@ export default function WorldPage() {
   const [pendingHandle, setPendingHandle] = useState<FileSystemDirectoryHandle | null>(null);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [viewport, setViewport] = useState<MapViewport | undefined>(undefined);
+  // ?e= read once at first render, BEFORE the URL-writing effect can clear it.
+  const [initialDeepLink] = useState(() => readEntityFromUrl());
 
   const mapWrapRef = useRef<HTMLDivElement>(null);
-  const fittedModelRef = useRef<WorldModel | null>(null);
+  const fittedRef = useRef<{
+    model: WorldModel | null;
+    tier: 'sector' | 'system';
+    focus: string | null;
+  }>({ model: null, tier: 'sector', focus: null });
+  const deepLinkDoneRef = useRef(false);
 
   /** The single open-and-scan path: picker, reconnect and the OPFS test hook all land here. */
   const openWorld = useCallback(async (handle: FileSystemDirectoryHandle) => {
@@ -160,7 +200,66 @@ export default function WorldPage() {
     await openWorld(handle);
   }, [pendingHandle, openWorld]);
 
+  // ── Tier navigation ───────────────────────────────────────────────────────
+
+  /** Select an entity AND move the map to where it lives (search/deep-link/breadcrumb). */
+  const navigateToEntity = useCallback((id: string) => {
+    const currentModel = useWorldStore.getState().model;
+    const actions = useUiStore.getState().actions;
+    if (!currentModel || !currentModel.entidades.has(id)) return;
+    actions.selectEntity(id);
+    const target = tierTargetFor(currentModel, id);
+    if (!target) return; // non-spatial entity — selection is enough
+    if (target.tier === 'system' && target.focusSystemId) {
+      actions.focusSystem(target.focusSystemId);
+    } else {
+      actions.backToSector();
+    }
+    if (target.siteListId) actions.openSiteList(target.siteListId);
+  }, []);
+
+  /** Drill INTO an entity (dblclick / Entrar): sistema -> system tier; place with children -> its SiteList. */
+  const enterEntity = useCallback((id: string) => {
+    const currentModel = useWorldStore.getState().model;
+    const actions = useUiStore.getState().actions;
+    if (!currentModel) return;
+    const entity = currentModel.entidades.get(id);
+    if (!entity) return;
+    actions.selectEntity(id);
+    if (entity.tipo === 'sistema') {
+      actions.focusSystem(id);
+      return;
+    }
+    if ((currentModel.childrenOf.get(id)?.length ?? 0) > 0) {
+      // Make sure the spatial tier behind the list matches the place first.
+      const target = tierTargetFor(currentModel, id);
+      if (target?.tier === 'system' && target.focusSystemId) {
+        actions.focusSystem(target.focusSystemId);
+      } else if (target) {
+        actions.backToSector();
+      }
+      actions.openSiteList(id);
+    }
+  }, []);
+
   // ── Derived map data ──────────────────────────────────────────────────────
+
+  /** Focused sistema at the system tier; a stale/invalid focus degrades to the sector tier. */
+  const focusSistema = useMemo(() => {
+    if (!model || tier !== 'system' || !focusSystemId) return null;
+    const entity = model.entidades.get(focusSystemId);
+    return entity && entity.tipo === 'sistema' ? (entity as SystemEntity) : null;
+  }, [model, tier, focusSystemId]);
+
+  const activeTier: 'sector' | 'system' = focusSistema ? 'system' : 'sector';
+
+  /** Direct children of the focused sistema (childrenOf is orbita-sorted). */
+  const systemChildren = useMemo(() => {
+    if (!model || !focusSistema) return [];
+    return (model.childrenOf.get(focusSistema.id) ?? [])
+      .map((id) => model.entidades.get(id))
+      .filter(isPlace);
+  }, [model, focusSistema]);
 
   /** Deep-space lugares: own coordinates, no parent — sector-tier nodes. */
   const deepSpace = useMemo(
@@ -215,12 +314,87 @@ export default function WorldPage() {
     [dominantFactionByNode]
   );
 
+  // ── Party readout ─────────────────────────────────────────────────────────
+
+  const estadoGrupo = model?.estadoGrupo ?? null;
+  const ubicacion = estadoGrupo?.ubicacion ?? null;
+
+  const fecha = useMemo(
+    () => (model ? formatFecha(estadoGrupo?.diaMundo ?? 1, model.manifest) : ''),
+    [model, estadoGrupo]
+  );
+
+  /** Root -> current breadcrumb chain for the party bar (dangling ids keep their raw id as label). */
+  const locationPath = useMemo(() => {
+    if (!model || !ubicacion) return [];
+    return ancestryChain(model, ubicacion)
+      .map((id) => ({ id, label: model.entidades.get(id)?.nombre ?? id }))
+      .reverse();
+  }, [model, ubicacion]);
+
+  /**
+   * Party-marker roll-up onto the ACTIVE spatial tier: at sector tier the
+   * marker sits on the `en:` chain root (sistema / deep-space node); at
+   * system tier on the focused sistema's direct child (or its star).
+   */
+  const partyMapNodeId = useMemo(() => {
+    if (!model || !ubicacion) return null;
+    if (activeTier === 'system' && focusSistema) {
+      return childNodeWithin(model, ubicacion, focusSistema.id);
+    }
+    return sectorNodeFor(model, ubicacion);
+  }, [model, ubicacion, activeTier, focusSistema]);
+
+  // ── SiteList (non-spatial tier 3) ─────────────────────────────────────────
+
+  const siteListPlace = useMemo(() => {
+    if (!model || !siteListId) return null;
+    const entity = model.entidades.get(siteListId);
+    return isPlace(entity) ? entity : null;
+  }, [model, siteListId]);
+
+  const siteListSites = useMemo(() => {
+    if (!model || !siteListPlace) return [];
+    return (model.childrenOf.get(siteListPlace.id) ?? [])
+      .map((id) => model.entidades.get(id))
+      .filter(isPlace);
+  }, [model, siteListPlace]);
+
+  /**
+   * Pistas surfaced in the SiteList: direct matches on the lugar or a listed
+   * site, plus deeper-descendant leads rolled up (`donde` remapped) to their
+   * nearest listed site so the star lands on a visible row.
+   */
+  const siteListLeads = useMemo(() => {
+    if (!model || !siteListPlace) return [];
+    const siteIds = new Set(siteListSites.map((site) => site.id));
+    return model.pistas.flatMap((pista) => {
+      if (!pista.donde) return [];
+      if (pista.donde === siteListPlace.id || siteIds.has(pista.donde)) return [pista];
+      const rolledUp = childNodeWithin(model, pista.donde, siteListPlace.id);
+      return rolledUp && rolledUp !== siteListPlace.id ? [{ ...pista, donde: rolledUp }] : [];
+    });
+  }, [model, siteListPlace, siteListSites]);
+
+  const siteListPartyId = useMemo(() => {
+    if (!model || !ubicacion || !siteListPlace) return null;
+    return childNodeWithin(model, ubicacion, siteListPlace.id);
+  }, [model, ubicacion, siteListPlace]);
+
   // ── Selection panel data ──────────────────────────────────────────────────
 
   const selectedEntity = useMemo(
     () => (model && selectedEntityId ? model.entidades.get(selectedEntityId) : undefined),
     [model, selectedEntityId]
   );
+
+  const selectedIsContainer = useMemo(() => {
+    if (!model || !selectedEntity) return false;
+    return (
+      selectedEntity.tipo === 'sistema' ||
+      (model.childrenOf.get(selectedEntity.id)?.length ?? 0) > 0
+    );
+  }, [model, selectedEntity]);
 
   const childNames = useMemo(() => {
     if (!model || !selectedEntity) return [];
@@ -239,26 +413,67 @@ export default function WorldPage() {
     if (!model || !selectedEntity) return [];
     return model.pistas
       .filter((pista) => pista.donde === selectedEntity.id)
-      .map((pista) => ({
-        id: pista.id,
-        nombre: pista.nombre,
-        estadoPista: pista.estadoPista,
-        accionable: pista.accionable,
-      }));
+      .map(toPanelLead);
   }, [model, selectedEntity]);
 
-  // ── Fit-to-content initial viewport (once per scanned model) ─────────────
+  /** Descendant pistas for containers — the panel-side match of the map badge roll-up. */
+  const interiorLeads = useMemo<EntityPanelLead[]>(() => {
+    if (!model || !selectedEntity || !selectedIsContainer) return [];
+    return model.pistas
+      .filter(
+        (pista) =>
+          pista.donde !== undefined &&
+          pista.donde !== selectedEntity.id &&
+          ancestryChain(model, pista.donde).includes(selectedEntity.id)
+      )
+      .map(toPanelLead);
+  }, [model, selectedEntity, selectedIsContainer]);
+
+  // ── Search & deep link ────────────────────────────────────────────────────
+
+  // Model is immutable-after-scan, so the index never staleses within a scan.
+  const searchIndex = useMemo(() => (model ? buildWorldSearchIndex(model) : null), [model]);
+
+  // Deep-link init: consume ?e= once, after the first successful scan.
+  useEffect(() => {
+    if (status !== 'ready' || !model || deepLinkDoneRef.current) return;
+    deepLinkDoneRef.current = true;
+    if (initialDeepLink && model.entidades.has(initialDeepLink)) {
+      navigateToEntity(initialDeepLink);
+    }
+  }, [status, model, initialDeepLink, navigateToEntity]);
+
+  // Selection -> URL (replaceState — no history spam; declared AFTER the
+  // consumer above so the pending ?e= is read before it can be cleared).
+  useEffect(() => {
+    if (status !== 'ready') return;
+    writeEntityToUrl(selectedEntityId);
+  }, [status, selectedEntityId]);
+
+  // ── Fit-to-content viewport (per model AND per spatial tier) ─────────────
   useLayoutEffect(() => {
-    if (status !== 'ready' || !model || fittedModelRef.current === model) return;
+    if (status !== 'ready' || !model) return;
     // While collapsed the wrapper is the slim chip, not the map — defer the
     // fit until the map is expanded (mapCollapsed persists across navigations).
     if (mapCollapsed) return;
+    const focus = focusSistema?.id ?? null;
+    const fitted = fittedRef.current;
+    if (fitted.model === model && fitted.tier === activeTier && fitted.focus === focus) return;
     const el = mapWrapRef.current;
     if (!el) return;
     const width = el.clientWidth;
     const height = el.clientHeight;
     if (width === 0 || height === 0) return;
-    fittedModelRef.current = model;
+    fittedRef.current = { model, tier: activeTier, focus };
+
+    if (activeTier === 'system' && focusSistema) {
+      // System views are centered on (0,0) with rings out to systemFitRadius.
+      const radius = systemFitRadius(systemChildren);
+      const PADDING = 60;
+      const k = Math.min(1.5, Math.max(0.3, (Math.min(width, height) / 2 - PADDING) / radius));
+      setViewport({ x: width / 2, y: height / 2, k });
+      return;
+    }
 
     const points = [
       ...model.sistemas.map((s) => s.coordenadas),
@@ -290,7 +505,28 @@ export default function WorldPage() {
       y: height / 2 - ((minY + maxY) / 2) * k,
       k,
     });
-  }, [status, model, deepSpace, mapCollapsed]);
+  }, [status, model, activeTier, focusSistema, systemChildren, deepSpace, mapCollapsed]);
+
+  // ── Map breadcrumb (Sector / Sistema / Lugar) with clickable pops ────────
+  const breadcrumb = useMemo<BreadcrumbItem[]>(() => {
+    if (!model) return [];
+    const items: BreadcrumbItem[] = [];
+    const atRoot = activeTier === 'sector' && !siteListPlace;
+    items.push({
+      label: model.manifest.nombre || 'Sector',
+      onClick: atRoot ? undefined : () => uiActions.backToSector(),
+    });
+    if (activeTier === 'system' && focusSistema) {
+      items.push({
+        label: focusSistema.nombre,
+        onClick: siteListPlace ? () => uiActions.closeSiteList() : undefined,
+      });
+    }
+    if (siteListPlace) {
+      items.push({ label: siteListPlace.nombre });
+    }
+    return items;
+  }, [model, activeTier, focusSistema, siteListPlace, uiActions]);
 
   const handleCopyReport = useCallback(() => {
     const current = useWorldStore.getState().model;
@@ -318,6 +554,7 @@ export default function WorldPage() {
             <Globe className="size-5 text-muted-foreground" aria-hidden />
             <h1 className="text-lg font-semibold">{model.manifest.nombre || 'Mundo'}</h1>
             <div className="ml-auto flex items-center gap-2">
+              <WorldSearchDialog index={searchIndex} onResultSelect={navigateToEntity} />
               <Button
                 variant="outline"
                 size="sm"
@@ -341,6 +578,14 @@ export default function WorldPage() {
             </div>
           </header>
 
+          <PartyStatusBar
+            estado={estadoGrupo}
+            fecha={fecha}
+            locationName={ubicacion}
+            locationPath={locationPath}
+            onLocationClick={navigateToEntity}
+          />
+
           <main className="flex min-h-0 flex-1 gap-3 p-3">
             <div
               ref={mapWrapRef}
@@ -349,32 +594,58 @@ export default function WorldPage() {
               <StarMap
                 viewport={viewport}
                 onViewportChange={setViewport}
-                breadcrumb={[{ label: model.manifest.nombre || 'Sector' }]}
+                breadcrumb={breadcrumb}
                 showUnknown={showUnknown}
                 onToggleUnknown={() => uiActions.setShowUnknown(!showUnknown)}
                 collapsed={mapCollapsed}
                 onToggleCollapsed={() => uiActions.setMapCollapsed(!mapCollapsed)}
               >
-                <SectorView
-                  sistemas={model.sistemas}
-                  deepSpace={deepSpace}
-                  selectedId={selectedEntityId}
-                  partyLocationId={null /* M2: read from estado/grupo.md */}
-                  leadsBadgeCounts={leadsBadgeCounts}
-                  factionColor={factionColor}
-                  showUnknown={showUnknown}
-                  onSelect={(id) => uiActions.selectEntity(id)}
-                  /* M2 adds tier navigation; until then drill-in (dblclick) just selects. */
-                  onDrillIn={(id) => uiActions.selectEntity(id)}
-                />
+                {activeTier === 'system' && focusSistema ? (
+                  <SystemView
+                    sistema={focusSistema}
+                    children={systemChildren}
+                    selectedId={selectedEntityId}
+                    partyLocationId={partyMapNodeId}
+                    leadsBadgeCounts={leadsBadgeCounts}
+                    factionColor={factionColor}
+                    showUnknown={showUnknown}
+                    onSelect={(id) => uiActions.selectEntity(id)}
+                    onDrillIn={enterEntity}
+                    onBack={() => uiActions.backToSector()}
+                  />
+                ) : (
+                  <SectorView
+                    sistemas={model.sistemas}
+                    deepSpace={deepSpace}
+                    selectedId={selectedEntityId}
+                    partyLocationId={partyMapNodeId}
+                    leadsBadgeCounts={leadsBadgeCounts}
+                    factionColor={factionColor}
+                    showUnknown={showUnknown}
+                    onSelect={(id) => uiActions.selectEntity(id)}
+                    onDrillIn={enterEntity}
+                  />
+                )}
               </StarMap>
             </div>
 
-            {(diagnosticsOpen || selectedEntity) && (
+            {(diagnosticsOpen || selectedEntity || siteListPlace) && (
               <aside className="flex min-h-0 w-96 shrink-0 flex-col gap-3">
                 {diagnosticsOpen && (
                   <div className="min-h-0 flex-1">
                     <DiagnosticsPanel problemas={model.problemas} onCopyReport={handleCopyReport} />
+                  </div>
+                )}
+                {siteListPlace && (
+                  <div className="min-h-0 flex-1">
+                    <SiteList
+                      lugar={siteListPlace}
+                      sites={siteListSites}
+                      leads={siteListLeads}
+                      partyLocationId={siteListPartyId}
+                      onSelect={(id) => uiActions.selectEntity(id)}
+                      onBack={() => uiActions.closeSiteList()}
+                    />
                   </div>
                 )}
                 {selectedEntity && (
@@ -384,6 +655,10 @@ export default function WorldPage() {
                       childNames={childNames}
                       factionNames={factionNames}
                       leads={panelLeads}
+                      interiorLeads={interiorLeads}
+                      onDrillIn={
+                        selectedIsContainer ? () => enterEntity(selectedEntity.id) : undefined
+                      }
                       onClose={() => uiActions.selectEntity(null)}
                     />
                   </div>

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -45,14 +45,25 @@
  *     with coordinates and the plan is not portal — a RoutePreview line on the
  *     sector tier (system tier renders no routes layer; preview also hides
  *     while a trip is running).
- *   - Confirming the TravelDialog (active session required — otherwise toast
- *     "Inicia sesión para viajar") journals `rumbo` and arms the TravelStepper.
- *     CONSUMPTION SCHEDULE: travelDaySchedule() spreads each leg's combustible
- *     inside that leg (unit i of C on leg-day ceil(i·D/C); the default 1 per
- *     tramo lands on the sector leg's LAST day) and charges 1 víveres every
- *     viveresCadaDias-th day of the whole trip — per-day amounts sum exactly
- *     to the plan totals, so stepping == "Resolver resto". Gauges clamp at 0
- *     (GM override); the clamped medidor entry is what gets journaled.
+ *   - Confirming the TravelDialog (active session required — the confirm is
+ *     disabled with a hint row until "Iniciar sesión") journals `rumbo` and
+ *     arms the TravelStepper.
+ *     CONSUMPTION SCHEDULE (economy redesign): travelDaySchedule() burns each
+ *     sector leg's combustible at combustible_cada_dias boundaries inside that
+ *     leg (remainder on the leg's last day) and charges 1 víveres on every
+ *     dia_mundo that is a multiple of viveres_cada_dias — CALENDAR-anchored,
+ *     so the same route costs ±1 ration depending on the departure phase and
+ *     the dialog previews the exact number. Per-day amounts sum exactly to
+ *     the plan totals, so stepping == "Resolver resto". Gauges clamp at 0
+ *     (GM override); the clamped medidor entry is what gets journaled, and a
+ *     tick meeting an ALREADY-EMPTY gauge journals a deficit nota (hambre /
+ *     a la deriva) + warning toast with a "Tirar evento" action instead of a
+ *     no-op `medidor 0->0` line.
+ *   - DESCANSO: the QuickLogBar «Descansar» button advances dia_mundo outside
+ *     travel (stepper owns days mid-trip) — one `descanso` entry plus the
+ *     calendar víveres ticks via the same consumption path. Undoing a
+ *     descanso therefore takes two undos (tick first) — same as travel-day
+ *     pairs.
  *   - REGION OF ROUTE for travel event draws: the CondContext anchors on the
  *     ORIGIN until the sector leg completes (dia <= sectorLegEndDay), then on
  *     the DESTINATION — ubicacion itself only changes at arrival. Intra-system
@@ -139,7 +150,7 @@ import {
   useWorldStore,
 } from '@/lib/world/stores';
 import type { SessionMirror } from '@/lib/world/stores';
-import { formatFecha, serializePartyState } from '@/lib/world/partyState';
+import { defaultPartyState, formatFecha, serializePartyState } from '@/lib/world/partyState';
 import { JournalWriter } from '@/lib/world/journalWriter';
 import {
   makeEntry,
@@ -157,6 +168,7 @@ import {
   computeTravelPlan,
   sectorLegEndDay,
   travelDaySchedule,
+  viveresTicksBetween,
 } from '@/lib/world/travel';
 import type { TravelDayConsumption } from '@/lib/world/travel';
 import {
@@ -386,8 +398,15 @@ export default function WorldPage() {
   const [travelDialog, setTravelDialog] = useState<{
     targetId: string;
     plan: TravelPlan | null;
+    /** Per-day consumption for the plan, computed at dialog-open time. */
+    schedule: TravelDayConsumption[];
   } | null>(null);
   const [travel, setTravel] = useState<TravelRun | null>(null);
+  // Ref twins for closures that outlive a render (toast actions, deficit hook).
+  const travelStateRef = useRef<TravelRun | null>(null);
+  useEffect(() => {
+    travelStateRef.current = travel;
+  }, [travel]);
   const [eventOpen, setEventOpen] = useState(false);
   const [eventDraw, setEventDraw] = useState<{ table: EventTable; event: WorldEvent } | null>(
     null
@@ -496,7 +515,11 @@ export default function WorldPage() {
   const handleReconnect = useCallback(async () => {
     if (!pendingHandle) return;
     const handle = await reconnectDirHandle(pendingHandle);
-    if (!handle) return; // permission denied — keep offering the button
+    if (!handle) {
+      // Permission denied — keep offering the button, but say why it did nothing.
+      toast.error('Permiso denegado al reconectar — vuelve a intentarlo o elige otra carpeta');
+      return;
+    }
     setPendingHandle(null);
     setEntry('select');
     await openWorld(handle);
@@ -743,67 +766,6 @@ export default function WorldPage() {
 
   // ── M3: quick-log actions (partyStore.log is the single mutation point) ───
 
-  const handleCreditos = useCallback(
-    (delta: number) => {
-      if (delta === 0) return;
-      const logged = usePartyStore
-        .getState()
-        .actions.log(delta < 0 ? makeEntry.gasto(-delta) : makeEntry.ganancia(delta));
-      if (!logged) return;
-      rederiveLeads(); // requisitos like creditos>=N track the live balance
-      toast.success(`${delta > 0 ? '+' : ''}${delta} créditos anotados`);
-    },
-    [rederiveLeads]
-  );
-
-  const handleMedidor = useCallback(
-    (nombre: string, to: number) => {
-      const store = usePartyStore.getState();
-      const from = store.medidores[nombre] ?? 0;
-      if (from === to) return;
-      if (!store.actions.log(makeEntry.medidor(nombre, from, to))) return;
-      rederiveLeads();
-      toast.success(`${medidorLabel(nombre)} ${from} → ${to}`);
-    },
-    [rederiveLeads]
-  );
-
-  const handleNota = useCallback((text: string) => {
-    if (!usePartyStore.getState().actions.log(makeEntry.nota(text))) return;
-    toast.success('Nota registrada');
-  }, []);
-
-  const handleMove = useCallback(
-    (id: string) => {
-      const currentModel = useWorldStore.getState().model;
-      const store = usePartyStore.getState();
-      if (!currentModel) return;
-      if (!store.actions.log(makeEntry.llegada(id, store.diaMundo))) return;
-      // In-memory knowledge bump — reuses the scanner's journal-overlay rule
-      // (applyLlegadaConocimiento): destination ≥ visitado, `en:` ancestors
-      // ≥ conocido. The files are updated later by the agent from the journal.
-      applyLlegadaConocimiento(currentModel, id);
-      rederiveLeads(); // llegada moves the ctx anchor AND unlocks donde-based pistas
-      navigateToEntity(id);
-      toast.success(`Llegada: ${currentModel.entidades.get(id)?.nombre ?? id}`);
-    },
-    [navigateToEntity, rederiveLeads]
-  );
-
-  const handlePistaTransition = useCallback(
-    (pista: Lead, to: Lead['estadoPista']) => {
-      const currentModel = useWorldStore.getState().model;
-      if (!currentModel) return;
-      const from = pista.estadoPista;
-      if (!usePartyStore.getState().actions.log(makeEntry.pista(pista.id, from, to))) return;
-      pista.estadoPista = to;
-      // Full re-derive: other pistas may gate on pista:<id>:<estado> conditions.
-      rederiveLeads();
-      toast.success(`Pista «${pista.nombre}»: ${from.replace('_', ' ')} → ${to.replace('_', ' ')}`);
-    },
-    [rederiveLeads]
-  );
-
   const handleUndo = useCallback(() => {
     const currentModel = useWorldStore.getState().model;
     const removed = usePartyStore.getState().actions.undoLast();
@@ -828,6 +790,120 @@ export default function WorldPage() {
     toast.success(`Última entrada deshecha (${removed.tipo})`);
   }, [rederiveLeads]);
 
+  /**
+   * Sonner action for quick-log success toasts: undo where the eyes are,
+   * without the Diario tab detour. Undo stays BLOCKED mid-travel (same rule
+   * as the Diario button — see the canUndo comment below), read via the ref
+   * because the toast can outlive the render that created it.
+   */
+  const undoToastAction = useMemo(
+    () => ({
+      label: 'Deshacer',
+      onClick: () => {
+        if (travelStateRef.current !== null) return;
+        handleUndo();
+      },
+    }),
+    [handleUndo]
+  );
+
+  const handleCreditos = useCallback(
+    (delta: number) => {
+      if (delta === 0) return;
+      const logged = usePartyStore
+        .getState()
+        .actions.log(delta < 0 ? makeEntry.gasto(-delta) : makeEntry.ganancia(delta));
+      if (!logged) return;
+      rederiveLeads(); // requisitos like creditos>=N track the live balance
+      toast.success(`${delta > 0 ? '+' : ''}${delta} créditos anotados`, {
+        action: undoToastAction,
+      });
+    },
+    [rederiveLeads, undoToastAction]
+  );
+
+  const handleMedidor = useCallback(
+    (nombre: string, to: number) => {
+      const store = usePartyStore.getState();
+      const from = store.medidores[nombre] ?? 0;
+      if (from === to) return;
+      if (!store.actions.log(makeEntry.medidor(nombre, from, to))) return;
+      rederiveLeads();
+      toast.success(`${medidorLabel(nombre)} ${from} → ${to}`, { action: undoToastAction });
+    },
+    [rederiveLeads, undoToastAction]
+  );
+
+  const handleNota = useCallback((text: string) => {
+    if (!usePartyStore.getState().actions.log(makeEntry.nota(text))) return;
+    toast.success('Nota registrada');
+  }, []);
+
+  const handleMove = useCallback(
+    (id: string) => {
+      const currentModel = useWorldStore.getState().model;
+      const store = usePartyStore.getState();
+      if (!currentModel) return;
+      if (!store.actions.log(makeEntry.llegada(id, store.diaMundo))) return;
+      // In-memory knowledge bump — reuses the scanner's journal-overlay rule
+      // (applyLlegadaConocimiento): destination ≥ visitado, `en:` ancestors
+      // ≥ conocido. The files are updated later by the agent from the journal.
+      applyLlegadaConocimiento(currentModel, id);
+      rederiveLeads(); // llegada moves the ctx anchor AND unlocks donde-based pistas
+      navigateToEntity(id);
+      toast.success(`Llegada: ${currentModel.entidades.get(id)?.nombre ?? id}`, {
+        action: undoToastAction,
+      });
+    },
+    [navigateToEntity, rederiveLeads, undoToastAction]
+  );
+
+  const handlePistaTransition = useCallback(
+    (pista: Lead, to: Lead['estadoPista']) => {
+      const currentModel = useWorldStore.getState().model;
+      if (!currentModel) return;
+      const from = pista.estadoPista;
+      if (!usePartyStore.getState().actions.log(makeEntry.pista(pista.id, from, to))) return;
+      pista.estadoPista = to;
+      // Full re-derive: other pistas may gate on pista:<id>:<estado> conditions.
+      rederiveLeads();
+      toast.success(
+        `Pista «${pista.nombre}»: ${from.replace('_', ' ')} → ${to.replace('_', ' ')}`,
+        { action: undoToastAction }
+      );
+    },
+    [rederiveLeads, undoToastAction]
+  );
+
+  // ── M4: event drawer (openers first — the travel deficit hook uses them) ──
+
+  /** Weighted draw over the tables applicable at `anchorId` for `contexto`. */
+  const drawFromTables = useCallback(
+    (
+      contexto: 'viaje' | 'estancia',
+      anchorId: string | null
+    ): { table: EventTable; event: WorldEvent } | null => {
+      const currentModel = useWorldStore.getState().model;
+      if (!currentModel) return null;
+      const party = usePartyStore.getState();
+      const ctx = buildCondContext(currentModel, party, anchorId);
+      const tables = applicableTables(currentModel.tablas, contexto, ctx.regionActual);
+      return drawEvent(tables, ctx, Math.random);
+    },
+    []
+  );
+
+  const openEventDrawer = useCallback(
+    (contexto: 'viaje' | 'estancia', anchorId: string | null) => {
+      eventSourceRef.current = { contexto, anchorId };
+      setEventDraw(drawFromTables(contexto, anchorId));
+      setEventApplied([]);
+      setEventDrawCount(1);
+      setEventOpen(true);
+    },
+    [drawFromTables]
+  );
+
   // ── M4: travel flow ───────────────────────────────────────────────────────
 
   /** Arrival shared by the stepper paths + portal confirm: llegada entry, knowledge bump, navigate. */
@@ -846,26 +922,93 @@ export default function WorldPage() {
     [navigateToEntity, rederiveLeads]
   );
 
-  /** One clamped medidor entry (0..5); logging the clamp IS the GM override record. */
-  const logGaugeConsumption = useCallback((nombre: string, amount: number) => {
-    if (amount <= 0) return;
-    const store = usePartyStore.getState();
-    const from = store.medidores[nombre] ?? 0;
-    const to = Math.max(0, Math.min(5, from - amount));
-    store.actions.log(makeEntry.medidor(nombre, from, to));
-  }, []);
+  /**
+   * One clamped medidor entry (0..5); logging the clamp IS the GM override
+   * record. A tick that meets an ALREADY-EMPTY gauge journals a deficit nota
+   * instead of a no-op `medidor 0->0` line, and surfaces a warning toast with
+   * a «Tirar evento» action (the viaje/estancia tables are the complication
+   * source — the GM resolves and logs via `:::efecto`).
+   */
+  const logGaugeConsumption = useCallback(
+    (nombre: string, amount: number, comentario?: string) => {
+      if (amount <= 0) return;
+      const store = usePartyStore.getState();
+      const from = store.medidores[nombre] ?? 0;
+      const to = Math.max(0, from - amount);
+      if (from > 0) {
+        store.actions.log(makeEntry.medidor(nombre, from, to, comentario));
+      }
+      if (amount <= from) return;
+      // Deficit: the gauge cannot cover the tick(s) — complication hook.
+      const dia = store.diaMundo;
+      const texto =
+        nombre === 'viveres'
+          ? `Sin víveres desde el día ${dia} — el grupo pasa hambre; complicación pendiente`
+          : nombre === 'combustible'
+            ? `Sin combustible el día ${dia} — la nave queda a la deriva; complicación pendiente`
+            : `Sin ${nombre} el día ${dia} — complicación pendiente`;
+      if (!store.actions.log(makeEntry.nota(texto))) return;
+      toast.warning(texto, {
+        action: {
+          label: 'Tirar evento',
+          onClick: () => {
+            const run = travelStateRef.current;
+            const loc = usePartyStore.getState().ubicacion;
+            if (run) {
+              openEventDrawer('viaje', run.dia <= run.sectorEndDay ? loc : run.destinoId);
+            } else {
+              openEventDrawer('estancia', loc);
+            }
+          },
+        },
+      });
+    },
+    [openEventDrawer]
+  );
 
-  /** "Viajar aquí": snapshot the target + plan at click time and open the dialog. */
+  /**
+   * «Descansar»: advances dia_mundo OUTSIDE travel (the stepper owns day
+   * advancement mid-trip — the QuickLogBar button is disabled then). One
+   * `descanso` entry + the calendar víveres ticks through the shared
+   * consumption path, then re-derive (plazo / dia>=N requisitos).
+   */
+  const handleDescanso = useCallback(
+    (dias: number) => {
+      const currentModel = useWorldStore.getState().model;
+      const store = usePartyStore.getState();
+      if (dias <= 0 || !currentModel || !store.session.active) return;
+      if (travelStateRef.current !== null) return;
+      const d0 = store.diaMundo;
+      if (!store.actions.log(makeEntry.descanso(dias))) return;
+      const ticks = viveresTicksBetween(
+        d0,
+        d0 + dias,
+        currentModel.manifest.viaje.viveresCadaDias
+      );
+      logGaugeConsumption('viveres', ticks, 'consumo de víveres');
+      rederiveLeads();
+      toast.success(`Descanso de ${diasLabel(dias)} — día ${d0 + dias}`);
+    },
+    [logGaugeConsumption, rederiveLeads]
+  );
+
+  /** "Viajar aquí": snapshot the target + plan/schedule at click time and open the dialog. */
   const handleOpenTravelDialog = useCallback(() => {
     const currentModel = useWorldStore.getState().model;
     const party = usePartyStore.getState();
     const targetId = useUiStore.getState().selectedEntityId;
     if (!currentModel || !party.ubicacion || !targetId) return;
+    const plan = computeTravelPlan(party.ubicacion, targetId, currentModel, {
+      medidores: party.medidores,
+      diaMundo: party.diaMundo,
+    });
     setTravelDialog({
       targetId,
-      plan: computeTravelPlan(party.ubicacion, targetId, currentModel, {
-        medidores: party.medidores,
-      }),
+      plan,
+      schedule:
+        plan && !plan.portal
+          ? travelDaySchedule(plan, currentModel.manifest.viaje, party.diaMundo)
+          : [],
     });
   }, []);
 
@@ -902,7 +1045,9 @@ export default function WorldPage() {
       destinoId: dialog.targetId,
       destinoName,
       dia: 1,
-      schedule: travelDaySchedule(plan, currentModel.manifest.viaje.viveresCadaDias),
+      // Computed at dialog-open time with the same diaMundo the plan used —
+      // dialog preview and stepper ticks always agree.
+      schedule: dialog.schedule,
       sectorEndDay: sectorLegEndDay(plan, currentModel),
     });
     toast.success(`Rumbo a ${destinoName} — ${diasLabel(plan.totalDias)}`);
@@ -916,8 +1061,8 @@ export default function WorldPage() {
     if (!store.actions.log(makeEntry.dia(store.diaMundo, store.diaMundo + 1))) return;
     const consumo = run.schedule[run.dia - 1];
     if (consumo) {
-      logGaugeConsumption('combustible', consumo.combustible);
-      logGaugeConsumption('viveres', consumo.viveres);
+      logGaugeConsumption('combustible', consumo.combustible, 'consumo de combustible');
+      logGaugeConsumption('viveres', consumo.viveres, 'consumo de víveres');
     }
     if (run.dia >= run.plan.totalDias) {
       arriveAt(run.destinoId);
@@ -941,8 +1086,8 @@ export default function WorldPage() {
       }),
       { combustible: 0, viveres: 0 }
     );
-    logGaugeConsumption('combustible', totals.combustible);
-    logGaugeConsumption('viveres', totals.viveres);
+    logGaugeConsumption('combustible', totals.combustible, 'consumo de combustible');
+    logGaugeConsumption('viveres', totals.viveres, 'consumo de víveres');
     arriveAt(run.destinoId);
   }, [travel, arriveAt, logGaugeConsumption]);
 
@@ -967,34 +1112,7 @@ export default function WorldPage() {
     }
   }, [session.active]);
 
-  // ── M4: event drawer ──────────────────────────────────────────────────────
-
-  /** Weighted draw over the tables applicable at `anchorId` for `contexto`. */
-  const drawFromTables = useCallback(
-    (
-      contexto: 'viaje' | 'estancia',
-      anchorId: string | null
-    ): { table: EventTable; event: WorldEvent } | null => {
-      const currentModel = useWorldStore.getState().model;
-      if (!currentModel) return null;
-      const party = usePartyStore.getState();
-      const ctx = buildCondContext(currentModel, party, anchorId);
-      const tables = applicableTables(currentModel.tablas, contexto, ctx.regionActual);
-      return drawEvent(tables, ctx, Math.random);
-    },
-    []
-  );
-
-  const openEventDrawer = useCallback(
-    (contexto: 'viaje' | 'estancia', anchorId: string | null) => {
-      eventSourceRef.current = { contexto, anchorId };
-      setEventDraw(drawFromTables(contexto, anchorId));
-      setEventApplied([]);
-      setEventDrawCount(1);
-      setEventOpen(true);
-    },
-    [drawFromTables]
-  );
+  // ── M4: event drawer (draw lifecycle) ─────────────────────────────────────
 
   /** Otra tirada: one redraw per opening, journals nothing by itself. */
   const handleEventRedraw = useCallback(() => {
@@ -1197,7 +1315,12 @@ export default function WorldPage() {
       else if (e.tipo === 'gasto') net -= Number(e.payload) || 0;
       else if (e.tipo === 'ganancia') net += Number(e.payload) || 0;
     }
-    return `${session.entries.length} registros · ${viajes} viajes · ${net >= 0 ? '+' : ''}${net} cr · ${pistasCount} pistas`;
+    const total = session.entries.length;
+    return (
+      `${total} ${total === 1 ? 'registro' : 'registros'} · ` +
+      `${viajes} ${viajes === 1 ? 'viaje' : 'viajes'} · ${net >= 0 ? '+' : ''}${net} cr · ` +
+      `${pistasCount} ${pistasCount === 1 ? 'pista' : 'pistas'}`
+    );
   }, [session]);
 
   // ── Derived map data ──────────────────────────────────────────────────────
@@ -1275,8 +1398,36 @@ export default function WorldPage() {
 
   // ── Party readout (live store fields; hydrate seeds them from the file) ──
 
+  /**
+   * B1 fix: without estado/grupo.md the whole cockpit is dead-ended (no
+   * "Iniciar sesión"), so the hint bar offers creating the file with the
+   * defaults (the GM tweaks it later — or the agent does). Write + in-memory
+   * model update + hydrate: no re-scan needed.
+   */
+  const handleCreateEstado = useCallback(async () => {
+    const currentModel = useWorldStore.getState().model;
+    const fsm = useWorldStore.getState().fs;
+    if (!currentModel || currentModel.estadoGrupo || !fsm) return;
+    if (!(await ensureWriteAccess())) {
+      toast.error('Permisos de escritura denegados — no se pudo crear estado/grupo.md');
+      return;
+    }
+    const estado = defaultPartyState(ESTADO_PATH);
+    try {
+      await fsm.writeTextFile(ESTADO_PATH, serializePartyState(estado, new Date().toISOString()));
+      currentModel.estadoGrupo = estado;
+      usePartyStore.getState().actions.hydrate(currentModel);
+      touchModel();
+      toast.success('estado/grupo.md creado — ya puedes iniciar sesión');
+    } catch (error) {
+      console.error('No se pudo crear estado/grupo.md:', error);
+      toast.error('No se pudo escribir estado/grupo.md');
+    }
+  }, [ensureWriteAccess, touchModel]);
+
   /** Live PartyState view for the status bar; null keeps the M2 absent-file hint. */
   const estadoBar = useMemo<PartyState | null>(() => {
+    void modelRev; // handleCreateEstado mutates model.estadoGrupo in place
     if (!model?.estadoGrupo) return null;
     return {
       sesionActiva: session.active,
@@ -1288,7 +1439,7 @@ export default function WorldPage() {
       bodyMd: '',
       filePath: model.estadoGrupo.filePath,
     };
-  }, [model, session.active, diaMundo, ubicacion, rumbo, creditos, medidores]);
+  }, [model, modelRev, session.active, diaMundo, ubicacion, rumbo, creditos, medidores]);
 
   const fecha = useMemo(
     () => (model ? formatFecha(diaMundo, model.manifest) : ''),
@@ -1434,12 +1585,17 @@ export default function WorldPage() {
 
   // ── M4: travel + events derived data ─────────────────────────────────────
 
-  /** Viajar aquí offered for spatial (sistema/lugar) non-current selections, once per trip. */
+  /**
+   * Viajar aquí offered for spatial (sistema/lugar) non-current selections,
+   * once per trip. Anything on the current location's `en:` chain is excluded
+   * too: "travelling" to the sistema you are already inside would only lose
+   * positional precision (ubicacion would coarsen to the container).
+   */
   const canTravelToSelected = useMemo(() => {
-    if (!selectedEntity || !ubicacion || travel !== null) return false;
-    if (selectedEntity.id === ubicacion) return false;
+    if (!model || !selectedEntity || !ubicacion || travel !== null) return false;
+    if (ancestryChain(model, ubicacion).includes(selectedEntity.id)) return false;
     return selectedEntity.tipo === 'sistema' || isPlace(selectedEntity);
-  }, [selectedEntity, ubicacion, travel]);
+  }, [model, selectedEntity, ubicacion, travel]);
 
   /**
    * Event-context place anchor mid-travel: origin until the sector leg
@@ -1468,7 +1624,7 @@ export default function WorldPage() {
     void modelRev; // llegadas bump conocimiento/ubicacion-derived data in place
     if (!model || !ubicacion || !selectedEntity || travel !== null) return null;
     if (!canTravelToSelected) return null;
-    const plan = computeTravelPlan(ubicacion, selectedEntity.id, model, { medidores });
+    const plan = computeTravelPlan(ubicacion, selectedEntity.id, model, { medidores, diaMundo });
     if (!plan || plan.portal) return null;
     const fromRoot = sectorNodeFor(model, ubicacion);
     const toRoot = sectorNodeFor(model, selectedEntity.id);
@@ -1486,7 +1642,7 @@ export default function WorldPage() {
       toXY: { x: toCoords.x * WORLD_SCALE, y: toCoords.y * WORLD_SCALE },
       label,
     };
-  }, [model, ubicacion, selectedEntity, canTravelToSelected, medidores, travel, modelRev]);
+  }, [model, ubicacion, selectedEntity, canTravelToSelected, medidores, diaMundo, travel, modelRev]);
 
   // ── Search & deep link ────────────────────────────────────────────────────
 
@@ -1665,7 +1821,14 @@ export default function WorldPage() {
 
   return (
     <div data-world-status={status} className="flex h-screen flex-col bg-background">
-      <Toaster position="top-center" richColors />
+      {/* Bottom-center, above the QuickLogBar: feedback lands next to the
+          buttons that caused it and never occludes the party status bar. */}
+      <Toaster
+        position="bottom-center"
+        offset={{ bottom: 96 }}
+        mobileOffset={{ bottom: 96 }}
+        richColors
+      />
       {status === 'ready' && model ? (
         <>
           <header className="flex items-center gap-3 border-b px-4 py-2">
@@ -1699,6 +1862,7 @@ export default function WorldPage() {
 
           <PartyStatusBar
             estado={estadoBar}
+            onCreateEstado={handleCreateEstado}
             fecha={fecha}
             locationName={ubicacion}
             locationPath={locationPath}
@@ -1758,10 +1922,23 @@ export default function WorldPage() {
             />
           )}
 
+          {/* Diagnóstico floats over the map instead of stacking a 4th card
+              into the right column (which collapsed it at small heights). */}
+          {diagnosticsOpen && (
+            <div
+              data-diagnostics-overlay
+              className="fixed right-3 top-36 z-40 flex max-h-[65vh] w-96 max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden rounded-xl shadow-lg"
+            >
+              <DiagnosticsPanel problemas={model.problemas} onCopyReport={handleCopyReport} />
+            </div>
+          )}
+
           <main className="flex min-h-0 flex-1 gap-3 p-3">
             <div
               ref={mapWrapRef}
-              className={mapCollapsed ? 'min-w-0 flex-1 self-start' : 'relative min-h-0 min-w-0 flex-1'}
+              className={
+                mapCollapsed ? 'min-w-0 shrink-0 self-start' : 'relative min-h-0 min-w-0 flex-1'
+              }
             >
               <StarMap
                 viewport={viewport}
@@ -1802,13 +1979,15 @@ export default function WorldPage() {
               </StarMap>
             </div>
 
-            <aside className="flex min-h-0 w-96 shrink-0 flex-col gap-2">
-              {diagnosticsOpen && (
-                <div className="min-h-0 flex-1">
-                  <DiagnosticsPanel problemas={model.problemas} onCopyReport={handleCopyReport} />
-                </div>
-              )}
-
+            {/* Collapsing the map is a request for panel room: the aside takes
+                the freed width instead of leaving a dead void. */}
+            <aside
+              className={
+                mapCollapsed
+                  ? 'flex min-h-0 min-w-0 flex-1 flex-col gap-2'
+                  : 'flex min-h-0 w-96 shrink-0 flex-col gap-2'
+              }
+            >
               {/* Right-panel tabs: Entidad / Pistas / Diario (plan Part B cockpit). */}
               <div role="tablist" aria-label="Panel lateral" className="flex shrink-0 gap-1 rounded-lg border bg-muted/40 p-1">
                 {(
@@ -1852,7 +2031,10 @@ export default function WorldPage() {
                       />
                     </div>
                   )}
-                  {selectedEntity && (
+                  {/* When the SiteList's lugar IS the selection (the common
+                      case right after "Entrar") the panel would duplicate the
+                      list's own header card — skip it (UX audit P1-2a). */}
+                  {selectedEntity && selectedEntity.id !== siteListPlace?.id && (
                     <div className="min-h-0 flex-1">
                       <EntityPanel
                         entity={selectedEntity as EntityPanelEntity}
@@ -1860,6 +2042,7 @@ export default function WorldPage() {
                         factionNames={factionNames}
                         leads={panelLeads}
                         interiorLeads={interiorLeads}
+                        isCurrentLocation={selectedEntity.id === ubicacion}
                         onDrillIn={
                           selectedIsContainer ? () => enterEntity(selectedEntity.id) : undefined
                         }
@@ -1867,17 +2050,6 @@ export default function WorldPage() {
                         actions={
                           canTravelToSelected || selectedPlayable ? (
                             <>
-                              {canTravelToSelected && (
-                                <Button
-                                  size="sm"
-                                  data-travel-here
-                                  onClick={handleOpenTravelDialog}
-                                  className="min-h-11"
-                                >
-                                  <Rocket />
-                                  Viajar aquí
-                                </Button>
-                              )}
                               {selectedPlayable && (
                                 <Button
                                   size="sm"
@@ -1888,6 +2060,18 @@ export default function WorldPage() {
                                 >
                                   <Play />
                                   Jugar
+                                </Button>
+                              )}
+                              {/* Primary action last: anchors the row's right edge. */}
+                              {canTravelToSelected && (
+                                <Button
+                                  size="sm"
+                                  data-travel-here
+                                  onClick={handleOpenTravelDialog}
+                                  className="min-h-11"
+                                >
+                                  <Rocket />
+                                  Viajar aquí
                                 </Button>
                               )}
                             </>
@@ -1930,6 +2114,13 @@ export default function WorldPage() {
                     entries={session.entries}
                     canUndo={canUndo}
                     onUndo={handleUndo}
+                    undoDisabledTitle={
+                      session.active && travel !== null
+                        ? 'No disponible mientras hay un viaje en curso — usa «Cancelar» en la banda de viaje y deshaz después'
+                        : session.active
+                          ? 'Nada que deshacer todavía'
+                          : 'Inicia sesión para registrar'
+                    }
                     sessionActive={session.active}
                     startedAt={session.startedAt}
                   />
@@ -1943,11 +2134,15 @@ export default function WorldPage() {
             creditos={creditos}
             medidores={medidores}
             medidorNames={model.manifest.medidores}
+            diaMundo={diaMundo}
             onMover={() => setMoverOpen(true)}
             onCreditos={handleCreditos}
             onMedidor={handleMedidor}
+            onDescanso={handleDescanso}
+            descansoDisabled={travel !== null}
             onPista={() => uiActions.setPanelTab('pistas')}
             onEvento={() => openEventDrawer('estancia', usePartyStore.getState().ubicacion)}
+            eventoDisabled={travel !== null}
             onNota={handleNota}
           />
 
@@ -1966,6 +2161,8 @@ export default function WorldPage() {
               if (!open) setTravelDialog(null);
             }}
             plan={travelDialog?.plan ?? null}
+            schedule={travelDialog?.schedule ?? []}
+            sessionActive={session.active}
             fromName={
               ubicacion ? (model.entidades.get(ubicacion)?.nombre ?? ubicacion) : 'desconocida'
             }

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -348,11 +348,18 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import type {
   Conocimiento,
   EventEffect,
   EventTable,
   FactionPresence,
+  Guia,
   JournalDay,
   JournalEntry,
   Lead,
@@ -366,7 +373,7 @@ import type {
   WorldEvent,
   WorldModel,
 } from '@/types/world';
-import { BookOpen, Eye, FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
+import { BookOpen, Eye, FolderOpen, Globe, Lock, Map as MapIcon, Play, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -572,6 +579,10 @@ export default function WorldPage() {
   // Feature 2: in-app session recap dialog (mundo/resumen.md). Button + dialog
   // render only when model.resumen is non-null.
   const [resumenOpen, setResumenOpen] = useState(false);
+  // Guías header menu (curated GM play-aid sheets, model.guias). The dropdown
+  // and dialog render only when model.guias is non-empty; `guiaAbierta` holds
+  // the guía whose read-only dialog is open (null = closed), one at a time.
+  const [guiaAbierta, setGuiaAbierta] = useState<Guia | null>(null);
   const [viewport, setViewport] = useState<MapViewport | undefined>(undefined);
   // ?e= read once at first render, BEFORE the URL-writing effect can clear it.
   const [initialDeepLink] = useState(() => readEntityFromUrl());
@@ -2562,6 +2573,30 @@ export default function WorldPage() {
                   Resumen
                 </Button>
               )}
+              {/* Guías: curated GM play-aid sheets (model.guias). Only present
+                  when at least one allowlisted guía file exists — a dropdown
+                  that opens each sheet in the same read-only dialog. */}
+              {model.guias.length > 0 && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" size="sm" data-guias-menu className="min-h-11">
+                      <MapIcon />
+                      Guías
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {model.guias.map((guia) => (
+                      <DropdownMenuItem
+                        key={guia.id}
+                        data-guia-item={guia.id}
+                        onSelect={() => setGuiaAbierta(guia)}
+                      >
+                        {guia.titulo}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
               {/* Manual rescan: the app never watches the filesystem (no FS Access
                   watch API), so after the maintenance agent edits mundo/ — or after
                   an app update changes the scanner — the GM refreshes here instead
@@ -3147,6 +3182,30 @@ export default function WorldPage() {
                 </DialogHeader>
                 <div className="min-h-0 overflow-y-auto">
                   <MarkdownViewer content={model.resumen} className="prose-sm" />
+                </div>
+              </DialogContent>
+            </Dialog>
+          )}
+
+          {/* Guías: read-only dialog for the selected GM play-aid sheet, mirror
+              of the Resumen dialog — one open at a time, closing returns to the
+              map. Rendered only while a guía is selected (guiaAbierta non-null). */}
+          {guiaAbierta && (
+            <Dialog
+              open
+              onOpenChange={(open) => {
+                if (!open) setGuiaAbierta(null);
+              }}
+            >
+              <DialogContent data-guia-dialog className="max-h-[80vh] overflow-hidden sm:max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>{guiaAbierta.titulo}</DialogTitle>
+                  <DialogDescription className="sr-only">
+                    Guía del GM: {guiaAbierta.titulo}
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="min-h-0 overflow-y-auto">
+                  <MarkdownViewer content={guiaAbierta.content} className="prose-sm" />
                 </div>
               </DialogContent>
             </Dialog>

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -1535,6 +1535,22 @@ export default function WorldPage() {
   }, []);
 
   // ── Fit-to-content viewport (per model AND per spatial tier) ─────────────
+  // The wrapper can transiently measure 0×0 (or a few px) while the first
+  // ready-render is still laying out — hydration timing, dev overlays, small
+  // embeds. If the fit bailed then, nothing re-ran it (deps only change with
+  // model/tier), leaving the map at the identity transform with every node
+  // off-screen. A ResizeObserver bumps `mapSizeRev` so the effect retries
+  // once the wrapper reaches a usable size; unusable sizes return WITHOUT
+  // marking fittedRef so the retry actually recomputes.
+  const [mapSizeRev, setMapSizeRev] = useState(0);
+  useEffect(() => {
+    const el = mapWrapRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => setMapSizeRev((r) => r + 1));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [status, mapCollapsed]);
+
   useLayoutEffect(() => {
     if (status !== 'ready' || !model) return;
     // While collapsed the wrapper is the slim chip, not the map — defer the
@@ -1555,7 +1571,9 @@ export default function WorldPage() {
     if (!el) return;
     const width = el.clientWidth;
     const height = el.clientHeight;
-    if (width === 0 || height === 0) return;
+    // Below ~50px the layout hasn't settled — bail WITHOUT marking fitted so
+    // the ResizeObserver retry recomputes with real dimensions.
+    if (width < 50 || height < 50) return;
     fittedRef.current = { model, tier: activeTier, focus };
 
     if (activeTier === 'system' && focusSistema) {
@@ -1597,7 +1615,7 @@ export default function WorldPage() {
       y: height / 2 - ((minY + maxY) / 2) * k,
       k,
     });
-  }, [status, model, activeTier, focusSistema, systemChildren, deepSpace, mapCollapsed]);
+  }, [status, model, activeTier, focusSistema, systemChildren, deepSpace, mapCollapsed, mapSizeRev]);
 
   // ── Map breadcrumb (Sector / Sistema / Lugar) with clickable pops ────────
   const breadcrumb = useMemo<BreadcrumbItem[]>(() => {

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -38,6 +38,46 @@
  *   - Crash mirror: partyStore's SessionMirror (sessionStorage) -> recovery
  *     banner; `sesion_activa: true` without a mirror -> stale-lock notice
  *     (plan Part A anti-conflict protocol).
+ *
+ * M4 travel + events wiring (plan Part B "Travel" + "Cockpit"):
+ *   - Selecting a spatial non-current entity offers "Viajar aquí" (EntityPanel
+ *     actions) and — when origin/destination resolve to DIFFERENT sector roots
+ *     with coordinates and the plan is not portal — a RoutePreview line on the
+ *     sector tier (system tier renders no routes layer; preview also hides
+ *     while a trip is running).
+ *   - Confirming the TravelDialog (active session required — otherwise toast
+ *     "Inicia sesión para viajar") journals `rumbo` and arms the TravelStepper.
+ *     CONSUMPTION SCHEDULE: travelDaySchedule() spreads each leg's combustible
+ *     inside that leg (unit i of C on leg-day ceil(i·D/C); the default 1 per
+ *     tramo lands on the sector leg's LAST day) and charges 1 víveres every
+ *     viveresCadaDias-th day of the whole trip — per-day amounts sum exactly
+ *     to the plan totals, so stepping == "Resolver resto". Gauges clamp at 0
+ *     (GM override); the clamped medidor entry is what gets journaled.
+ *   - REGION OF ROUTE for travel event draws: the CondContext anchors on the
+ *     ORIGIN until the sector leg completes (dia <= sectorLegEndDay), then on
+ *     the DESTINATION — ubicacion itself only changes at arrival. Intra-system
+ *     trips have no sector leg, so the anchor stays on the origin (same root).
+ *   - CANCEL SEMANTICS: cancelling mid-travel stops the stepper and journals
+ *     ONLY a nota ("Viaje interrumpido hacia X en dia N"); ubicacion stays at
+ *     the origin, already-stepped days stay elapsed, and the `rumbo` field
+ *     stays set in estado until the next llegada clears it — there is no
+ *     rumbo-clearing entry type by design; the agent reconciles from the nota.
+ *   - UNDO IS DISABLED WHILE A TRIP RUNS (canUndo requires travel === null):
+ *     the TravelRun day counter/schedule are component state the replay-undo
+ *     cannot revert, so a mid-travel undo would desync stepper vs journal
+ *     (consumption already charged for a day the store no longer counts).
+ *     The escape hatch is Cancelar (position kept), then undo normally.
+ *   - PORTAL plans skip rumbo/days entirely: confirm journals the llegada
+ *     immediately (comentario "por portal") and applies the knowledge bump.
+ *   - Event `:::efecto` lines convert to journal entries against CURRENT party
+ *     state (gasto/ganancia direct; medidor deltas clamp 0..5; sabe also bumps
+ *     the in-memory conocimiento — never lowering — and pista mutates
+ *     estadoPista like a manual transition). Unparseable/unknown effects
+ *     degrade to a nota entry so nothing is silently lost. Redraw is allowed
+ *     once per drawer opening and journals nothing by itself.
+ *   - rederiveLeads(): every pista/medidor/creditos/llegada/sabe mutation (and
+ *     undo) re-runs deriveLeadActionability over ALL pistas with a live
+ *     CondContext, then bumps modelRev.
  */
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -64,7 +104,16 @@ import {
   applyLlegadaConocimiento,
   deriveLeadActionability,
 } from '@/lib/world/worldScanner';
+import { buildCondContext } from '@/lib/world/conditions';
+import { applicableTables, drawEvent } from '@/lib/world/eventEngine';
 import {
+  computeTravelPlan,
+  sectorLegEndDay,
+  travelDaySchedule,
+} from '@/lib/world/travel';
+import type { TravelDayConsumption } from '@/lib/world/travel';
+import {
+  CONOCIMIENTOS,
   ENTITY_DIRS,
   ESTADOS_PISTA,
   PARTY_STATE_FILE,
@@ -78,7 +127,7 @@ import {
   sectorNodeFor,
   tierTargetFor,
 } from '@/lib/world/worldNav';
-import { StarMap } from '@/components/world/StarMap';
+import { StarMap, useMapScale } from '@/components/world/StarMap';
 import type { BreadcrumbItem, MapViewport } from '@/components/world/StarMap';
 import { SectorView, WORLD_SCALE } from '@/components/world/SectorView';
 import { SystemView, systemFitRadius } from '@/components/world/SystemView';
@@ -93,20 +142,32 @@ import { MoverDialog } from '@/components/world/MoverDialog';
 import type { MoverDialogLugar } from '@/components/world/MoverDialog';
 import { JournalPanel } from '@/components/world/JournalPanel';
 import { SessionRecoveryBanner } from '@/components/world/SessionRecoveryBanner';
+import { LeadsBoard } from '@/components/world/LeadsBoard';
+import { EventDrawer } from '@/components/world/EventDrawer';
+import type { EventOutcome } from '@/components/world/EventDrawer';
+import { TravelDialog } from '@/components/world/TravelDialog';
+import { TravelStepper } from '@/components/world/TravelStepper';
+import { RoutePreview } from '@/components/world/RoutePreview';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import type {
+  Conocimiento,
+  EventEffect,
+  EventTable,
   FactionPresence,
   JournalDay,
+  JournalEntry,
   Lead,
   PartyState,
   PlaceEntity,
   SystemEntity,
+  TravelPlan,
   WorldEntityBase,
+  WorldEvent,
   WorldModel,
 } from '@/types/world';
-import { FolderOpen, Globe, Lock, RefreshCw, Star, TriangleAlert } from 'lucide-react';
+import { FolderOpen, Globe, Lock, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -177,6 +238,60 @@ function toPanelLead(pista: Lead): EntityPanelLead {
   };
 }
 
+// ── M4 travel + events module helpers ────────────────────────────────────────
+
+/** A running trip (armed by the TravelDialog confirm, driven by the stepper). */
+interface TravelRun {
+  plan: TravelPlan;
+  destinoId: string;
+  destinoName: string;
+  /** 1-based day ABOUT to be traveled ("Día N de total"). */
+  dia: number;
+  /** Per-day consumption (index dia-1); see travelDaySchedule docs. */
+  schedule: TravelDayConsumption[];
+  /** Last 1-based day of the sector leg — event anchor switches after it. */
+  sectorEndDay: number;
+}
+
+interface RoutePreviewData {
+  fromXY: { x: number; y: number };
+  toXY: { x: number; y: number };
+  label: string;
+}
+
+/**
+ * Bridges the page-computed preview data to RoutePreview, which needs the
+ * LIVE zoom k. Must render inside StarMap's children (MapScaleContext).
+ */
+function RouteLayer({ data }: { data: RoutePreviewData | null }) {
+  const k = useMapScale();
+  if (!data) return null;
+  return <RoutePreview fromXY={data.fromXY} toXY={data.toXY} label={data.label} k={k} />;
+}
+
+/** Split an efecto value on its first `|`: machine part + free comment. */
+function splitEffectValue(value: string): { main: string; comentario?: string } {
+  const idx = value.indexOf('|');
+  if (idx === -1) return { main: value.trim() };
+  const comentario = value.slice(idx + 1).trim();
+  return { main: value.slice(0, idx).trim(), comentario: comentario || undefined };
+}
+
+/** Raises an entity's conocimiento to at least `nivel` in memory — never lowers. */
+function bumpConocimientoInMemory(
+  entity: WorldEntityBase | undefined,
+  nivel: Conocimiento
+): void {
+  if (!entity) return;
+  if (CONOCIMIENTOS.indexOf(nivel) > CONOCIMIENTOS.indexOf(entity.conocimiento)) {
+    entity.conocimiento = nivel;
+  }
+}
+
+function diasLabel(dias: number): string {
+  return dias === 1 ? '1 día' : `${dias} días`;
+}
+
 export default function WorldPage() {
   const status = useWorldStore((s) => s.status);
   const model = useWorldStore((s) => s.model);
@@ -217,6 +332,43 @@ export default function WorldPage() {
   // pista transitions); bumping this counter re-renders the derived views.
   const [modelRev, setModelRev] = useState(0);
   const touchModel = useCallback(() => setModelRev((rev) => rev + 1), []);
+
+  // M4 travel + events state.
+  const [travelDialog, setTravelDialog] = useState<{
+    targetId: string;
+    plan: TravelPlan | null;
+  } | null>(null);
+  const [travel, setTravel] = useState<TravelRun | null>(null);
+  const [eventOpen, setEventOpen] = useState(false);
+  const [eventDraw, setEventDraw] = useState<{ table: EventTable; event: WorldEvent } | null>(
+    null
+  );
+  const [eventApplied, setEventApplied] = useState<number[]>([]);
+  const [eventDrawCount, setEventDrawCount] = useState(0);
+  /** Contexto + place anchor of the current drawer opening (redraw reuses them). */
+  const eventSourceRef = useRef<{ contexto: 'viaje' | 'estancia'; anchorId: string | null }>({
+    contexto: 'estancia',
+    anchorId: null,
+  });
+
+  /**
+   * M4: re-derives `accionable` for ALL pistas against a LIVE CondContext
+   * (current partyStore numbers + ubicacion ancestry) and bumps modelRev.
+   * Cheap (pure loops over the scanned pistas) — called after every
+   * pista/medidor/creditos/llegada/sabe mutation and after undo.
+   */
+  const rederiveLeads = useCallback(() => {
+    const currentModel = useWorldStore.getState().model;
+    if (!currentModel) return;
+    const party = usePartyStore.getState();
+    deriveLeadActionability(
+      currentModel,
+      currentModel.pistas,
+      [],
+      buildCondContext(currentModel, party, party.ubicacion)
+    );
+    setModelRev((rev) => rev + 1);
+  }, []);
 
   const mapWrapRef = useRef<HTMLDivElement>(null);
   const fittedRef = useRef<{
@@ -538,22 +690,30 @@ export default function WorldPage() {
 
   // ── M3: quick-log actions (partyStore.log is the single mutation point) ───
 
-  const handleCreditos = useCallback((delta: number) => {
-    if (delta === 0) return;
-    const logged = usePartyStore
-      .getState()
-      .actions.log(delta < 0 ? makeEntry.gasto(-delta) : makeEntry.ganancia(delta));
-    if (!logged) return;
-    toast.success(`${delta > 0 ? '+' : ''}${delta} créditos anotados`);
-  }, []);
+  const handleCreditos = useCallback(
+    (delta: number) => {
+      if (delta === 0) return;
+      const logged = usePartyStore
+        .getState()
+        .actions.log(delta < 0 ? makeEntry.gasto(-delta) : makeEntry.ganancia(delta));
+      if (!logged) return;
+      rederiveLeads(); // requisitos like creditos>=N track the live balance
+      toast.success(`${delta > 0 ? '+' : ''}${delta} créditos anotados`);
+    },
+    [rederiveLeads]
+  );
 
-  const handleMedidor = useCallback((nombre: string, to: number) => {
-    const store = usePartyStore.getState();
-    const from = store.medidores[nombre] ?? 0;
-    if (from === to) return;
-    if (!store.actions.log(makeEntry.medidor(nombre, from, to))) return;
-    toast.success(`${medidorLabel(nombre)} ${from} → ${to}`);
-  }, []);
+  const handleMedidor = useCallback(
+    (nombre: string, to: number) => {
+      const store = usePartyStore.getState();
+      const from = store.medidores[nombre] ?? 0;
+      if (from === to) return;
+      if (!store.actions.log(makeEntry.medidor(nombre, from, to))) return;
+      rederiveLeads();
+      toast.success(`${medidorLabel(nombre)} ${from} → ${to}`);
+    },
+    [rederiveLeads]
+  );
 
   const handleNota = useCallback((text: string) => {
     if (!usePartyStore.getState().actions.log(makeEntry.nota(text))) return;
@@ -570,11 +730,11 @@ export default function WorldPage() {
       // (applyLlegadaConocimiento): destination ≥ visitado, `en:` ancestors
       // ≥ conocido. The files are updated later by the agent from the journal.
       applyLlegadaConocimiento(currentModel, id);
-      touchModel();
+      rederiveLeads(); // llegada moves the ctx anchor AND unlocks donde-based pistas
       navigateToEntity(id);
       toast.success(`Llegada: ${currentModel.entidades.get(id)?.nombre ?? id}`);
     },
-    [navigateToEntity, touchModel]
+    [navigateToEntity, rederiveLeads]
   );
 
   const handlePistaTransition = useCallback(
@@ -584,11 +744,11 @@ export default function WorldPage() {
       const from = pista.estadoPista;
       if (!usePartyStore.getState().actions.log(makeEntry.pista(pista.id, from, to))) return;
       pista.estadoPista = to;
-      deriveLeadActionability(currentModel.entidades, [pista], []);
-      touchModel();
+      // Full re-derive: other pistas may gate on pista:<id>:<estado> conditions.
+      rederiveLeads();
       toast.success(`Pista «${pista.nombre}»: ${from.replace('_', ' ')} → ${to.replace('_', ' ')}`);
     },
-    [touchModel]
+    [rederiveLeads]
   );
 
   const handleUndo = useCallback(() => {
@@ -607,12 +767,315 @@ export default function WorldPage() {
         (ESTADOS_PISTA as readonly string[]).includes(parsed.from)
       ) {
         pista.estadoPista = parsed.from as Lead['estadoPista'];
-        deriveLeadActionability(currentModel.entidades, [pista], []);
-        touchModel();
       }
     }
+    // rederiveLeads reads the store AFTER undoLast, so the replay-reverted
+    // numbers apply to every requisito (not only the undone pista's).
+    rederiveLeads();
     toast.success(`Última entrada deshecha (${removed.tipo})`);
-  }, [touchModel]);
+  }, [rederiveLeads]);
+
+  // ── M4: travel flow ───────────────────────────────────────────────────────
+
+  /** Arrival shared by the stepper paths + portal confirm: llegada entry, knowledge bump, navigate. */
+  const arriveAt = useCallback(
+    (destinoId: string, comentario?: string) => {
+      const currentModel = useWorldStore.getState().model;
+      const store = usePartyStore.getState();
+      if (!currentModel) return;
+      if (!store.actions.log(makeEntry.llegada(destinoId, store.diaMundo, comentario))) return;
+      applyLlegadaConocimiento(currentModel, destinoId);
+      setTravel(null);
+      navigateToEntity(destinoId);
+      rederiveLeads();
+      toast.success(`Llegada: ${currentModel.entidades.get(destinoId)?.nombre ?? destinoId}`);
+    },
+    [navigateToEntity, rederiveLeads]
+  );
+
+  /** One clamped medidor entry (0..5); logging the clamp IS the GM override record. */
+  const logGaugeConsumption = useCallback((nombre: string, amount: number) => {
+    if (amount <= 0) return;
+    const store = usePartyStore.getState();
+    const from = store.medidores[nombre] ?? 0;
+    const to = Math.max(0, Math.min(5, from - amount));
+    store.actions.log(makeEntry.medidor(nombre, from, to));
+  }, []);
+
+  /** "Viajar aquí": snapshot the target + plan at click time and open the dialog. */
+  const handleOpenTravelDialog = useCallback(() => {
+    const currentModel = useWorldStore.getState().model;
+    const party = usePartyStore.getState();
+    const targetId = useUiStore.getState().selectedEntityId;
+    if (!currentModel || !party.ubicacion || !targetId) return;
+    setTravelDialog({
+      targetId,
+      plan: computeTravelPlan(party.ubicacion, targetId, currentModel, {
+        medidores: party.medidores,
+      }),
+    });
+  }, []);
+
+  const handleTravelConfirm = useCallback(() => {
+    const dialog = travelDialog;
+    const currentModel = useWorldStore.getState().model;
+    if (!dialog || !dialog.plan || !currentModel) return;
+    const store = usePartyStore.getState();
+    if (!store.session.active) {
+      toast.error('Inicia sesión para viajar');
+      return;
+    }
+    const destinoName = currentModel.entidades.get(dialog.targetId)?.nombre ?? dialog.targetId;
+    if (dialog.plan.portal) {
+      // Portal: manual arrival, no rumbo/days/consumption (plan Part A).
+      arriveAt(dialog.targetId, 'por portal');
+      return;
+    }
+    const plan = dialog.plan;
+    if (
+      !store.actions.log(
+        makeEntry.rumbo(dialog.targetId, plan.totalDias, store.diaMundo + plan.totalDias)
+      )
+    ) {
+      return;
+    }
+    if (plan.totalDias <= 0) {
+      // Degenerate 0-day plan (coincident roots): arrive immediately.
+      arriveAt(dialog.targetId);
+      return;
+    }
+    setTravel({
+      plan,
+      destinoId: dialog.targetId,
+      destinoName,
+      dia: 1,
+      schedule: travelDaySchedule(plan, currentModel.manifest.viaje.viveresCadaDias),
+      sectorEndDay: sectorLegEndDay(plan, currentModel),
+    });
+    toast.success(`Rumbo a ${destinoName} — ${diasLabel(plan.totalDias)}`);
+  }, [travelDialog, arriveAt]);
+
+  /** Continuar: journal the day + its scheduled consumption; last day = arrival. */
+  const handleTravelNext = useCallback(() => {
+    const run = travel;
+    if (!run) return;
+    const store = usePartyStore.getState();
+    if (!store.actions.log(makeEntry.dia(store.diaMundo, store.diaMundo + 1))) return;
+    const consumo = run.schedule[run.dia - 1];
+    if (consumo) {
+      logGaugeConsumption('combustible', consumo.combustible);
+      logGaugeConsumption('viveres', consumo.viveres);
+    }
+    if (run.dia >= run.plan.totalDias) {
+      arriveAt(run.destinoId);
+    } else {
+      setTravel({ ...run, dia: run.dia + 1 });
+      rederiveLeads(); // dia>=N / medidor requisitos track each travel day
+    }
+  }, [travel, arriveAt, logGaugeConsumption, rederiveLeads]);
+
+  /** Resolver resto: remaining days + consumption in one batch, then arrive. */
+  const handleTravelRest = useCallback(() => {
+    const run = travel;
+    if (!run) return;
+    const store = usePartyStore.getState();
+    const remaining = run.plan.totalDias - run.dia + 1;
+    if (!store.actions.log(makeEntry.dia(store.diaMundo, store.diaMundo + remaining))) return;
+    const totals = run.schedule.slice(run.dia - 1).reduce(
+      (acc, day) => ({
+        combustible: acc.combustible + day.combustible,
+        viveres: acc.viveres + day.viveres,
+      }),
+      { combustible: 0, viveres: 0 }
+    );
+    logGaugeConsumption('combustible', totals.combustible);
+    logGaugeConsumption('viveres', totals.viveres);
+    arriveAt(run.destinoId);
+  }, [travel, arriveAt, logGaugeConsumption]);
+
+  /** Cancel: only a nota — ubicacion stays at origin (see module doc CANCEL SEMANTICS). */
+  const handleTravelCancel = useCallback(() => {
+    const run = travel;
+    if (!run) return;
+    const store = usePartyStore.getState();
+    store.actions.log(
+      makeEntry.nota(`Viaje interrumpido hacia ${run.destinoName} en dia ${store.diaMundo}`)
+    );
+    setTravel(null);
+    rederiveLeads();
+    toast(`Viaje a ${run.destinoName} cancelado — el grupo mantiene su posición`);
+  }, [travel, rederiveLeads]);
+
+  // A trip cannot outlive its session (log() would reject every step anyway).
+  useEffect(() => {
+    if (!session.active) {
+      setTravel(null);
+      setEventOpen(false);
+    }
+  }, [session.active]);
+
+  // ── M4: event drawer ──────────────────────────────────────────────────────
+
+  /** Weighted draw over the tables applicable at `anchorId` for `contexto`. */
+  const drawFromTables = useCallback(
+    (
+      contexto: 'viaje' | 'estancia',
+      anchorId: string | null
+    ): { table: EventTable; event: WorldEvent } | null => {
+      const currentModel = useWorldStore.getState().model;
+      if (!currentModel) return null;
+      const party = usePartyStore.getState();
+      const ctx = buildCondContext(currentModel, party, anchorId);
+      const tables = applicableTables(currentModel.tablas, contexto, ctx.regionActual);
+      return drawEvent(tables, ctx, Math.random);
+    },
+    []
+  );
+
+  const openEventDrawer = useCallback(
+    (contexto: 'viaje' | 'estancia', anchorId: string | null) => {
+      eventSourceRef.current = { contexto, anchorId };
+      setEventDraw(drawFromTables(contexto, anchorId));
+      setEventApplied([]);
+      setEventDrawCount(1);
+      setEventOpen(true);
+    },
+    [drawFromTables]
+  );
+
+  /** Otra tirada: one redraw per opening, journals nothing by itself. */
+  const handleEventRedraw = useCallback(() => {
+    const { contexto, anchorId } = eventSourceRef.current;
+    setEventDraw(drawFromTables(contexto, anchorId));
+    setEventApplied([]);
+    setEventDrawCount((count) => count + 1);
+  }, [drawFromTables]);
+
+  const handleEventOutcome = useCallback(
+    (outcome: EventOutcome, nota?: string) => {
+      const draw = eventDraw;
+      if (!draw) return;
+      const comentario =
+        outcome === 'complicacion'
+          ? nota
+            ? `complicación: ${nota}`
+            : 'complicación'
+          : outcome;
+      if (
+        !usePartyStore
+          .getState()
+          .actions.log(makeEntry.evento(draw.table.id, draw.event.id, comentario))
+      ) {
+        return;
+      }
+      toast.success(`Evento «${draw.event.titulo}»: ${comentario}`);
+    },
+    [eventDraw]
+  );
+
+  /**
+   * One `:::efecto` line -> one journal entry via makeEntry against CURRENT
+   * party state. Grammar per plan Part A (module doc "Event :::efecto lines");
+   * unparseable/unknown effects degrade to a nota entry.
+   */
+  const handleApplyEffect = useCallback(
+    (effect: EventEffect) => {
+      const currentModel = useWorldStore.getState().model;
+      const store = usePartyStore.getState();
+      const draw = eventDraw;
+      if (!currentModel || !draw) return;
+
+      const { main, comentario } = splitEffectValue(effect.value);
+      let entry: JournalEntry | null = null;
+      let mensaje = '';
+      /** In-memory model mutation to run only after log() accepts the entry. */
+      let after: (() => void) | undefined;
+
+      const fallbackNota = () => {
+        entry = makeEntry.nota(`${effect.key}: ${effect.value}`);
+        mensaje = 'Efecto no interpretable — anotado como nota';
+      };
+
+      switch (effect.key) {
+        case 'gasto':
+        case 'ganancia': {
+          if (!/^[+-]?\d+$/.test(main)) {
+            fallbackNota();
+            break;
+          }
+          const cantidad = Number(main);
+          entry =
+            effect.key === 'gasto'
+              ? makeEntry.gasto(cantidad, comentario)
+              : makeEntry.ganancia(cantidad, comentario);
+          mensaje = `${effect.key === 'gasto' ? '-' : '+'}${cantidad} créditos anotados`;
+          break;
+        }
+        case 'medidor': {
+          const match = /^(\S+)\s+([+-]?\d+)$/.exec(main);
+          if (!match) {
+            fallbackNota();
+            break;
+          }
+          const nombre = match[1];
+          const from = store.medidores[nombre] ?? 0;
+          const to = Math.max(0, Math.min(5, from + Number(match[2])));
+          entry = makeEntry.medidor(nombre, from, to, comentario);
+          mensaje = `${medidorLabel(nombre)} ${from} → ${to}`;
+          break;
+        }
+        case 'sabe': {
+          const match = /^(\S+)\s+(\S+)$/.exec(main);
+          if (!match || !(CONOCIMIENTOS as readonly string[]).includes(match[2])) {
+            fallbackNota();
+            break;
+          }
+          const id = match[1];
+          const nivel = match[2] as Conocimiento;
+          const from = currentModel.entidades.get(id)?.conocimiento ?? 'desconocido';
+          entry = makeEntry.sabe(id, from, nivel, comentario);
+          mensaje = `Sabe: ${currentModel.entidades.get(id)?.nombre ?? id} → ${nivel}`;
+          after = () => bumpConocimientoInMemory(currentModel.entidades.get(id), nivel);
+          break;
+        }
+        case 'pista': {
+          const match = /^(\S+)\s+(\S+)$/.exec(main);
+          const pista = match
+            ? currentModel.pistas.find((candidate) => candidate.id === match[1])
+            : undefined;
+          if (!match || !pista || !(ESTADOS_PISTA as readonly string[]).includes(match[2])) {
+            fallbackNota();
+            break;
+          }
+          const to = match[2] as Lead['estadoPista'];
+          entry = makeEntry.pista(pista.id, pista.estadoPista, to, comentario);
+          mensaje = `Pista «${pista.nombre}» → ${to.replace('_', ' ')}`;
+          after = () => {
+            pista.estadoPista = to;
+          };
+          break;
+        }
+        case 'nota':
+          entry = makeEntry.nota(effect.value);
+          mensaje = 'Nota registrada';
+          break;
+        default:
+          fallbackNota();
+      }
+
+      if (!entry || !store.actions.log(entry)) return;
+      after?.();
+      // Covers every effect type: creditos/medidor numbers, pista estados and
+      // sabe knowledge (donde-conocido gating) all feed accionable.
+      rederiveLeads();
+      const index = draw.event.efectos.indexOf(effect);
+      if (index >= 0) {
+        setEventApplied((prev) => (prev.includes(index) ? prev : [...prev, index]));
+      }
+      toast.success(mensaje);
+    },
+    [eventDraw, rederiveLeads]
+  );
 
   const endSummaryPreview = useMemo(() => {
     if (!session.active) return undefined;
@@ -854,6 +1317,62 @@ export default function WorldPage() {
       .map(toPanelLead);
   }, [model, selectedEntity, selectedIsContainer, modelRev]);
 
+  // ── M4: travel + events derived data ─────────────────────────────────────
+
+  /** Viajar aquí offered for spatial (sistema/lugar) non-current selections, once per trip. */
+  const canTravelToSelected = useMemo(() => {
+    if (!selectedEntity || !ubicacion || travel !== null) return false;
+    if (selectedEntity.id === ubicacion) return false;
+    return selectedEntity.tipo === 'sistema' || isPlace(selectedEntity);
+  }, [selectedEntity, ubicacion, travel]);
+
+  /**
+   * Event-context place anchor mid-travel: origin until the sector leg
+   * completes, then the destination (module doc REGION OF ROUTE).
+   */
+  const travelAnchorId = useMemo(() => {
+    if (!travel) return ubicacion;
+    return travel.dia <= travel.sectorEndDay ? ubicacion : travel.destinoId;
+  }, [travel, ubicacion]);
+
+  /** Stepper "Tirar evento" disabled when no viaje table applies at the anchor. */
+  const travelEventDisabled = useMemo(() => {
+    void modelRev;
+    if (!model || !travel) return true;
+    const ctx = buildCondContext(model, { creditos, medidores, diaMundo }, travelAnchorId);
+    return applicableTables(model.tablas, 'viaje', ctx.regionActual).length === 0;
+  }, [model, travel, travelAnchorId, creditos, medidores, diaMundo, modelRev]);
+
+  /**
+   * RoutePreview endpoints (map pixels) + label for the CURRENT selection.
+   * Sector tier only (SystemView has no routes layer), and only when both
+   * endpoints resolve to different sector roots with coordinates and the plan
+   * is a real route (not null/portal). Hidden while a trip runs.
+   */
+  const routePreview = useMemo<RoutePreviewData | null>(() => {
+    void modelRev; // llegadas bump conocimiento/ubicacion-derived data in place
+    if (!model || !ubicacion || !selectedEntity || travel !== null) return null;
+    if (!canTravelToSelected) return null;
+    const plan = computeTravelPlan(ubicacion, selectedEntity.id, model, { medidores });
+    if (!plan || plan.portal) return null;
+    const fromRoot = sectorNodeFor(model, ubicacion);
+    const toRoot = sectorNodeFor(model, selectedEntity.id);
+    if (!fromRoot || !toRoot || fromRoot === toRoot) return null;
+    const fromCoords = (model.entidades.get(fromRoot) as Partial<PlaceEntity> | undefined)
+      ?.coordenadas;
+    const toCoords = (model.entidades.get(toRoot) as Partial<PlaceEntity> | undefined)
+      ?.coordenadas;
+    if (!fromCoords || !toCoords) return null;
+    const label =
+      diasLabel(plan.totalDias) +
+      (plan.totalCombustible > 0 ? ` · −${plan.totalCombustible} combustible` : '');
+    return {
+      fromXY: { x: fromCoords.x * WORLD_SCALE, y: fromCoords.y * WORLD_SCALE },
+      toXY: { x: toCoords.x * WORLD_SCALE, y: toCoords.y * WORLD_SCALE },
+      label,
+    };
+  }, [model, ubicacion, selectedEntity, canTravelToSelected, medidores, travel, modelRev]);
+
   // ── Search & deep link ────────────────────────────────────────────────────
 
   // Model is immutable-after-scan, so the index never staleses within a scan.
@@ -971,7 +1490,12 @@ export default function WorldPage() {
 
   const erroresCount = model?.problemas.filter((p) => p.nivel === 'error').length ?? 0;
 
-  const canUndo = session.active && session.entries.length > 1;
+  // Undo is BLOCKED mid-travel: the stepper's day counter and consumption
+  // schedule live outside the journal (TravelRun state), so undoing a stepper
+  // entry (dia/medidor) would revert the store but not the run — the journal
+  // trail would stop summing to the plan totals. Cancel the trip first (nota,
+  // position kept), then undo freely.
+  const canUndo = session.active && session.entries.length > 1 && travel === null;
 
   return (
     <div data-world-status={status} className="flex h-screen flex-col bg-background">
@@ -1053,6 +1577,19 @@ export default function WorldPage() {
             </div>
           )}
 
+          {travel && (
+            <TravelStepper
+              dia={travel.dia}
+              totalDias={travel.plan.totalDias}
+              destinoName={travel.destinoName}
+              onDrawEvent={() => openEventDrawer('viaje', travelAnchorId)}
+              onNextDay={handleTravelNext}
+              onResolveRest={handleTravelRest}
+              onCancel={handleTravelCancel}
+              eventDisabled={travelEventDisabled}
+            />
+          )}
+
           <main className="flex min-h-0 flex-1 gap-3 p-3">
             <div
               ref={mapWrapRef}
@@ -1091,6 +1628,7 @@ export default function WorldPage() {
                     showUnknown={showUnknown}
                     onSelect={selectEntity}
                     onDrillIn={enterEntity}
+                    routes={<RouteLayer data={routePreview} />}
                   />
                 )}
               </StarMap>
@@ -1156,6 +1694,18 @@ export default function WorldPage() {
                           selectedIsContainer ? () => enterEntity(selectedEntity.id) : undefined
                         }
                         onClose={() => uiActions.selectEntity(null)}
+                        actions={
+                          canTravelToSelected ? (
+                            <Button
+                              size="sm"
+                              data-travel-here
+                              onClick={handleOpenTravelDialog}
+                            >
+                              <Rocket />
+                              Viajar aquí
+                            </Button>
+                          ) : undefined
+                        }
                       />
                     </div>
                   )}
@@ -1171,12 +1721,18 @@ export default function WorldPage() {
 
               {panelTab === 'pistas' && (
                 <div className="min-h-0 flex-1">
-                  <LeadsListCard
+                  <LeadsBoard
                     pistas={model.pistas}
-                    modelRev={modelRev}
+                    tramas={model.tramas}
+                    diaMundo={diaMundo}
                     sessionActive={session.active}
-                    onTransition={handlePistaTransition}
-                    onNavigate={navigateToEntity}
+                    modelRev={modelRev}
+                    onTransition={(id, _from, to) => {
+                      const pista = model.pistas.find((candidate) => candidate.id === id);
+                      if (pista) handlePistaTransition(pista, to);
+                    }}
+                    onSelectPlace={navigateToEntity}
+                    placeNombre={(id) => model.entidades.get(id)?.nombre}
                   />
                 </div>
               )}
@@ -1204,6 +1760,7 @@ export default function WorldPage() {
             onCreditos={handleCreditos}
             onMedidor={handleMedidor}
             onPista={() => uiActions.setPanelTab('pistas')}
+            onEvento={() => openEventDrawer('estancia', usePartyStore.getState().ubicacion)}
             onNota={handleNota}
           />
 
@@ -1214,6 +1771,40 @@ export default function WorldPage() {
             recentIds={recentMoveIds}
             currentId={ubicacion}
             onMove={handleMove}
+          />
+
+          <TravelDialog
+            open={travelDialog !== null}
+            onOpenChange={(open) => {
+              if (!open) setTravelDialog(null);
+            }}
+            plan={travelDialog?.plan ?? null}
+            fromName={
+              ubicacion ? (model.entidades.get(ubicacion)?.nombre ?? ubicacion) : 'desconocida'
+            }
+            toName={
+              travelDialog
+                ? (model.entidades.get(travelDialog.targetId)?.nombre ?? travelDialog.targetId)
+                : ''
+            }
+            medidores={medidores}
+            onConfirm={handleTravelConfirm}
+            nameFor={(id) => model.entidades.get(id)?.nombre ?? id}
+          />
+
+          <EventDrawer
+            open={eventOpen}
+            onOpenChange={setEventOpen}
+            draw={
+              eventDraw
+                ? { tableNombre: eventDraw.table.nombre, event: eventDraw.event }
+                : null
+            }
+            onRedraw={handleEventRedraw}
+            onOutcome={handleEventOutcome}
+            onApplyEffect={handleApplyEffect}
+            appliedEffects={eventApplied}
+            canRedraw={eventDraw !== null && eventDrawCount < 2}
           />
         </>
       ) : (
@@ -1279,136 +1870,5 @@ export default function WorldPage() {
         </div>
       )}
     </div>
-  );
-}
-
-// ── Pistas tab (M3 placeholder — the full LeadsBoard arrives in M4) ─────────
-
-/** Allowed one-tap estado transitions per current estado (plan Part A workflow). */
-const PISTA_TRANSITIONS: Record<Lead['estadoPista'], Lead['estadoPista'][]> = {
-  rumor: ['activa'],
-  activa: ['en_curso', 'fallida'],
-  en_curso: ['resuelta', 'fallida'],
-  resuelta: [],
-  fallida: [],
-};
-
-const PISTA_ESTADO_LABEL: Record<Lead['estadoPista'], string> = {
-  rumor: 'Rumor',
-  activa: 'Activa',
-  en_curso: 'En curso',
-  resuelta: 'Resuelta',
-  fallida: 'Fallida',
-};
-
-const PISTA_ESTADO_ORDER: Record<Lead['estadoPista'], number> = {
-  activa: 0,
-  en_curso: 1,
-  rumor: 2,
-  resuelta: 3,
-  fallida: 4,
-};
-
-interface LeadsListCardProps {
-  pistas: Lead[];
-  /** Re-render key: pista estado/accionable are mutated in place on the model. */
-  modelRev: number;
-  sessionActive: boolean;
-  onTransition: (pista: Lead, to: Lead['estadoPista']) => void;
-  onNavigate: (id: string) => void;
-}
-
-function LeadsListCard({ pistas, modelRev, sessionActive, onTransition, onNavigate }: LeadsListCardProps) {
-  const sorted = useMemo(() => {
-    void modelRev;
-    return [...pistas].sort((a, b) => {
-      const accA = a.accionable === true ? 0 : 1;
-      const accB = b.accionable === true ? 0 : 1;
-      if (accA !== accB) return accA - accB;
-      const orderDelta = PISTA_ESTADO_ORDER[a.estadoPista] - PISTA_ESTADO_ORDER[b.estadoPista];
-      if (orderDelta !== 0) return orderDelta;
-      return a.nombre.localeCompare(b.nombre, 'es');
-    });
-  }, [pistas, modelRev]);
-
-  return (
-    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-leads-panel>
-      <div className="border-b px-3 py-2">
-        <p className="text-sm font-medium">Pistas</p>
-        <p className="text-xs text-muted-foreground">Tablero completo en M4</p>
-      </div>
-      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
-        {sorted.length === 0 ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">Sin pistas.</p>
-        ) : (
-          sorted.map((pista) => (
-            <div
-              key={pista.id}
-              data-lead-id={pista.id}
-              data-lead-estado={pista.estadoPista}
-              className="rounded-md border px-3 py-2"
-            >
-              <div className="flex items-start gap-2">
-                {pista.accionable === true && (
-                  <Star
-                    className="mt-0.5 size-4 shrink-0 fill-amber-400 text-amber-400"
-                    aria-label="Accionable"
-                  />
-                )}
-                <div className="min-w-0 flex-1">
-                  <p className="break-words text-sm font-medium">{pista.nombre}</p>
-                  {pista.donde && (
-                    <button
-                      type="button"
-                      onClick={() => onNavigate(pista.donde!)}
-                      className="text-xs text-muted-foreground hover:underline"
-                    >
-                      @ {pista.donde}
-                    </button>
-                  )}
-                </div>
-                <div className="flex shrink-0 flex-col items-end gap-1">
-                  <Badge
-                    variant={
-                      pista.estadoPista === 'resuelta' || pista.estadoPista === 'fallida'
-                        ? 'outline'
-                        : 'secondary'
-                    }
-                  >
-                    {PISTA_ESTADO_LABEL[pista.estadoPista]}
-                  </Badge>
-                  {pista.accionable === 'manual' && (
-                    <Badge variant="outline" className="text-muted-foreground">
-                      según GM
-                    </Badge>
-                  )}
-                </div>
-              </div>
-              {PISTA_TRANSITIONS[pista.estadoPista].length > 0 && (
-                <div className="mt-1.5 flex flex-wrap justify-end gap-1">
-                  {PISTA_TRANSITIONS[pista.estadoPista].map((to) => (
-                    <Button
-                      key={to}
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      data-lead-transition={to}
-                      disabled={!sessionActive}
-                      title={sessionActive ? undefined : 'Inicia sesión para registrar'}
-                      onClick={() => onTransition(pista, to)}
-                      className={`h-6 px-2 text-xs ${
-                        to === 'fallida' ? 'border-destructive/40 text-destructive' : ''
-                      }`}
-                    >
-                      {PISTA_ESTADO_LABEL[to]}
-                    </Button>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))
-        )}
-      </div>
-    </Card>
   );
 }

--- a/app/world/page.tsx
+++ b/app/world/page.tsx
@@ -207,6 +207,32 @@
  *     openSignal is world-only — /play passes nothing and keeps the tracker's
  *     self-managed hover-to-expand behavior unchanged.
  *
+ * SHOP SYSTEM (feature — mundo/lugares/<place>/tiendas/<shop>.md):
+ *   - The scanner keys shops by place id in model.tiendas. A place panel lists
+ *     them in a "Tiendas" section (EntityPanel tiendas prop); clicking a row
+ *     sets the page-level `selectedShopId` and the entidad tab swaps the whole
+ *     panel for the ShopPanel — the SAME swap idea as selectedPnj -> PnjCard,
+ *     but shops are NOT entities so they get their own state piece (not
+ *     selectedEntityId). Changing the selected entity clears selectedShopId
+ *     (an effect), so a shop never lingers over the wrong place; a re-scan that
+ *     drops the id closes the panel too (openShop resolves live from
+ *     model.tiendas). Back clears selectedShopId -> the place panel returns.
+ *   - onBuy is session-gated: it journals gasto(precio, `compra: <articulo>`),
+ *     decrements finite stock IN MEMORY (touchModel re-renders; unlimited stock
+ *     = null never decrements — the market never runs out) and toasts
+ *     `−<precio> cr · <articulo>` with an undo action. No session -> the log is
+ *     rejected and a "Inicia sesión para comprar" toast fires (the button is
+ *     already disabled with the same hint when enabled=false). Stock lives in
+ *     the scanned model only — a reload re-reads the file's stock (the agent
+ *     reconciles purchases from the journal gasto entries), same
+ *     scan-is-source-of-truth rule as pista transitions.
+ *
+ * IN-APP RESUMEN (mundo/resumen.md — optional session recap):
+ *   - The scanner reads it like the manifest (one read, model.resumen: string |
+ *     null; never an entity). When non-null the header shows a "Resumen" button
+ *     that opens a read-only dialog ("Anteriormente…") rendering the recap via
+ *     the existing MarkdownViewer. Absent file -> no button.
+ *
  * SCAN-OVERLAY ASYMMETRY (M4 decision — documented, not a bug):
  *   worldScanner.overlayUnprocessedJournals re-derives ONLY knowledge (sabe)
  *   and location knowledge (llegada) from journals with procesado: false.
@@ -279,8 +305,10 @@ import type {
   EntityPanelEntity,
   EntityPanelLead,
   EntityPanelPersonaje,
+  EntityPanelTienda,
 } from '@/components/world/EntityPanel';
 import { PnjCard } from '@/components/world/PnjCard';
+import { ShopPanel } from '@/components/world/ShopPanel';
 import { FullscreenImage } from '@/components/world/FullscreenImage';
 import { DiagnosticsPanel } from '@/components/world/DiagnosticsPanel';
 import { WorldSearchDialog } from '@/components/world/WorldSearchDialog';
@@ -303,6 +331,14 @@ import { WorldAudioDock } from '@/components/world/WorldAudioDock';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
 import type {
   Conocimiento,
   EventEffect,
@@ -313,13 +349,15 @@ import type {
   Lead,
   PartyState,
   PlaceEntity,
+  Shop,
+  ShopItem,
   SystemEntity,
   TravelPlan,
   WorldEntityBase,
   WorldEvent,
   WorldModel,
 } from '@/types/world';
-import { Eye, FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, Swords, TriangleAlert } from 'lucide-react';
+import { BookOpen, Eye, FolderOpen, Globe, Lock, Play, RefreshCw, Rocket, TriangleAlert } from 'lucide-react';
 
 interface TtrpgWorldTestHook {
   openFromOPFS: () => Promise<void>;
@@ -520,6 +558,9 @@ export default function WorldPage() {
   const [entry, setEntry] = useState<EntryMode>('checking');
   const [pendingHandle, setPendingHandle] = useState<FileSystemDirectoryHandle | null>(null);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  // Feature 2: in-app session recap dialog (mundo/resumen.md). Button + dialog
+  // render only when model.resumen is non-null.
+  const [resumenOpen, setResumenOpen] = useState(false);
   const [viewport, setViewport] = useState<MapViewport | undefined>(undefined);
   // ?e= read once at first render, BEFORE the URL-writing effect can clear it.
   const [initialDeepLink] = useState(() => readEntityFromUrl());
@@ -560,6 +601,16 @@ export default function WorldPage() {
   // force the full panel open (not just the pull-tab).
   const [combatOpen, setCombatOpen] = useState(false);
   const [combatOpenSignal, setCombatOpenSignal] = useState(0);
+  // Feature 3: the world audio dock open state is page-owned now (the dock is
+  // controlled) so the QuickLogBar «Música» button drives it. Survives the
+  // ActRunner conceal round-trip because it lives here, not in the dock.
+  const [musicaOpen, setMusicaOpen] = useState(false);
+  // Shop system: the shop whose ShopPanel is open in the right column (null =
+  // closed). It is a page-level piece (shops are NOT entities, so they cannot
+  // ride selectedEntityId like pnjs do); the render below swaps the entity
+  // panel for the ShopPanel while it is set. Scoped to the selected place —
+  // changing the selected entity clears it (effect below).
+  const [selectedShopId, setSelectedShopId] = useState<string | null>(null);
   // M6: resolved object URL currently zoomed in the player-safe fullscreen
   // viewer (null = closed). The URL belongs to the page-owned image cache.
   const [zoomedImageUrl, setZoomedImageUrl] = useState<string | null>(null);
@@ -1977,6 +2028,64 @@ export default function WorldPage() {
       }));
   }, [model, selectedEntity, modelRev]);
 
+  /**
+   * Shop system: shops located AT the selected entity (Tiendas section rows),
+   * with the shopkeeper pnj name pre-resolved. Keyed by place id in
+   * model.tiendas; empty when the place has no tiendas/ folder.
+   */
+  const placeShops = useMemo<Shop[]>(() => {
+    if (!model || !selectedEntity) return [];
+    return model.tiendas.get(selectedEntity.id) ?? [];
+  }, [model, selectedEntity]);
+
+  const panelTiendas = useMemo<EntityPanelTienda[]>(() => {
+    if (!model) return [];
+    return placeShops.map((shop) => ({
+      id: shop.id,
+      nombre: shop.nombre,
+      pnj: shop.pnj ? (model.entidades.get(shop.pnj)?.nombre ?? shop.pnj) : undefined,
+    }));
+  }, [model, placeShops]);
+
+  /**
+   * The shop whose ShopPanel is open, resolved LIVE from the selected place's
+   * shops (so a re-scan or a selection change that drops the id closes the
+   * panel). modelRev is a dep because onBuy mutates item.stock in place.
+   */
+  const openShop = useMemo<Shop | null>(() => {
+    void modelRev;
+    if (!selectedShopId) return null;
+    return placeShops.find((shop) => shop.id === selectedShopId) ?? null;
+  }, [placeShops, selectedShopId, modelRev]);
+
+  /** Selecting a different entity closes any open shop (it belonged to the old place). */
+  useEffect(() => {
+    setSelectedShopId(null);
+  }, [selectedEntityId]);
+
+  /**
+   * Shop buy: session-gated. Journals a gasto (`compra: <articulo>`),
+   * decrements finite stock in memory (touchModel re-renders the derived
+   * views) and toasts. Unlimited stock (null) never decrements. Without a
+   * session the log is rejected and the GM sees the hint.
+   */
+  const handleBuy = useCallback(
+    (item: ShopItem) => {
+      const store = usePartyStore.getState();
+      if (!store.session.active) {
+        toast.error('Inicia sesión para comprar');
+        return;
+      }
+      if (item.stock === 0) return;
+      if (!store.actions.log(makeEntry.gasto(item.precio, `compra: ${item.articulo}`))) return;
+      if (item.stock !== null) item.stock -= 1;
+      touchModel();
+      rederiveLeads(); // creditos>=N requisitos track the live balance
+      toast.success(`−${item.precio} cr · ${item.articulo}`, { action: undoToastAction });
+    },
+    [touchModel, rederiveLeads, undoToastAction]
+  );
+
   /** PnjCard back: to the pnj's ubicacion place (or clear a dangling one). */
   const handlePnjBack = useCallback(() => {
     const currentModel = useWorldStore.getState().model;
@@ -2289,6 +2398,20 @@ export default function WorldPage() {
             <h1 className="text-lg font-semibold">{model.manifest.nombre || 'Mundo'}</h1>
             <div className="ml-auto flex items-center gap-2">
               <WorldSearchDialog index={searchIndex} onResultSelect={navigateToEntity} />
+              {/* Feature 2: session recap. Only present when mundo/resumen.md
+                  exists (model.resumen non-null) — opens the read-only dialog. */}
+              {model.resumen !== null && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  data-resumen-open
+                  onClick={() => setResumenOpen(true)}
+                  className="min-h-11"
+                >
+                  <BookOpen />
+                  Resumen
+                </Button>
+              )}
               {/* Manual rescan: the app never watches the filesystem (no FS Access
                   watch API), so after the maintenance agent edits mundo/ — or after
                   an app update changes the scanner — the GM refreshes here instead
@@ -2520,7 +2643,27 @@ export default function WorldPage() {
                 </button>
               </div>
 
-              {panelTab === 'entidad' && (
+              {panelTab === 'entidad' && openShop && (
+                <div className="min-h-0 flex-1">
+                  {/* Shop system: the ShopPanel takes the whole entidad slot
+                      while a shop is open (swap pattern reused from selectedPnj
+                      -> PnjCard). Back clears selectedShopId -> the place panel
+                      returns. See page state `selectedShopId`. */}
+                  <ShopPanel
+                    shop={openShop}
+                    pnjNombre={
+                      openShop.pnj
+                        ? (model.entidades.get(openShop.pnj)?.nombre ?? openShop.pnj)
+                        : undefined
+                    }
+                    onBack={() => setSelectedShopId(null)}
+                    onBuy={handleBuy}
+                    enabled={session.active}
+                  />
+                </div>
+              )}
+
+              {panelTab === 'entidad' && !openShop && (
                 <>
                   {siteListPlace && (
                     <div className="min-h-0 flex-1">
@@ -2568,6 +2711,8 @@ export default function WorldPage() {
                         isCurrentLocation={selectedEntity.id === ubicacion}
                         personajes={panelPersonajes}
                         onSelectPnj={selectEntity}
+                        tiendas={panelTiendas}
+                        onSelectShop={setSelectedShopId}
                         loadImageUrl={loadEntityImageUrl}
                         onImageZoom={handleImageZoom}
                         onDrillIn={
@@ -2696,6 +2841,13 @@ export default function WorldPage() {
             onEvento={() => openEventDrawer('estancia', usePartyStore.getState().ubicacion)}
             eventoDisabled={travel !== null}
             onNota={handleNota}
+            onMusica={() => setMusicaOpen((current) => !current)}
+            musicaOpen={musicaOpen}
+            onCombat={() => {
+              setCombatOpen(true);
+              setCombatOpenSignal((n) => n + 1);
+            }}
+            combatOpen={combatOpen}
           />
 
           <MoverDialog
@@ -2753,6 +2905,7 @@ export default function WorldPage() {
             audioManager={worldAudio}
             bgm={model.musica.bgm}
             eventPlaylists={model.musica.eventPlaylists}
+            open={musicaOpen}
             concealed={actRunnerOpen}
           />
 
@@ -2784,34 +2937,33 @@ export default function WorldPage() {
             />
           )}
 
-          {/* "Combate" affordance: mounts the tracker AND force-opens it via
-              openSignal (the full panel, not just the pull-tab). Hidden while
-              the ActRunner overlay owns the screen (it has its own tracker). */}
-          {actRunnerPlace === null && (
-            <Button
-              type="button"
-              size="sm"
-              variant={combatOpen ? 'secondary' : 'outline'}
-              data-combat-open
-              aria-pressed={combatOpen}
-              onClick={() => {
-                setCombatOpen(true);
-                setCombatOpenSignal((n) => n + 1);
-              }}
-              title="Abrir el rastreador de iniciativa (combate)"
-              // Bottom-RIGHT, clear of the bottom-left WorldAudioDock and the
-              // bottom-center toaster; above the QuickLogBar band.
-              className="fixed bottom-20 right-3 z-30 min-h-11 shadow-lg"
-            >
-              <Swords aria-hidden />
-              Combate
-            </Button>
-          )}
+          {/* Feature 3: the standalone floating "Combate" button moved into the
+              QuickLogBar (data-combat-open lives on that button now). The
+              QuickLogBar onCombat handler force-opens the tracker via
+              combatOpenSignal exactly as the old button did. */}
 
           {/* M6: player-safe fullscreen for entity images (z above everything;
               the URL lives in the page cache — never revoked here). */}
           {zoomedImageUrl && (
             <FullscreenImage imageUrl={zoomedImageUrl} onClose={() => setZoomedImageUrl(null)} />
+          )}
+
+          {/* Feature 2: read-only session-recap dialog ("Anteriormente…"),
+              rendering mundo/resumen.md through the existing MarkdownViewer. */}
+          {model.resumen !== null && (
+            <Dialog open={resumenOpen} onOpenChange={setResumenOpen}>
+              <DialogContent data-resumen-dialog className="max-h-[80vh] overflow-hidden sm:max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>Anteriormente…</DialogTitle>
+                  <DialogDescription className="sr-only">
+                    Resumen de la sesión anterior
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="min-h-0 overflow-y-auto">
+                  <MarkdownViewer content={model.resumen} className="prose-sm" />
+                </div>
+              </DialogContent>
+            </Dialog>
           )}
         </>
       ) : (

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "idb-keyval": "^6.2.6",
         "lucide-react": "^1.7.0",
         "lunr": "^2.3.9",
         "next": "16.2.9",
@@ -23,7 +24,10 @@
         "react-dom": "19.2.7",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
+        "yaml": "^2.9.0",
+        "zustand": "^5.0.14",
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -328,6 +332,8 @@
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
+    "idb-keyval": ["idb-keyval@6.2.6", "", {}, "sha512-FY64UEhw+5liMzMQ1R9Mw6AF0+wyBrg1CIA1z4CjI/EvT5ty/SvQcWZgd8s9sgaNhX10Y8UzScTh89tEAls5nA=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
@@ -512,6 +518,8 @@
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
@@ -567,6 +575,10 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+# Bun config — keep `bun test` scoped to unit tests.
+# The e2e/ specs are Playwright tests and must run via `bun run test:e2e`.
+[test]
+root = "lib"

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,9 @@
-# Bun config — keep `bun test` scoped to unit tests.
-# The e2e/ specs are Playwright tests and must run via `bun run test:e2e`.
+# Bun config for `bun test`.
+# Discover unit tests across the repo (lib/ AND components/, e.g.
+# components/world/PlaceView.test.ts) — a `root = "lib"` restriction would
+# silently hide component unit tests. The e2e/ specs are Playwright tests and
+# must run via `bun run test:e2e`; they are excluded from `bun run test` via
+# the --path-ignore-patterns flag in package.json's "test" script (bunfig does
+# not honor a testPathIgnorePatterns key, so the exclusion lives in the script).
 [test]
-root = "lib"
+root = "."

--- a/components/play/ActPanels.tsx
+++ b/components/play/ActPanels.tsx
@@ -117,9 +117,23 @@ interface ActPanelsProps {
   content: string;
   initialScrollTop?: number;
   onScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
+  /**
+   * Player-safe view (screen-share). When true, the GM-only rails are omitted
+   * from the DOM entirely — no :::gm reminders (left), no :::accion cards
+   * (right), and no :::recurso cue chips / action-count hints in the center —
+   * leaving only the :::leer / :::info read-aloud flow the players may see.
+   * Default false → the full 3-panel GM view (byte-identical to before). /play
+   * never passes this, so /play is unaffected.
+   */
+  playerView?: boolean;
 }
 
-export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanelsProps) {
+export function ActPanels({
+  content,
+  initialScrollTop = 0,
+  onScroll,
+  playerView = false,
+}: ActPanelsProps) {
   const model = useMemo(() => parseAct(content), [content]);
   const centerRef = useRef<HTMLDivElement>(null);
   const ticking = useRef(false);
@@ -155,9 +169,13 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
 
   // Publish the actions-rail width so fixed-position widgets (e.g. the timer) can
   // shift clear of it. Open = 20rem (w-80), collapsed = 2.25rem (w-9), unmounted = 0.
+  // Player view has no rail at all, so it publishes 0.
   useEffect(() => {
-    document.documentElement.style.setProperty('--actions-rail-w', rightOpen ? '20rem' : '2.25rem');
-  }, [rightOpen]);
+    document.documentElement.style.setProperty(
+      '--actions-rail-w',
+      playerView ? '0px' : rightOpen ? '20rem' : '2.25rem'
+    );
+  }, [rightOpen, playerView]);
   useEffect(
     () => () => {
       document.documentElement.style.setProperty('--actions-rail-w', '0px');
@@ -183,8 +201,9 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
 
   return (
     <div className="flex-1 flex overflow-hidden">
-      {/* LEFT RAIL — persistent act-level reminders */}
-      {leftOpen ? (
+      {/* LEFT RAIL — persistent act-level reminders (GM-only; omitted in player view) */}
+      {!playerView &&
+        (leftOpen ? (
         <aside className="w-72 shrink-0 border-r bg-muted/20 flex flex-col">
           <div className="flex items-center justify-between px-3 py-2 border-b">
             <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
@@ -206,15 +225,15 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
             )}
           </div>
         </aside>
-      ) : (
-        <button
-          onClick={() => setLeftOpen(true)}
-          title="Recordatorios del acto"
-          className="w-9 shrink-0 border-r bg-muted/20 flex items-start justify-center pt-3 text-muted-foreground hover:text-foreground"
-        >
-          <PanelLeftOpen className="h-4 w-4" />
-        </button>
-      )}
+        ) : (
+          <button
+            onClick={() => setLeftOpen(true)}
+            title="Recordatorios del acto"
+            className="w-9 shrink-0 border-r bg-muted/20 flex items-start justify-center pt-3 text-muted-foreground hover:text-foreground"
+          >
+            <PanelLeftOpen className="h-4 w-4" />
+          </button>
+        ))}
 
       {/* CENTER — the scene flow: read-aloud + GM guidance inline, in order */}
       <div ref={centerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto">
@@ -236,7 +255,7 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
                 <h2 className={s.isSection ? 'text-xl font-bold border-b pb-1' : 'text-lg font-semibold text-muted-foreground'}>
                   {s.title}
                 </h2>
-                {resources.length > 0 && (
+                {!playerView && resources.length > 0 && (
                   <div className="mt-2 flex flex-wrap gap-1.5">
                     {resources.map((b, i) => (
                       <ResourceChip key={`r-${i}`} block={b} />
@@ -259,11 +278,15 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
                       );
                     const b = item.block;
                     if (b.type === 'recurso' || b.type === 'accion') return null;
-                    if (b.type === 'gm') return <GmNote key={i} block={b} />;
+                    // Section-scoped :::gm notes are GM answer-key too — a bare
+                    // :::gm under a numbered heading parses as a section block and
+                    // renders inline here. In player view they must be truly
+                    // absent from the DOM so nothing leaks on the shared screen.
+                    if (b.type === 'gm') return playerView ? null : <GmNote key={i} block={b} />;
                     return <ReadAloud key={i} block={b} />;
                   })}
                 </div>
-                {actionCount > 0 && (
+                {!playerView && actionCount > 0 && (
                   <p className="mt-2 text-xs text-muted-foreground italic flex items-center gap-1">
                     <Dice5 className="h-3 w-3" /> {actionCount} acción(es) en el panel derecho →
                   </p>
@@ -275,8 +298,9 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
         </div>
       </div>
 
-      {/* RIGHT RAIL — actions for the section in view (+ parents + act) */}
-      {rightOpen ? (
+      {/* RIGHT RAIL — actions for the section in view (GM-only; omitted in player view) */}
+      {!playerView &&
+        (rightOpen ? (
         <aside className="w-80 shrink-0 border-l bg-muted/20 flex flex-col">
           <div className="flex items-center justify-between px-3 py-2 border-b">
             <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground truncate">
@@ -294,15 +318,15 @@ export function ActPanels({ content, initialScrollTop = 0, onScroll }: ActPanels
             )}
           </div>
         </aside>
-      ) : (
-        <button
-          onClick={() => setRightOpen(true)}
-          title="Acciones"
-          className="w-9 shrink-0 border-l bg-muted/20 flex items-start justify-center pt-3 text-muted-foreground hover:text-foreground"
-        >
-          <PanelRightOpen className="h-4 w-4" />
-        </button>
-      )}
+        ) : (
+          <button
+            onClick={() => setRightOpen(true)}
+            title="Acciones"
+            className="w-9 shrink-0 border-l bg-muted/20 flex items-start justify-center pt-3 text-muted-foreground hover:text-foreground"
+          >
+            <PanelRightOpen className="h-4 w-4" />
+          </button>
+        ))}
     </div>
   );
 }

--- a/components/play/ActPanels.tsx
+++ b/components/play/ActPanels.tsx
@@ -46,7 +46,87 @@ const FIELD_CLASS: Record<string, string> = {
   nota: 'text-muted-foreground',
 };
 
+// Skill-challenge tracker: N success + M fail pips the GM taps to count a
+// "X éxitos antes de Y fallos" beat mid-scene. Stepper feel — tapping the k-th
+// pip sets the count to k; tapping the current-topmost filled pip unfills it.
+// Purely local GM bookkeeping (no store/journal coupling); it lives inside the
+// :::accion card, which the Vista jugador toggle already hides from players.
+function RetoTracker({ exitosMeta, fallosMeta }: { exitosMeta: number; fallosMeta: number }) {
+  const [exitos, setExitos] = useState(0);
+  const [fallos, setFallos] = useState(0);
+
+  // Tap pip index p (1-based): set to p, or unfill to p-1 if it was the top pip.
+  const step = (p: number, cur: number, set: (n: number) => void) => set(cur === p ? p - 1 : p);
+
+  const superado = exitos >= exitosMeta;
+  const fallado = fallos >= fallosMeta;
+
+  const pipBtn = (
+    filled: boolean,
+    onColor: string,
+    onTap: () => void,
+    kind: 'exito' | 'fallo',
+    idx: number
+  ) => (
+    <button
+      key={`${kind}-${idx}`}
+      type="button"
+      data-reto-exito={kind === 'exito' ? idx + 1 : undefined}
+      data-reto-fallo={kind === 'fallo' ? idx + 1 : undefined}
+      aria-label={`${kind === 'exito' ? 'Éxito' : 'Fallo'} ${idx + 1}`}
+      aria-pressed={filled}
+      onClick={onTap}
+      className={`h-5 w-5 rounded-full border transition-colors ${
+        filled ? onColor : 'bg-transparent border-muted-foreground/40'
+      }`}
+    />
+  );
+
+  return (
+    <div data-reto-tracker className="rounded-md border border-dashed bg-muted/25 px-2.5 py-2 space-y-1.5">
+      <div className="flex flex-wrap items-center gap-1">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground w-10">Éxito</span>
+        {Array.from({ length: exitosMeta }, (_, i) =>
+          pipBtn(
+            i < exitos,
+            'bg-emerald-500 border-emerald-600 dark:bg-emerald-400 dark:border-emerald-300',
+            () => step(i + 1, exitos, setExitos),
+            'exito',
+            i
+          )
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-1">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground w-10">Fallo</span>
+        {Array.from({ length: fallosMeta }, (_, i) =>
+          pipBtn(
+            i < fallos,
+            'bg-rose-500 border-rose-600 dark:bg-rose-400 dark:border-rose-300',
+            () => step(i + 1, fallos, setFallos),
+            'fallo',
+            i
+          )
+        )}
+      </div>
+      <div data-reto-readout className="text-xs text-muted-foreground tabular-nums">
+        éxitos {exitos}/{exitosMeta} · fallos {fallos}/{fallosMeta}
+        {superado && (
+          <span className="ml-1.5 font-semibold text-emerald-600 dark:text-emerald-400">▶ SUPERADO</span>
+        )}
+        {fallado && (
+          <span className="ml-1.5 font-semibold text-rose-600 dark:text-rose-400">▶ FALLADO</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function ActionCard({ block }: { block: ActBlock }) {
+  const hasReto = block.exitosMeta !== undefined && block.fallosMeta !== undefined;
+  // The reto: field drives the tracker (below), so don't also list it as a raw
+  // field row. Only filter when it actually parsed into a tracker — a malformed
+  // reto still shows as a plain field so the GM can see/fix it.
+  const fields = hasReto ? block.fields?.filter((f) => f.key !== 'reto') : block.fields;
   return (
     <div className="rounded-lg border bg-card p-3 text-sm space-y-2">
       {block.name && (
@@ -55,9 +135,9 @@ function ActionCard({ block }: { block: ActBlock }) {
           <span>{block.name}</span>
         </div>
       )}
-      {block.fields && block.fields.length > 0 ? (
+      {fields && fields.length > 0 ? (
         <dl className="space-y-1.5">
-          {block.fields.map((f, i) => (
+          {fields.map((f, i) => (
             <div key={i} className="grid grid-cols-[5.5rem_1fr] gap-x-2">
               <dt className="text-[10px] uppercase tracking-wide text-muted-foreground pt-1">
                 {FIELD_LABEL[f.key] ?? f.key}
@@ -68,6 +148,9 @@ function ActionCard({ block }: { block: ActBlock }) {
         </dl>
       ) : (
         <Md>{block.body}</Md>
+      )}
+      {hasReto && (
+        <RetoTracker exitosMeta={block.exitosMeta!} fallosMeta={block.fallosMeta!} />
       )}
     </div>
   );
@@ -312,7 +395,9 @@ export function ActPanels({
           </div>
           <div className="overflow-y-auto p-3 space-y-3">
             {actionBlocks.length ? (
-              actionBlocks.map((b, i) => <ActionCard key={i} block={b} />)
+              // Key by the active section so the per-card reto tracker state
+              // resets when the GM switches acts/parts (not reused by index).
+              actionBlocks.map((b, i) => <ActionCard key={`${activeId ?? 'x'}-${i}`} block={b} />)
             ) : (
               <p className="text-muted-foreground text-xs">— sin acciones para esta sección —</p>
             )}

--- a/components/play/InitiativeTracker.tsx
+++ b/components/play/InitiativeTracker.tsx
@@ -30,6 +30,18 @@ interface InitiativeTrackerProps {
    * tracker keeps its self-managed hover-to-expand behavior, byte-unchanged.
    */
   openSignal?: number;
+  /**
+   * World-mode only: a signal to append prefilled NPC combatants (e.g. from a
+   * parsed threat statblock). Same monotonic-nonce pattern as openSignal: each
+   * time `nonce` increments, the `combatants` payload is appended as NPC rows
+   * (currentHP=maxHP, defense set, initiative 0 for the GM to roll). Names that
+   * collide with existing rows are suffixed #2/#3. Undefined (the /play
+   * default) = inert: the tracker behaves byte-identically to before.
+   */
+  addCombatants?: {
+    nonce: number;
+    combatants: { name: string; maxHP: number; defense: number }[];
+  };
 }
 
 interface CombatState {
@@ -40,7 +52,7 @@ interface CombatState {
 
 const STORAGE_KEY = 'initiativeTrackerState';
 
-export function InitiativeTracker({ playerCharacters, pcStats, openSignal }: InitiativeTrackerProps) {
+export function InitiativeTracker({ playerCharacters, pcStats, openSignal, addCombatants }: InitiativeTrackerProps) {
   const [entries, setEntries] = useState<InitiativeEntry[]>([]);
   const [currentTurnIndex, setCurrentTurnIndex] = useState(0);
   const [roundCount, setRoundCount] = useState(1);
@@ -63,6 +75,52 @@ export function InitiativeTracker({ playerCharacters, pcStats, openSignal }: Ini
     setIsPinned(false);
     setIsExpanded(true);
   }, [openSignal]);
+
+  // World-mode append: when addCombatants.nonce increments, append the payload
+  // as NPC rows with HP/AC prefilled. The initial mount value is ignored (no
+  // spurious add). /play never passes addCombatants so this is inert there.
+  const prevAddNonce = useRef<number | undefined>(addCombatants?.nonce);
+  useEffect(() => {
+    if (addCombatants === undefined) return;
+    if (prevAddNonce.current === addCombatants.nonce) return;
+    prevAddNonce.current = addCombatants.nonce;
+    const incoming = addCombatants.combatants;
+    if (incoming.length === 0) return;
+
+    setEntries(prev => {
+      // De-dupe names against existing rows AND within this batch: a repeated
+      // name gets a " #2" / " #3" suffix so the tracker never shows twins.
+      const used = new Set(prev.map(e => e.name));
+      const uniqueName = (name: string): string => {
+        if (!used.has(name)) {
+          used.add(name);
+          return name;
+        }
+        let n = 2;
+        while (used.has(`${name} #${n}`)) n++;
+        const result = `${name} #${n}`;
+        used.add(result);
+        return result;
+      };
+
+      const rows: InitiativeEntry[] = incoming.map((c, i) => {
+        const maxHP = Math.max(0, Math.floor(c.maxHP) || 0);
+        return {
+          id: `npc-${Date.now()}-${i}`,
+          name: uniqueName(c.name),
+          initiative: 0,
+          type: 'npc' as const,
+          currentHP: maxHP,
+          maxHP,
+          tempHP: 0,
+          defense: Math.max(0, Math.floor(c.defense) || 0),
+          statusEffects: [],
+        };
+      });
+
+      return [...prev, ...rows].sort((a, b) => b.initiative - a.initiative);
+    });
+  }, [addCombatants]);
 
   useEffect(() => {
     const savedState = localStorage.getItem(STORAGE_KEY);
@@ -306,6 +364,7 @@ export function InitiativeTracker({ playerCharacters, pcStats, openSignal }: Ini
       {/* Semi-circle indicator when collapsed */}
       {!isExpanded && (
         <div
+          data-initiative-toggle
           className="fixed left-0 top-1/2 -translate-y-1/2 z-40 cursor-pointer"
           onMouseEnter={() => setIsExpanded(true)}
         >

--- a/components/play/InitiativeTracker.tsx
+++ b/components/play/InitiativeTracker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -23,6 +23,13 @@ interface InitiativeEntry {
 interface InitiativeTrackerProps {
   playerCharacters: string[];
   pcStats?: PlayerCharacterStats[];
+  /**
+   * World-mode only: a monotonically increasing counter. Each time it changes
+   * the tracker force-expands (unpins + opens the full panel) so a "Combate"
+   * button can pop it open. Undefined (the /play default) = no effect: the
+   * tracker keeps its self-managed hover-to-expand behavior, byte-unchanged.
+   */
+  openSignal?: number;
 }
 
 interface CombatState {
@@ -33,7 +40,7 @@ interface CombatState {
 
 const STORAGE_KEY = 'initiativeTrackerState';
 
-export function InitiativeTracker({ playerCharacters, pcStats }: InitiativeTrackerProps) {
+export function InitiativeTracker({ playerCharacters, pcStats, openSignal }: InitiativeTrackerProps) {
   const [entries, setEntries] = useState<InitiativeEntry[]>([]);
   const [currentTurnIndex, setCurrentTurnIndex] = useState(0);
   const [roundCount, setRoundCount] = useState(1);
@@ -44,6 +51,18 @@ export function InitiativeTracker({ playerCharacters, pcStats }: InitiativeTrack
   const [isPinned, setIsPinned] = useState(false);
   const [newStatusInput, setNewStatusInput] = useState<Record<string, string>>({});
   const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
+
+  // World-mode force-open: expand the full panel when openSignal increments.
+  // The initial mount value is ignored (no spurious auto-open); /play never
+  // passes openSignal so this is inert there.
+  const prevOpenSignal = useRef<number | undefined>(openSignal);
+  useEffect(() => {
+    if (openSignal === undefined) return;
+    if (prevOpenSignal.current === openSignal) return;
+    prevOpenSignal.current = openSignal;
+    setIsPinned(false);
+    setIsExpanded(true);
+  }, [openSignal]);
 
   useEffect(() => {
     const savedState = localStorage.getItem(STORAGE_KEY);

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -67,12 +67,15 @@ import {
   SUPPORT_DOC_CATEGORY_ORDER,
   type SupportDocCategory,
 } from '@/lib/world/supportDocCategory';
+import { hasStatblock, parseThreatStatblock } from '@/lib/world/threatStatblock';
 import {
   ChevronDown,
   FileText,
   Grid3x3,
   Image as ImageIcon,
   Map as MapIcon,
+  Minus,
+  Plus,
   Swords,
   User,
   X,
@@ -129,6 +132,15 @@ export function ActRunner({ config, placeName, fsm, onClose, onActChange }: ActR
   const [currentTab, setCurrentTab] = useState('plan');
   const [previousTab, setPreviousTab] = useState('plan');
   const [planContent, setPlanContent] = useState<string | null>(null);
+  // Threat -> combat handoff: bumping this signal appends prefilled NPC rows to
+  // the mounted InitiativeTracker (the "Añadir al combate" one-tap add). The
+  // toast is a brief confirmation of what got added.
+  const [addCombatants, setAddCombatants] = useState<{
+    nonce: number;
+    combatants: { name: string; maxHP: number; defense: number }[];
+  }>({ nonce: 0, combatants: [] });
+  const [combatToast, setCombatToast] = useState<string | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Content/image caches live in refs so loadContent/loadImageUrl stay stable
   // (play keeps them in state; the runner avoids the identity churn).
   const contentCacheRef = useRef<Map<string, string>>(new Map());
@@ -242,6 +254,36 @@ abrir el acto.`;
     [currentTab]
   );
 
+  // A threat pane's "Añadir al combate" click lands here: parse the doc, build
+  // N combatants, bump the tracker's addCombatants signal, flash a toast. The
+  // fallback name keeps the row usable even if the ficha has no parseable name.
+  const handleAddToCombat = useCallback(
+    (content: string, fallbackName: string, count: number) => {
+      const parsed = parseThreatStatblock(content);
+      if (parsed.ca == null || parsed.pv == null) return;
+      const base = parsed.nombre?.trim() || fallbackName;
+      const n = Math.max(1, Math.min(8, Math.floor(count) || 1));
+      const combatants = Array.from({ length: n }, (_, i) => ({
+        name: n > 1 ? `${base} #${i + 1}` : base,
+        maxHP: parsed.pv as number,
+        defense: parsed.ca as number,
+      }));
+      setAddCombatants((prev) => ({ nonce: prev.nonce + 1, combatants }));
+
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      setCombatToast(`${base} ×${n} → combate`);
+      toastTimerRef.current = setTimeout(() => setCombatToast(null), 2600);
+    },
+    []
+  );
+
+  useEffect(
+    () => () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    },
+    []
+  );
+
   /** "bram_oskar.md" -> "bram oskar" — tabs read as names, not filenames. */
   const docTabLabel = (name: string): string =>
     name.replace(/\.md$/i, '').replace(/_/g, ' ');
@@ -324,7 +366,18 @@ abrir el acto.`;
       <InitiativeTracker
         playerCharacters={config.playerCharacters}
         pcStats={config.pcStats}
+        addCombatants={addCombatants}
       />
+
+      {combatToast && (
+        <div
+          data-combat-toast
+          role="status"
+          className="fixed top-16 left-1/2 z-[60] -translate-x-1/2 rounded-md border bg-background px-4 py-2 text-sm font-medium shadow-lg"
+        >
+          {combatToast}
+        </div>
+      )}
 
       {currentPart ? (
         <Tabs
@@ -407,7 +460,12 @@ abrir el acto.`;
                 value={`doc-${index}`}
                 className="m-0 h-full data-[state=active]:flex"
               >
-                <RunnerMarkdown file={doc} loadContent={loadContent} />
+                <RunnerMarkdown
+                  file={doc}
+                  loadContent={loadContent}
+                  isThreat={categorizeSupportDoc(doc.path) === 'amenazas'}
+                  onAddToCombat={handleAddToCombat}
+                />
               </TabsContent>
             ))}
           </div>
@@ -425,9 +483,15 @@ abrir el acto.`;
 function RunnerMarkdown({
   file,
   loadContent,
+  isThreat = false,
+  onAddToCombat,
 }: {
   file: FileReference;
   loadContent: (file: FileReference) => Promise<string>;
+  /** True when this doc lives in a threats/ folder (category 'amenazas'). */
+  isThreat?: boolean;
+  /** Adds N combatants parsed from `content` to the initiative tracker. */
+  onAddToCombat?: (content: string, fallbackName: string, count: number) => void;
 }) {
   const [content, setContent] = useState<string | null>(null);
 
@@ -450,14 +514,100 @@ function RunnerMarkdown({
     );
   }
 
-  if (isActFormat(content)) {
-    return <ActPanels content={content} />;
-  }
+  // A threat ficha with a parseable CA/PV statblock gets a one-tap add-to-combat
+  // header above the body. Non-threat docs and threat docs without a statblock
+  // render exactly as before (no header).
+  const showAdd = isThreat && onAddToCombat !== undefined && hasStatblock(content);
 
-  return (
+  const body = isActFormat(content) ? (
+    <ActPanels content={content} />
+  ) : (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-4xl p-6">
         <MarkdownViewer content={content} />
+      </div>
+    </div>
+  );
+
+  if (!showAdd) return body;
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      <AddToCombatBar
+        content={content}
+        fallbackName={file.name.replace(/\.md$/i, '').replace(/_/g, ' ')}
+        onAddToCombat={onAddToCombat}
+      />
+      <div className="flex min-h-0 flex-1 overflow-hidden">{body}</div>
+    </div>
+  );
+}
+
+/**
+ * The "⚔️ Añadir al combate" header shown above a threat ficha with a statblock.
+ * A 1–8 count stepper (default 1) plus the add button: clicking hands the raw
+ * doc content + the desired count up to ActRunner, which parses + appends the
+ * combatants and flashes a toast.
+ */
+function AddToCombatBar({
+  content,
+  fallbackName,
+  onAddToCombat,
+}: {
+  content: string;
+  fallbackName: string;
+  onAddToCombat: (content: string, fallbackName: string, count: number) => void;
+}) {
+  const [count, setCount] = useState(1);
+  const parsed = parseThreatStatblock(content);
+  const name = parsed.nombre?.trim() || fallbackName;
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-2 border-b bg-muted/30 px-4 py-2">
+      <span className="text-sm font-medium">{name}</span>
+      {parsed.ca != null && (
+        <span className="text-muted-foreground text-xs">CA {parsed.ca}</span>
+      )}
+      {parsed.pv != null && (
+        <span className="text-muted-foreground text-xs">PV {parsed.pv}</span>
+      )}
+      <div className="ml-auto flex items-center gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Menos"
+          onClick={() => setCount((c) => Math.max(1, c - 1))}
+        >
+          <Minus className="h-3.5 w-3.5" />
+        </Button>
+        <span
+          data-threat-count
+          className="w-6 text-center text-sm font-medium tabular-nums"
+        >
+          {count}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Más"
+          onClick={() => setCount((c) => Math.min(8, c + 1))}
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          data-threat-add
+          className="ml-1 min-h-8"
+          onClick={() => onAddToCombat(content, fallbackName, count)}
+        >
+          <Swords className="h-3.5 w-3.5" />
+          Añadir al combate
+        </Button>
       </div>
     </div>
   );

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -49,9 +49,10 @@ import { AudioControls } from '@/components/play/AudioControls';
 import { PartTimer } from '@/components/play/PartTimer';
 import { InitiativeTracker } from '@/components/play/InitiativeTracker';
 import { FullscreenImage } from '@/components/world/FullscreenImage';
+import { BattlemapViewer } from '@/components/world/BattlemapViewer';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { X } from 'lucide-react';
+import { Grid3x3, X } from 'lucide-react';
 
 const CLOSE_FADE_MS = 800;
 const CLOSE_FADE_INTERVAL_MS = 50;
@@ -210,7 +211,8 @@ abrir el acto.`;
 
   const handleTabChange = useCallback(
     (newTab: string) => {
-      if (newTab.startsWith('image-')) setPreviousTab(currentTab);
+      if (newTab.startsWith('image-') || newTab.startsWith('battlemap-'))
+        setPreviousTab(currentTab);
       setCurrentTab(newTab);
     },
     [currentTab]
@@ -224,9 +226,14 @@ abrir el acto.`;
     setCurrentTab(previousTab);
   }, [previousTab]);
 
+  // battlemaps may be absent on configs stored before this field existed.
+  const battlemaps = currentPart?.battlemaps ?? [];
+
   const hasTabs =
     currentPart !== undefined &&
-    (currentPart.images.length > 0 || currentPart.supportDocs.length > 0);
+    (currentPart.images.length > 0 ||
+      battlemaps.length > 0 ||
+      currentPart.supportDocs.length > 0);
 
   return (
     <div data-act-runner className="fixed inset-0 z-50 flex flex-col bg-background">
@@ -303,6 +310,16 @@ abrir el acto.`;
                     {img.name}
                   </TabsTrigger>
                 ))}
+                {battlemaps.map((map, index) => (
+                  <TabsTrigger
+                    key={`battlemap-${index}`}
+                    value={`battlemap-${index}`}
+                    className="gap-1.5"
+                  >
+                    <Grid3x3 className="h-3.5 w-3.5" />
+                    {docTabLabel(map.name)}
+                  </TabsTrigger>
+                ))}
                 {currentPart.supportDocs.map((doc, index) => (
                   <TabsTrigger key={`doc-${index}`} value={`doc-${index}`}>
                     {docTabLabel(doc.name)}
@@ -326,6 +343,20 @@ abrir el acto.`;
             {currentPart.images.map((img, index) => (
               <TabsContent key={`img-${index}`} value={`image-${index}`} className="m-0 h-full">
                 <RunnerImage file={img} loadImageUrl={loadImageUrl} onClose={handleImageClose} />
+              </TabsContent>
+            ))}
+
+            {battlemaps.map((map, index) => (
+              <TabsContent
+                key={`battlemap-${index}`}
+                value={`battlemap-${index}`}
+                className="m-0 h-full"
+              >
+                <RunnerBattlemap
+                  file={map}
+                  loadImageUrl={loadImageUrl}
+                  onClose={handleImageClose}
+                />
               </TabsContent>
             ))}
 
@@ -428,4 +459,43 @@ function RunnerImage({
   }
 
   return <FullscreenImage imageUrl={imageUrl} onClose={onClose} />;
+}
+
+/** Battlemap pane: resolves the object URL, then hands off to the pan/zoom/grid viewer. */
+function RunnerBattlemap({
+  file,
+  loadImageUrl,
+  onClose,
+}: {
+  file: FileReference;
+  loadImageUrl: (file: FileReference) => Promise<string>;
+  onClose: () => void;
+}) {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setImageUrl(null);
+    void loadImageUrl(file).then(
+      (url) => {
+        if (!cancelled) setImageUrl(url);
+      },
+      (error) => {
+        console.error(`Error al cargar el mapa ${file.path}:`, error);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [file, loadImageUrl]);
+
+  if (imageUrl === null) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Cargando mapa…</p>
+      </div>
+    );
+  }
+
+  return <BattlemapViewer imageUrl={imageUrl} onClose={onClose} />;
 }

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -1,0 +1,424 @@
+'use client';
+
+/**
+ * ActRunner — plays a prepared place inside /world (M5, plan Part B "Cockpit").
+ *
+ * Fullscreen overlay mounted by the world page when the GM hits "Jugar" on a
+ * playable place. `config` IS the place's ready SessionConfig
+ * (PlaceEntity.playable): scanSessionFolder() ran verbatim on the
+ * `lugares/<id>/` folder and every FileReference path arrives prefixed
+ * `mundo/lugares/<id>/`, so the world fs manager (campaign root) resolves
+ * them directly. Composition mirrors app/play/page.tsx — the selected part's
+ * plan renders through ActPanels when it is `:::` act format (MarkdownViewer
+ * otherwise), and AudioControls / PartTimer / InitiativeTracker / ImageViewer
+ * are the EXISTING play components mounted unmodified (they position
+ * themselves `fixed`, which inside this overlay still paints above the
+ * overlay background because they are its DOM children). Support docs and
+ * images ride on the same Tabs pattern as play.
+ *
+ * Deliberate differences from /play (kept lean on purpose):
+ *   - The part selector is a local header tab row (`data-act-part` items):
+ *     FloatingNav's fixed top-left placement + path-switcher props don't fit
+ *     a header-owned overlay. Parts on a non-active path stay hidden (same
+ *     visibleParts rule as play) and the runner offers no path switcher —
+ *     playable places are expected to be trunk-only.
+ *   - No SearchDialog / NotesPanel / SplitView / scroll persistence: those
+ *     flows stay with the cockpit (world search, journal) outside the runner.
+ *   - AUDIO LIFETIME: one AudioManager per runner instance. Closing = the
+ *     page unmounts the overlay; the unmount effect fades the volume to
+ *     silence (~0.8s, page stays responsive — the fade outlives the React
+ *     tree) and THEN releases the element (cleanup pauses + revokes the
+ *     object URL), so Cerrar never cuts the music hard.
+ *
+ * The page owns the act open/close journaling (see app/world/page.tsx M5
+ * notes); `onActChange` keeps it informed of the current part name so the
+ * closing nota names the act the GM actually ended on.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FileReference, Part, SessionConfig } from '@/types';
+import { FileSystemManager } from '@/lib/fileSystem';
+import { AudioManager } from '@/lib/audioManager';
+import { isActFormat } from '@/lib/actFormat';
+import { ActPanels } from '@/components/play/ActPanels';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import { AudioControls } from '@/components/play/AudioControls';
+import { PartTimer } from '@/components/play/PartTimer';
+import { InitiativeTracker } from '@/components/play/InitiativeTracker';
+import { ImageViewer } from '@/components/play/ImageViewer';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+const CLOSE_FADE_MS = 800;
+const CLOSE_FADE_INTERVAL_MS = 50;
+
+/**
+ * Fades the runner's audio to silence, then releases it (pause + revoke via
+ * AudioManager.cleanup). Runs detached from React — the overlay may already
+ * be unmounted while the fade finishes. Silent/paused audio is released
+ * immediately.
+ */
+function fadeOutAndCleanup(audio: AudioManager): void {
+  const startVolume = audio.getVolume();
+  if (!audio.isPlaying() || startVolume <= 0) {
+    audio.cleanup();
+    return;
+  }
+  const steps = Math.ceil(CLOSE_FADE_MS / CLOSE_FADE_INTERVAL_MS);
+  let step = 0;
+  const interval = setInterval(() => {
+    step++;
+    audio.setVolume(startVolume * Math.max(0, 1 - step / steps));
+    if (step >= steps) {
+      clearInterval(interval);
+      audio.cleanup();
+    }
+  }, CLOSE_FADE_INTERVAL_MS);
+}
+
+interface ActRunnerProps {
+  /** The place's playable SessionConfig (paths prefixed mundo/lugares/<id>/). */
+  config: SessionConfig;
+  placeName: string;
+  /** World fs manager bound to the CAMPAIGN root (worldStore.fs). */
+  fsm: FileSystemManager;
+  onClose: () => void;
+  /** Fired with the part name whenever the GM switches acts. */
+  onActChange?: (actName: string) => void;
+}
+
+export function ActRunner({ config, placeName, fsm, onClose, onActChange }: ActRunnerProps) {
+  // Same visibility rule as play: trunk parts + the active path's parts.
+  const visibleParts = config.parts.filter(
+    (p) => p.pathId == null || p.pathId === (config.activePathId ?? null)
+  );
+
+  const [audioManager] = useState(() => new AudioManager(fsm));
+  const [currentPartId, setCurrentPartId] = useState<string | null>(
+    visibleParts[0]?.id ?? null
+  );
+  const [currentTab, setCurrentTab] = useState('plan');
+  const [previousTab, setPreviousTab] = useState('plan');
+  const [planContent, setPlanContent] = useState<string | null>(null);
+  // Content/image caches live in refs so loadContent/loadImageUrl stay stable
+  // (play keeps them in state; the runner avoids the identity churn).
+  const contentCacheRef = useRef<Map<string, string>>(new Map());
+  const imageUrlCacheRef = useRef<Map<string, string>>(new Map());
+
+  const currentPart: Part | undefined =
+    visibleParts.find((p) => p.id === currentPartId) ?? visibleParts[0];
+
+  // Audio teardown belongs to unmount (Cerrar just asks the page to unmount
+  // us), so a parent-driven unmount — world reset, re-scan — fades too. The
+  // image object URLs are revoked here as well: unlike /play (page-lifetime
+  // cache), each runner opening mints fresh URLs, so leaving them alive would
+  // leak one blob reference per viewed image per opening.
+  useEffect(() => {
+    const imageUrlCache = imageUrlCacheRef.current;
+    return () => {
+      fadeOutAndCleanup(audioManager);
+      imageUrlCache.forEach((url) => URL.revokeObjectURL(url));
+      imageUrlCache.clear();
+    };
+  }, [audioManager]);
+
+  const loadContent = useCallback(
+    async (file: FileReference): Promise<string> => {
+      const cached = contentCacheRef.current.get(file.path);
+      if (cached !== undefined) return cached;
+      try {
+        const content = await fsm.readTextFile(file.path);
+        contentCacheRef.current.set(file.path, content);
+        return content;
+      } catch (error) {
+        console.error(`Error al cargar ${file.path}:`, error);
+        return `# No se pudo abrir el archivo
+
+**Archivo**: ${file.name}
+**Ruta**: ${file.path}
+
+El archivo no se encontró en la carpeta de campaña. Puede haber sido movido
+o cambiado de nombre después del escaneo — usa "Recargar mundo" y vuelve a
+abrir el acto.`;
+      }
+    },
+    [fsm]
+  );
+
+  const loadImageUrl = useCallback(
+    async (file: FileReference): Promise<string> => {
+      const cached = imageUrlCacheRef.current.get(file.path);
+      if (cached !== undefined) return cached;
+      const url = await fsm.getFileURL(file.path);
+      imageUrlCacheRef.current.set(file.path, url);
+      return url;
+    },
+    [fsm]
+  );
+
+  // Part activation: plan content for the timer + audio wiring (same guards
+  // as play's loadPartContent: keep the current BGM/event playlist when the
+  // new part shares it, never auto-start an empty BGM list).
+  useEffect(() => {
+    const part = currentPart;
+    if (!part) return;
+
+    let cancelled = false;
+    if (part.planFile) {
+      void loadContent(part.planFile).then((content) => {
+        if (!cancelled) setPlanContent(content);
+      });
+    } else {
+      setPlanContent(null);
+    }
+
+    const isInEventMode = audioManager.getCurrentMode() === 'event';
+    const bgmPlaylist = audioManager.getBGMPlaylist();
+    const isSameBGM =
+      audioManager.getCurrentMode() === 'bgm' &&
+      bgmPlaylist.length === part.bgmPlaylist.length &&
+      bgmPlaylist.every((track, index) => track.path === part.bgmPlaylist[index]?.path);
+    const currentEventPlaylist = audioManager.getCurrentEventPlaylist();
+    const eventPlaylistStillExists =
+      currentEventPlaylist !== null &&
+      part.eventPlaylists.some((playlist) => playlist.id === currentEventPlaylist.id);
+
+    audioManager.loadBGM(part.bgmPlaylist);
+    audioManager.loadEventPlaylists(part.eventPlaylists);
+    if (part.bgmPlaylist.length > 0 && !isSameBGM && (!isInEventMode || !eventPlaylistStillExists)) {
+      void audioManager.playBGM();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentPart, audioManager, loadContent]);
+
+  const handlePartChange = useCallback(
+    (part: Part) => {
+      setCurrentPartId(part.id);
+      setCurrentTab('plan');
+      setPreviousTab('plan');
+      onActChange?.(part.name);
+    },
+    [onActChange]
+  );
+
+  const handleTabChange = useCallback(
+    (newTab: string) => {
+      if (newTab.startsWith('image-')) setPreviousTab(currentTab);
+      setCurrentTab(newTab);
+    },
+    [currentTab]
+  );
+
+  const handleImageClose = useCallback(() => {
+    setCurrentTab(previousTab);
+  }, [previousTab]);
+
+  const hasTabs =
+    currentPart !== undefined &&
+    (currentPart.images.length > 0 || currentPart.supportDocs.length > 0);
+
+  return (
+    <div data-act-runner className="fixed inset-0 z-50 flex flex-col bg-background">
+      {/* pr keeps the Cerrar button clear of AudioControls' top-right pill. */}
+      <header className="flex min-h-12 shrink-0 items-center gap-3 border-b py-2 pr-24 pl-4">
+        <h2 className="text-lg font-semibold whitespace-nowrap">{placeName}</h2>
+        <div
+          role="tablist"
+          aria-label="Actos del lugar"
+          className="flex min-w-0 flex-1 flex-wrap items-center gap-1"
+        >
+          {visibleParts.map((part) => (
+            <button
+              key={part.id}
+              type="button"
+              role="tab"
+              data-act-part={part.name}
+              aria-selected={part.id === currentPart?.id}
+              onClick={() => handlePartChange(part)}
+              // min-h-11 = 44px tap target (M5 sweep).
+              className={`min-h-11 rounded-md px-2.5 py-1 text-sm transition-colors ${
+                part.id === currentPart?.id
+                  ? 'bg-muted font-medium'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {part.name}
+            </button>
+          ))}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          data-act-close
+          onClick={onClose}
+          aria-label={`Cerrar ${placeName}`}
+          className="min-h-11"
+        >
+          <X />
+          Cerrar
+        </Button>
+      </header>
+
+      <AudioControls
+        audioManager={audioManager}
+        eventPlaylists={currentPart?.eventPlaylists ?? []}
+      />
+
+      {currentPart && (
+        <PartTimer
+          partId={currentPart.id}
+          partName={currentPart.name}
+          planContent={planContent}
+        />
+      )}
+
+      <InitiativeTracker
+        playerCharacters={config.playerCharacters}
+        pcStats={config.pcStats}
+      />
+
+      {currentPart ? (
+        <Tabs
+          value={currentTab}
+          onValueChange={handleTabChange}
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
+          {hasTabs && (
+            <div className="shrink-0 border-b px-4">
+              <TabsList className="h-10">
+                <TabsTrigger value="plan">Plan</TabsTrigger>
+                {currentPart.images.map((img, index) => (
+                  <TabsTrigger key={`img-${index}`} value={`image-${index}`}>
+                    {img.name}
+                  </TabsTrigger>
+                ))}
+                {currentPart.supportDocs.map((doc, index) => (
+                  <TabsTrigger key={`doc-${index}`} value={`doc-${index}`}>
+                    {doc.name}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
+          )}
+
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <TabsContent value="plan" className="m-0 h-full data-[state=active]:flex">
+              {currentPart.planFile ? (
+                <RunnerMarkdown file={currentPart.planFile} loadContent={loadContent} />
+              ) : (
+                <div className="flex h-full flex-1 items-center justify-center">
+                  <p className="text-muted-foreground">Este acto no tiene archivo de plan</p>
+                </div>
+              )}
+            </TabsContent>
+
+            {currentPart.images.map((img, index) => (
+              <TabsContent key={`img-${index}`} value={`image-${index}`} className="m-0 h-full">
+                <RunnerImage file={img} loadImageUrl={loadImageUrl} onClose={handleImageClose} />
+              </TabsContent>
+            ))}
+
+            {currentPart.supportDocs.map((doc, index) => (
+              <TabsContent
+                key={`doc-${index}`}
+                value={`doc-${index}`}
+                className="m-0 h-full data-[state=active]:flex"
+              >
+                <RunnerMarkdown file={doc} loadContent={loadContent} />
+              </TabsContent>
+            ))}
+          </div>
+        </Tabs>
+      ) : (
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-muted-foreground">Este lugar no tiene actos preparados.</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Markdown pane: `:::` act format -> ActPanels 3-panel view, else MarkdownViewer. */
+function RunnerMarkdown({
+  file,
+  loadContent,
+}: {
+  file: FileReference;
+  loadContent: (file: FileReference) => Promise<string>;
+}) {
+  const [content, setContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setContent(null);
+    void loadContent(file).then((text) => {
+      if (!cancelled) setContent(text);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [file, loadContent]);
+
+  if (content === null) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center">
+        <p className="text-muted-foreground">Cargando…</p>
+      </div>
+    );
+  }
+
+  if (isActFormat(content)) {
+    return <ActPanels content={content} />;
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-4xl p-6">
+        <MarkdownViewer content={content} />
+      </div>
+    </div>
+  );
+}
+
+/** Image pane: resolves the object URL, then hands off to ImageViewer. */
+function RunnerImage({
+  file,
+  loadImageUrl,
+  onClose,
+}: {
+  file: FileReference;
+  loadImageUrl: (file: FileReference) => Promise<string>;
+  onClose: () => void;
+}) {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setImageUrl(null);
+    void loadImageUrl(file).then(
+      (url) => {
+        if (!cancelled) setImageUrl(url);
+      },
+      (error) => {
+        console.error(`Error al cargar la imagen ${file.path}:`, error);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [file, loadImageUrl]);
+
+  if (imageUrl === null) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Cargando imagen…</p>
+      </div>
+    );
+  }
+
+  return <ImageViewer imageUrl={imageUrl} imageName={file.name} onClose={onClose} />;
+}

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -10,11 +10,14 @@
  * `mundo/lugares/<id>/`, so the world fs manager (campaign root) resolves
  * them directly. Composition mirrors app/play/page.tsx — the selected part's
  * plan renders through ActPanels when it is `:::` act format (MarkdownViewer
- * otherwise), and AudioControls / PartTimer / InitiativeTracker / ImageViewer
- * are the EXISTING play components mounted unmodified (they position
- * themselves `fixed`, which inside this overlay still paints above the
- * overlay background because they are its DOM children). Support docs and
- * images ride on the same Tabs pattern as play.
+ * otherwise), and AudioControls / PartTimer / InitiativeTracker are the
+ * EXISTING play components mounted unmodified (they position themselves
+ * `fixed`, which inside this overlay still paints above the overlay
+ * background because they are its DOM children). Support docs and images
+ * ride on the same Tabs pattern as play — but images display through the
+ * world FullscreenImage viewer, NOT play's ImageViewer: the play viewer
+ * overlays the image title, a GM-only filename leak on the shared screen the
+ * GM projects during sessions. Play mode keeps ImageViewer untouched.
  *
  * Deliberate differences from /play (kept lean on purpose):
  *   - The part selector is a local header tab row (`data-act-part` items):
@@ -45,7 +48,7 @@ import { MarkdownViewer } from '@/components/play/MarkdownViewer';
 import { AudioControls } from '@/components/play/AudioControls';
 import { PartTimer } from '@/components/play/PartTimer';
 import { InitiativeTracker } from '@/components/play/InitiativeTracker';
-import { ImageViewer } from '@/components/play/ImageViewer';
+import { FullscreenImage } from '@/components/world/FullscreenImage';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
@@ -388,7 +391,7 @@ function RunnerMarkdown({
   );
 }
 
-/** Image pane: resolves the object URL, then hands off to ImageViewer. */
+/** Image pane: resolves the object URL, then hands off to the player-safe viewer. */
 function RunnerImage({
   file,
   loadImageUrl,
@@ -424,5 +427,5 @@ function RunnerImage({
     );
   }
 
-  return <ImageViewer imageUrl={imageUrl} imageName={file.name} onClose={onClose} />;
+  return <FullscreenImage imageUrl={imageUrl} onClose={onClose} />;
 }

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -38,11 +38,18 @@
  * closing nota names the act the GM actually ended on.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileReference, Part, SessionConfig } from '@/types';
+import type { EventEffect } from '@/types/world';
 import { FileSystemManager } from '@/lib/fileSystem';
 import { AudioManager } from '@/lib/audioManager';
 import { isActFormat } from '@/lib/actFormat';
+import { extractEfectos } from '@/lib/world/eventEngine';
+import {
+  effectLabel,
+  splitComentario,
+  stripEfectoBlocks,
+} from '@/components/world/EventDrawer';
 import { ActPanels } from '@/components/play/ActPanels';
 import { MarkdownViewer } from '@/components/play/MarkdownViewer';
 import { AudioControls } from '@/components/play/AudioControls';
@@ -69,6 +76,7 @@ import {
 } from '@/lib/world/supportDocCategory';
 import { hasStatblock, parseThreatStatblock } from '@/lib/world/threatStatblock';
 import {
+  Check,
   ChevronDown,
   Eye,
   FileText,
@@ -77,6 +85,7 @@ import {
   Map as MapIcon,
   Minus,
   Plus,
+  Sparkles,
   Swords,
   User,
   X,
@@ -118,9 +127,27 @@ interface ActRunnerProps {
   onClose: () => void;
   /** Fired with the part name whenever the GM switches acts. */
   onActChange?: (actName: string) => void;
+  /**
+   * Apply ONE of the current act's `:::efecto` state-transitions to the party
+   * journal — the SAME page handler wired to EventDrawer's onApplyEffect
+   * (makeEntry.* → partyStore log). Absent ⇒ no "Efectos del acto" panel.
+   * Returns false when the apply was rejected (no session/model, log refused)
+   * so the button is NOT ticked off for an un-journaled transition.
+   */
+  onApplyEffect?: (effect: EventEffect) => boolean | void;
+  /** Session-gate for the apply buttons (disabled + hint when inactive). */
+  sessionActive?: boolean;
 }
 
-export function ActRunner({ config, placeName, fsm, onClose, onActChange }: ActRunnerProps) {
+export function ActRunner({
+  config,
+  placeName,
+  fsm,
+  onClose,
+  onActChange,
+  onApplyEffect,
+  sessionActive = false,
+}: ActRunnerProps) {
   // Same visibility rule as play: trunk parts + the active path's parts.
   const visibleParts = config.parts.filter(
     (p) => p.pathId == null || p.pathId === (config.activePathId ?? null)
@@ -137,6 +164,10 @@ export function ActRunner({ config, placeName, fsm, onClose, onActChange }: ActR
   // act. Off by default; resets each time the runner is opened (per-open state).
   const [playerView, setPlayerView] = useState(false);
   const [planContent, setPlanContent] = useState<string | null>(null);
+  // "Efectos del acto": indexes into the current act's parsed :::efecto blocks
+  // already applied (checks off + disables the button). Reset per act — a new
+  // part's transitions start un-applied.
+  const [appliedActEfectos, setAppliedActEfectos] = useState<number[]>([]);
   // Threat -> combat handoff: bumping this signal appends prefilled NPC rows to
   // the mounted InitiativeTracker (the "Añadir al combate" one-tap add). The
   // toast is a brief confirmation of what got added.
@@ -153,6 +184,15 @@ export function ActRunner({ config, placeName, fsm, onClose, onActChange }: ActR
 
   const currentPart: Part | undefined =
     visibleParts.find((p) => p.id === currentPartId) ?? visibleParts[0];
+
+  // The current act's declared state-transitions: parse its plan's :::efecto
+  // blocks with the SAME grammar the event scanner uses (extractEfectos), so
+  // the GM can one-tap apply them instead of hand-performing each across three
+  // panels mid-narration. Empty when the act has no :::efecto (no panel).
+  const actEfectos: EventEffect[] = useMemo(
+    () => (planContent ? extractEfectos(planContent.split(/\r?\n/)).efectos : []),
+    [planContent]
+  );
 
   // Audio teardown belongs to unmount (Cerrar just asks the page to unmount
   // us), so a parent-driven unmount — world reset, re-scan — fades too. The
@@ -239,6 +279,25 @@ abrir el acto.`;
       cancelled = true;
     };
   }, [currentPart, audioManager, loadContent]);
+
+  // Applied-effect ticks are per-act: switching acts starts the new act's
+  // transitions un-applied (keyed on the resolved part id so the auto-selected
+  // first act resets too, not just explicit clicks).
+  const currentPartKey = currentPart?.id ?? null;
+  useEffect(() => {
+    setAppliedActEfectos([]);
+  }, [currentPartKey]);
+
+  const handleApplyActEfecto = useCallback(
+    (effect: EventEffect, index: number) => {
+      if (!onApplyEffect || !sessionActive) return;
+      // Only tick the button off if the effect was actually journaled — a
+      // rejected apply (false) must stay un-applied so nothing silently reverts.
+      if (onApplyEffect(effect) === false) return;
+      setAppliedActEfectos((prev) => (prev.includes(index) ? prev : [...prev, index]));
+    },
+    [onApplyEffect, sessionActive]
+  );
 
   const handlePartChange = useCallback(
     (part: Part) => {
@@ -454,7 +513,19 @@ abrir el acto.`;
           )}
 
           <div className="min-h-0 flex-1 overflow-hidden">
-            <TabsContent value="plan" className="m-0 h-full data-[state=active]:flex">
+            <TabsContent
+              value="plan"
+              className="m-0 h-full data-[state=active]:flex data-[state=active]:flex-col"
+            >
+              {/* GM-only: hidden under Vista jugador, like the :::gm rails. */}
+              {!playerView && actEfectos.length > 0 && onApplyEffect && (
+                <ActEfectosPanel
+                  efectos={actEfectos}
+                  applied={appliedActEfectos}
+                  sessionActive={sessionActive}
+                  onApply={handleApplyActEfecto}
+                />
+              )}
               {currentPart.planFile ? (
                 <RunnerMarkdown
                   file={currentPart.planFile}
@@ -513,6 +584,64 @@ abrir el acto.`;
   );
 }
 
+/**
+ * "Efectos del acto" — GM-only strip at the top of the Plan tab listing the
+ * current act's declared `:::efecto` state-transitions as one-tap apply
+ * buttons (mirrors EventDrawer's Efectos button list). Each applied button
+ * checks off + disables. Session-gated: with no active session the buttons are
+ * disabled and carry the "Inicia sesión para aplicar" hint (like QuickLogBar),
+ * so an un-logged transition can never silently revert. Rendered only when the
+ * act HAS efectos (the caller guards that + Vista jugador).
+ */
+function ActEfectosPanel({
+  efectos,
+  applied,
+  sessionActive,
+  onApply,
+}: {
+  efectos: EventEffect[];
+  applied: number[];
+  sessionActive: boolean;
+  onApply: (effect: EventEffect, index: number) => void;
+}) {
+  return (
+    <div data-act-efectos className="shrink-0 border-b bg-muted/20 px-4 py-2.5">
+      <div className="mb-1.5 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <Sparkles className="h-3 w-3" aria-hidden />
+        Efectos del acto
+        {!sessionActive && (
+          <span data-act-efectos-hint className="ml-1 normal-case font-normal">
+            · Inicia sesión para aplicar
+          </span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {efectos.map((efecto, index) => {
+          const isApplied = applied.includes(index);
+          const { comentario } = splitComentario(efecto.value);
+          return (
+            <Button
+              key={index}
+              type="button"
+              variant={isApplied ? 'secondary' : 'outline'}
+              size="sm"
+              disabled={isApplied || !sessionActive}
+              title={!sessionActive ? 'Inicia sesión para aplicar' : comentario}
+              data-act-efecto={index}
+              onClick={() => onApply(efecto, index)}
+              // min-h-11 = 44px tap target (M5 sweep).
+              className="min-h-11"
+            >
+              {isApplied && <Check className="text-emerald-600 dark:text-emerald-400" />}
+              {effectLabel(efecto)}
+            </Button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 /** Markdown pane: `:::` act format -> ActPanels 3-panel view, else MarkdownViewer. */
 function RunnerMarkdown({
   file,
@@ -556,8 +685,12 @@ function RunnerMarkdown({
   // render exactly as before (no header).
   const showAdd = isThreat && onAddToCombat !== undefined && hasStatblock(content);
 
+  // `:::efecto` blocks (the act's declared state-transitions, surfaced as the
+  // GM-only "Efectos del acto" apply buttons) are not an actFormat block type —
+  // strip them so they never render as stray prose in the act view (mirrors
+  // EventDrawer's stripEfectoBlocks before parseAct).
   const body = isActFormat(content) ? (
-    <ActPanels content={content} playerView={playerView} />
+    <ActPanels content={stripEfectoBlocks(content)} playerView={playerView} />
   ) : (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-4xl p-6">

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -70,6 +70,7 @@ import {
 import { hasStatblock, parseThreatStatblock } from '@/lib/world/threatStatblock';
 import {
   ChevronDown,
+  Eye,
   FileText,
   Grid3x3,
   Image as ImageIcon,
@@ -131,6 +132,10 @@ export function ActRunner({ config, placeName, fsm, onClose, onActChange }: ActR
   );
   const [currentTab, setCurrentTab] = useState('plan');
   const [previousTab, setPreviousTab] = useState('plan');
+  // "Vista jugador": when ON, the Plan act view drops the GM-only rails
+  // (:::gm / :::accion / :::recurso) so the GM can screen-share a player-safe
+  // act. Off by default; resets each time the runner is opened (per-open state).
+  const [playerView, setPlayerView] = useState(false);
   const [planContent, setPlanContent] = useState<string | null>(null);
   // Threat -> combat handoff: bumping this signal appends prefilled NPC rows to
   // the mounted InitiativeTracker (the "Añadir al combate" one-tap add). The
@@ -318,7 +323,7 @@ abrir el acto.`;
           aria-label="Actos del lugar"
           className="flex min-w-0 flex-1 flex-wrap items-center gap-1"
         >
-          {visibleParts.map((part) => (
+          {visibleParts.map((part, index) => (
             <button
               key={part.id}
               type="button"
@@ -327,16 +332,41 @@ abrir el acto.`;
               aria-selected={part.id === currentPart?.id}
               onClick={() => handlePartChange(part)}
               // min-h-11 = 44px tap target (M5 sweep).
-              className={`min-h-11 rounded-md px-2.5 py-1 text-sm transition-colors ${
+              className={`flex min-h-11 items-center gap-1.5 rounded-md px-2.5 py-1 text-sm transition-colors ${
                 part.id === currentPart?.id
                   ? 'bg-muted font-medium'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {part.name}
+              {/* "ENTRADA" flags where to start: node places have no acto1, so
+                  the first available act (e.g. acto2) is the real entry point. */}
+              {index === 0 && (
+                <span
+                  data-act-entry
+                  className="rounded-sm bg-primary/15 px-1 py-0.5 text-[10px] font-semibold tracking-wide text-primary uppercase"
+                >
+                  Entrada
+                </span>
+              )}
             </button>
           ))}
         </div>
+        {/* Vista jugador: hide GM-only rails so the Plan act is safe to screen-share. */}
+        <Button
+          variant={playerView ? 'default' : 'outline'}
+          size="sm"
+          data-player-view
+          data-active={playerView || undefined}
+          aria-pressed={playerView}
+          onClick={() => setPlayerView((v) => !v)}
+          aria-label="Vista jugador"
+          title="Oculta las notas del GM para compartir pantalla"
+          className="min-h-11 whitespace-nowrap"
+        >
+          <Eye />
+          Vista jugador
+        </Button>
         <Button
           variant="outline"
           size="sm"
@@ -426,7 +456,11 @@ abrir el acto.`;
           <div className="min-h-0 flex-1 overflow-hidden">
             <TabsContent value="plan" className="m-0 h-full data-[state=active]:flex">
               {currentPart.planFile ? (
-                <RunnerMarkdown file={currentPart.planFile} loadContent={loadContent} />
+                <RunnerMarkdown
+                  file={currentPart.planFile}
+                  loadContent={loadContent}
+                  playerView={playerView}
+                />
               ) : (
                 <div className="flex h-full flex-1 items-center justify-center">
                   <p className="text-muted-foreground">Este acto no tiene archivo de plan</p>
@@ -485,6 +519,7 @@ function RunnerMarkdown({
   loadContent,
   isThreat = false,
   onAddToCombat,
+  playerView = false,
 }: {
   file: FileReference;
   loadContent: (file: FileReference) => Promise<string>;
@@ -492,6 +527,8 @@ function RunnerMarkdown({
   isThreat?: boolean;
   /** Adds N combatants parsed from `content` to the initiative tracker. */
   onAddToCombat?: (content: string, fallbackName: string, count: number) => void;
+  /** Player-safe act view: drops the GM-only rails from ActPanels. */
+  playerView?: boolean;
 }) {
   const [content, setContent] = useState<string | null>(null);
 
@@ -520,7 +557,7 @@ function RunnerMarkdown({
   const showAdd = isThreat && onAddToCombat !== undefined && hasStatblock(content);
 
   const body = isActFormat(content) ? (
-    <ActPanels content={content} />
+    <ActPanels content={content} playerView={playerView} />
   ) : (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-4xl p-6">

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -50,9 +50,33 @@ import { PartTimer } from '@/components/play/PartTimer';
 import { InitiativeTracker } from '@/components/play/InitiativeTracker';
 import { FullscreenImage } from '@/components/world/FullscreenImage';
 import { BattlemapViewer } from '@/components/world/BattlemapViewer';
+import { ScrollableTabsRow } from '@/components/world/ScrollableTabsRow';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { Grid3x3, X } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  categorizeSupportDoc,
+  SUPPORT_DOC_CATEGORY_LABEL,
+  SUPPORT_DOC_CATEGORY_ORDER,
+  type SupportDocCategory,
+} from '@/lib/world/supportDocCategory';
+import {
+  ChevronDown,
+  FileText,
+  Grid3x3,
+  Image as ImageIcon,
+  Map as MapIcon,
+  Swords,
+  User,
+  X,
+} from 'lucide-react';
 
 const CLOSE_FADE_MS = 800;
 const CLOSE_FADE_INTERVAL_MS = 50;
@@ -235,6 +259,13 @@ abrir el acto.`;
       battlemaps.length > 0 ||
       currentPart.supportDocs.length > 0);
 
+  // The support docs live behind the "Fichas" dropdown (not as flat tabs), so
+  // the current tab may be `doc-<n>` with no matching TabsTrigger. Radix still
+  // activates the matching TabsContent; this index just drives the dropdown's
+  // active highlight + trigger label.
+  const activeDocIndex =
+    currentTab.startsWith('doc-') ? Number(currentTab.slice('doc-'.length)) : -1;
+
   return (
     <div data-act-runner className="fixed inset-0 z-50 flex flex-col bg-background">
       {/* pr keeps the Cerrar button clear of AudioControls' top-right pill. */}
@@ -302,30 +333,40 @@ abrir el acto.`;
           className="flex min-h-0 flex-1 flex-col overflow-hidden"
         >
           {hasTabs && (
-            <div className="shrink-0 border-b px-4">
-              <TabsList className="h-10">
-                <TabsTrigger value="plan">Plan</TabsTrigger>
-                {currentPart.images.map((img, index) => (
-                  <TabsTrigger key={`img-${index}`} value={`image-${index}`}>
-                    {img.name}
+            <div className="flex shrink-0 items-center gap-2 border-b px-4">
+              <ScrollableTabsRow>
+                <TabsList className="h-10 w-max flex-nowrap">
+                  <TabsTrigger value="plan" className="gap-1.5">
+                    <FileText className="h-3.5 w-3.5" />
+                    Plan
                   </TabsTrigger>
-                ))}
-                {battlemaps.map((map, index) => (
-                  <TabsTrigger
-                    key={`battlemap-${index}`}
-                    value={`battlemap-${index}`}
-                    className="gap-1.5"
-                  >
-                    <Grid3x3 className="h-3.5 w-3.5" />
-                    {docTabLabel(map.name)}
-                  </TabsTrigger>
-                ))}
-                {currentPart.supportDocs.map((doc, index) => (
-                  <TabsTrigger key={`doc-${index}`} value={`doc-${index}`}>
-                    {docTabLabel(doc.name)}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+                  {currentPart.images.map((img, index) => (
+                    <TabsTrigger key={`img-${index}`} value={`image-${index}`} className="gap-1.5">
+                      <ImageIcon className="h-3.5 w-3.5" />
+                      {img.name}
+                    </TabsTrigger>
+                  ))}
+                  {battlemaps.map((map, index) => (
+                    <TabsTrigger
+                      key={`battlemap-${index}`}
+                      value={`battlemap-${index}`}
+                      className="gap-1.5"
+                    >
+                      <Grid3x3 className="h-3.5 w-3.5" />
+                      {docTabLabel(map.name)}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </ScrollableTabsRow>
+
+              {currentPart.supportDocs.length > 0 && (
+                <FichasMenu
+                  docs={currentPart.supportDocs}
+                  activeIndex={activeDocIndex}
+                  docTabLabel={docTabLabel}
+                  onSelect={(index) => handleTabChange(`doc-${index}`)}
+                />
+              )}
             </div>
           )}
 
@@ -498,4 +539,90 @@ function RunnerBattlemap({
   }
 
   return <BattlemapViewer imageUrl={imageUrl} onClose={onClose} />;
+}
+
+const CATEGORY_ICON: Record<SupportDocCategory, typeof User> = {
+  personajes: User,
+  amenazas: Swords,
+  mapas: MapIcon,
+  otros: FileText,
+};
+
+/**
+ * Fichas dropdown: collapses the many support-doc tabs (characters/, threats/,
+ * maps/*.md, …) into one grouped menu so the tab strip stops overflowing.
+ * Items are grouped by inferred category (path prefix) with a section label
+ * and icon; selecting one drives the SAME Tabs value (`doc-<index>`) the flat
+ * tabs used, so the existing <TabsContent value="doc-<index>"> renders it. The
+ * trigger highlights and names the active doc when a `doc-N` tab is open.
+ */
+function FichasMenu({
+  docs,
+  activeIndex,
+  docTabLabel,
+  onSelect,
+}: {
+  docs: FileReference[];
+  activeIndex: number;
+  docTabLabel: (name: string) => string;
+  onSelect: (index: number) => void;
+}) {
+  const isActive = activeIndex >= 0 && activeIndex < docs.length;
+  const activeDoc = isActive ? docs[activeIndex] : undefined;
+
+  // Preserve each doc's original index (the TabsContent key) while grouping.
+  const grouped = SUPPORT_DOC_CATEGORY_ORDER.map((category) => ({
+    category,
+    items: docs
+      .map((doc, index) => ({ doc, index }))
+      .filter(({ doc }) => categorizeSupportDoc(doc.path) === category),
+  })).filter((group) => group.items.length > 0);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          data-fichas-menu
+          data-active={isActive || undefined}
+          className={`flex h-8 min-h-8 shrink-0 items-center gap-1.5 rounded-md border px-2.5 text-sm whitespace-nowrap transition-colors ${
+            isActive
+              ? 'bg-muted text-foreground font-medium'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          <User className="h-3.5 w-3.5" />
+          <span className="max-w-40 truncate">
+            {activeDoc ? docTabLabel(activeDoc.name) : 'Fichas'}
+          </span>
+          <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-[60vh] w-56 overflow-y-auto">
+        {grouped.map((group, groupIndex) => {
+          const Icon = CATEGORY_ICON[group.category];
+          return (
+            <div key={group.category}>
+              {groupIndex > 0 && <DropdownMenuSeparator />}
+              <DropdownMenuLabel className="text-muted-foreground text-xs">
+                {SUPPORT_DOC_CATEGORY_LABEL[group.category]}
+              </DropdownMenuLabel>
+              {group.items.map(({ doc, index }) => (
+                <DropdownMenuItem
+                  key={`doc-${index}`}
+                  data-fichas-item
+                  data-active={index === activeIndex || undefined}
+                  onSelect={() => onSelect(index)}
+                  className={index === activeIndex ? 'bg-accent text-accent-foreground' : ''}
+                >
+                  <Icon className="h-4 w-4" />
+                  <span className="truncate">{docTabLabel(doc.name)}</span>
+                </DropdownMenuItem>
+              ))}
+            </div>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -213,6 +213,10 @@ abrir el acto.`;
     [currentTab]
   );
 
+  /** "bram_oskar.md" -> "bram oskar" — tabs read as names, not filenames. */
+  const docTabLabel = (name: string): string =>
+    name.replace(/\.md$/i, '').replace(/_/g, ' ');
+
   const handleImageClose = useCallback(() => {
     setCurrentTab(previousTab);
   }, [previousTab]);
@@ -298,7 +302,7 @@ abrir el acto.`;
                 ))}
                 {currentPart.supportDocs.map((doc, index) => (
                   <TabsTrigger key={`doc-${index}`} value={`doc-${index}`}>
-                    {doc.name}
+                    {docTabLabel(doc.name)}
                   </TabsTrigger>
                 ))}
               </TabsList>

--- a/components/world/ActRunner.tsx
+++ b/components/world/ActRunner.tsx
@@ -40,7 +40,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileReference, Part, SessionConfig } from '@/types';
-import type { EventEffect } from '@/types/world';
+import type { EventEffect, Shop, ShopItem } from '@/types/world';
 import { FileSystemManager } from '@/lib/fileSystem';
 import { AudioManager } from '@/lib/audioManager';
 import { isActFormat } from '@/lib/actFormat';
@@ -58,8 +58,17 @@ import { InitiativeTracker } from '@/components/play/InitiativeTracker';
 import { FullscreenImage } from '@/components/world/FullscreenImage';
 import { BattlemapViewer } from '@/components/world/BattlemapViewer';
 import { ScrollableTabsRow } from '@/components/world/ScrollableTabsRow';
+import { ActRunnerPartyStrip } from '@/components/world/ActRunnerPartyStrip';
+import { ShopPanel } from '@/components/world/ShopPanel';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -85,6 +94,7 @@ import {
   Map as MapIcon,
   Minus,
   Plus,
+  ShoppingCart,
   Sparkles,
   Swords,
   User,
@@ -137,6 +147,22 @@ interface ActRunnerProps {
   onApplyEffect?: (effect: EventEffect) => boolean | void;
   /** Session-gate for the apply buttons (disabled + hint when inactive). */
   sessionActive?: boolean;
+  /**
+   * Party state + callbacks for the in-act party strip (créditos + gauges).
+   * Same values/handlers the cockpit feeds the QuickLogBar — adjustments here
+   * journal identically. Omitted ⇒ no strip (e.g. an unwired caller).
+   */
+  creditos?: number;
+  medidores?: Record<string, number>;
+  medidorNames?: string[];
+  onCreditos?: (delta: number) => void;
+  onMedidor?: (nombre: string, to: number) => void;
+  /** Shops at this place (model.tiendas). Enables the Tienda button + dialog. */
+  shops?: Shop[];
+  /** Buy one unit — the SAME page handler as the cockpit ShopPanel. */
+  onBuy?: (item: ShopItem, precio: number) => void;
+  /** Resolve a pnj id to a display name (shopkeeper label). */
+  resolveName?: (id: string) => string;
 }
 
 export function ActRunner({
@@ -147,6 +173,14 @@ export function ActRunner({
   onActChange,
   onApplyEffect,
   sessionActive = false,
+  creditos,
+  medidores,
+  medidorNames,
+  onCreditos,
+  onMedidor,
+  shops,
+  onBuy,
+  resolveName,
 }: ActRunnerProps) {
   // Same visibility rule as play: trunk parts + the active path's parts.
   const visibleParts = config.parts.filter(
@@ -158,6 +192,13 @@ export function ActRunner({
     visibleParts[0]?.id ?? null
   );
   const [currentTab, setCurrentTab] = useState('plan');
+
+  // In-act shop dialog: opened from the party strip's Tienda button.
+  const [shopsOpen, setShopsOpen] = useState(false);
+  const [openShopId, setOpenShopId] = useState<string | null>(null);
+  const openShop = shops?.find((s) => s.id === openShopId) ?? null;
+  const partyStripReady =
+    creditos != null && medidores != null && medidorNames != null && !!onCreditos && !!onMedidor;
   const [previousTab, setPreviousTab] = useState('plan');
   // "Vista jugador": when ON, the Plan act view drops the GM-only rails
   // (:::gm / :::accion / :::recurso) so the GM can screen-share a player-safe
@@ -438,6 +479,81 @@ abrir el acto.`;
           Cerrar
         </Button>
       </header>
+
+      {partyStripReady && (
+        <ActRunnerPartyStrip
+          creditos={creditos!}
+          medidores={medidores!}
+          medidorNames={medidorNames!}
+          enabled={sessionActive}
+          onCreditos={onCreditos!}
+          onMedidor={onMedidor!}
+          shopCount={shops?.length ?? 0}
+          onOpenShops={() => {
+            setOpenShopId(shops && shops.length === 1 ? shops[0].id : null);
+            setShopsOpen(true);
+          }}
+        />
+      )}
+
+      {shops && shops.length > 0 && (
+        <Dialog
+          open={shopsOpen}
+          onOpenChange={(open) => {
+            setShopsOpen(open);
+            if (!open) setOpenShopId(null);
+          }}
+        >
+          <DialogContent
+            data-act-shop-dialog
+            className="flex max-h-[85vh] flex-col overflow-hidden sm:max-w-2xl"
+          >
+            <DialogHeader>
+              <DialogTitle>{openShop ? openShop.nombre : 'Tiendas'}</DialogTitle>
+              <DialogDescription className="sr-only">
+                Tienda del lugar — suministros y equipo
+              </DialogDescription>
+            </DialogHeader>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {openShop ? (
+                <ShopPanel
+                  shop={openShop}
+                  pnjNombre={
+                    openShop.pnj ? (resolveName?.(openShop.pnj) ?? openShop.pnj) : undefined
+                  }
+                  onBack={() => {
+                    if (shops.length > 1) setOpenShopId(null);
+                    else setShopsOpen(false);
+                  }}
+                  onBuy={(item, precio) => onBuy?.(item, precio)}
+                  enabled={sessionActive}
+                />
+              ) : (
+                <ul className="space-y-1">
+                  {shops.map((s) => (
+                    <li key={s.id}>
+                      <button
+                        type="button"
+                        data-act-shop-pick={s.id}
+                        onClick={() => setOpenShopId(s.id)}
+                        className="flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-sm hover:bg-accent"
+                      >
+                        <ShoppingCart className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <span className="font-medium">{s.nombre}</span>
+                        {s.pnj && (
+                          <span className="text-xs text-muted-foreground">
+                            · {resolveName?.(s.pnj) ?? s.pnj}
+                          </span>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
 
       <AudioControls
         audioManager={audioManager}

--- a/components/world/ActRunnerPartyStrip.tsx
+++ b/components/world/ActRunnerPartyStrip.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+/**
+ * ActRunnerPartyStrip — a compact party-state band for the fullscreen ActRunner.
+ *
+ * The play overlay hides the cockpit (PartyStatusBar + QuickLogBar), so while a
+ * GM runs an act they lose sight of credits/gauges and can't spend/adjust for
+ * the supply & repair beats that live INSIDE acts (e.g. porto_verne acto1
+ * "Suministros y muelle" + "Reparar el casco"). This strip mirrors the cockpit
+ * essentials — créditos (± popover) and the manifest gauges (0–5 pip popover) —
+ * plus a Tienda button — so those beats run without leaving the scene. Every
+ * adjustment flows through the SAME page callbacks as the QuickLogBar
+ * (onCreditos / onMedidor → partyStore log → journal), so it stays recorded.
+ *
+ * Read-out is always visible; adjustments are session-gated (`enabled`).
+ * Popovers open DOWNWARD (the strip sits under the header, unlike the
+ * bottom-anchored QuickLogBar whose popovers open upward).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Apple, Coins, Fuel, Gauge, LucideIcon, Rocket, ShoppingCart } from 'lucide-react';
+
+const MEDIDOR_MAX = 5;
+const DISABLED_TITLE = 'Inicia sesión para registrar';
+const CREDIT_DELTAS = [10, 50, 100, -10, -50, -100];
+
+const MEDIDOR_ICONS: Record<string, LucideIcon> = {
+  viveres: Apple,
+  combustible: Fuel,
+  nave: Rocket,
+};
+const MEDIDOR_LABELS: Record<string, string> = {
+  viveres: 'Víveres',
+  combustible: 'Combustible',
+  nave: 'Nave',
+};
+
+function medidorLabel(nombre: string): string {
+  return MEDIDOR_LABELS[nombre] ?? nombre.charAt(0).toUpperCase() + nombre.slice(1);
+}
+
+function clampPip(value: number): number {
+  return Math.max(0, Math.min(Math.round(value), MEDIDOR_MAX));
+}
+
+interface ActRunnerPartyStripProps {
+  creditos: number;
+  medidores: Record<string, number>;
+  medidorNames: string[];
+  /** Session active → adjustments allowed. Read-out shows regardless. */
+  enabled: boolean;
+  /** Signed credit delta (already GM-confirmed). */
+  onCreditos: (delta: number) => void;
+  /** Absolute new value 0-5 for the named gauge. */
+  onMedidor: (nombre: string, to: number) => void;
+  /** Shops at this place; 0 hides the Tienda button. */
+  shopCount: number;
+  onOpenShops: () => void;
+}
+
+export function ActRunnerPartyStrip({
+  creditos,
+  medidores,
+  medidorNames,
+  enabled,
+  onCreditos,
+  onMedidor,
+  shopCount,
+  onOpenShops,
+}: ActRunnerPartyStripProps) {
+  // Which popover is open: 'creditos' | medidor name | null.
+  const [open, setOpen] = useState<string | null>(null);
+  useEffect(() => {
+    if (!enabled) setOpen(null);
+  }, [enabled]);
+
+  return (
+    <div
+      data-act-party-strip
+      className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b bg-muted/30 px-4 py-1.5"
+    >
+      {/* Créditos */}
+      <Anchor
+        open={open === 'creditos'}
+        onClose={() => setOpen(null)}
+        panel={
+          <CreditosPanel
+            onDelta={(delta) => {
+              onCreditos(delta);
+              setOpen(null);
+            }}
+          />
+        }
+      >
+        <button
+          type="button"
+          data-strip-creditos
+          disabled={!enabled}
+          aria-expanded={open === 'creditos' || undefined}
+          title={enabled ? undefined : DISABLED_TITLE}
+          onClick={() => setOpen(open === 'creditos' ? null : 'creditos')}
+          className={`flex min-h-9 items-center gap-1.5 rounded-md border px-2 text-sm transition-colors disabled:opacity-60 ${
+            open === 'creditos' ? 'bg-accent' : 'hover:bg-accent/50'
+          }`}
+        >
+          <Coins className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="font-medium tabular-nums" data-strip-creditos-value={creditos}>
+            {creditos.toLocaleString('es-ES')}
+          </span>
+          <span className="text-xs text-muted-foreground">cr</span>
+        </button>
+      </Anchor>
+
+      {/* Medidores */}
+      {medidorNames.map((nombre) => {
+        const value = clampPip(medidores[nombre] ?? 0);
+        const Icon = MEDIDOR_ICONS[nombre] ?? Gauge;
+        const tone =
+          value <= 1 ? 'text-destructive' : value <= 2 ? 'text-amber-500' : 'text-muted-foreground';
+        return (
+          <Anchor
+            key={nombre}
+            open={open === nombre}
+            onClose={() => setOpen(null)}
+            panel={
+              <PipRow
+                nombre={nombre}
+                current={value}
+                onPick={(to) => {
+                  onMedidor(nombre, to);
+                  setOpen(null);
+                }}
+              />
+            }
+          >
+            <button
+              type="button"
+              data-strip-medidor={nombre}
+              data-valor={value}
+              disabled={!enabled}
+              aria-expanded={open === nombre || undefined}
+              title={enabled ? undefined : DISABLED_TITLE}
+              onClick={() => setOpen(open === nombre ? null : nombre)}
+              className={`flex min-h-9 items-center gap-1.5 rounded-md border px-2 text-sm transition-colors disabled:opacity-60 ${
+                open === nombre ? 'bg-accent' : 'hover:bg-accent/50'
+              }`}
+            >
+              <Icon className={`size-4 shrink-0 ${tone}`} aria-hidden />
+              <span className="text-xs font-medium">{medidorLabel(nombre)}</span>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {value}/{MEDIDOR_MAX}
+              </span>
+            </button>
+          </Anchor>
+        );
+      })}
+
+      {shopCount > 0 && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-strip-tienda
+          onClick={onOpenShops}
+          className="ml-auto min-h-9"
+        >
+          <ShoppingCart />
+          {shopCount > 1 ? `Tiendas (${shopCount})` : 'Tienda'}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+interface AnchorProps {
+  open: boolean;
+  onClose: () => void;
+  panel: ReactNode;
+  children: ReactNode;
+}
+
+/** Relative anchor whose panel opens downward; closes on outside click / Escape. */
+function Anchor({ open, onClose, panel, children }: AnchorProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) onClose();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div ref={ref} className="relative">
+      {children}
+      {open && (
+        <div className="absolute top-full left-0 z-50 mt-1 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+          {panel}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CreditosPanel({ onDelta }: { onDelta: (delta: number) => void }) {
+  const [custom, setCustom] = useState('');
+  const submitCustom = () => {
+    const amount = Number.parseInt(custom.replace(/−/g, '-'), 10);
+    if (!Number.isFinite(amount) || amount === 0) return;
+    onDelta(amount);
+    setCustom('');
+  };
+  return (
+    <div className="w-44 space-y-2" data-strip-creditos-menu>
+      <div className="grid grid-cols-3 gap-1">
+        {CREDIT_DELTAS.map((delta) => (
+          <Button
+            key={delta}
+            type="button"
+            variant={delta > 0 ? 'secondary' : 'outline'}
+            size="sm"
+            data-strip-delta={delta}
+            onClick={() => onDelta(delta)}
+            className={`h-11 tabular-nums ${delta < 0 ? 'text-destructive' : ''}`}
+          >
+            {delta > 0 ? `+${delta}` : delta}
+          </Button>
+        ))}
+      </div>
+      <Input
+        data-strip-creditos-custom
+        value={custom}
+        onChange={(event) => setCustom(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            submitCustom();
+          }
+        }}
+        placeholder="Cantidad… (-400)"
+        inputMode="numeric"
+        className="h-8"
+        aria-label="Cantidad de créditos"
+      />
+    </div>
+  );
+}
+
+function PipRow({
+  nombre,
+  current,
+  onPick,
+}: {
+  nombre: string;
+  current: number;
+  onPick: (to: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1" data-strip-pips={nombre}>
+      {Array.from({ length: MEDIDOR_MAX + 1 }, (_, value) => (
+        <button
+          key={value}
+          type="button"
+          data-strip-pip={value}
+          aria-pressed={value === current}
+          onClick={() => onPick(value)}
+          className={`flex size-11 items-center justify-center rounded-full border text-sm tabular-nums transition-colors hover:bg-accent hover:text-accent-foreground ${
+            value === current
+              ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
+              : value < current
+                ? 'border-primary/50'
+                : 'border-muted-foreground/40 text-muted-foreground'
+          }`}
+          title={`${medidorLabel(nombre)}: ${value}`}
+        >
+          {value}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/world/BattlemapViewer.tsx
+++ b/components/world/BattlemapViewer.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+/**
+ * BattlemapViewer — PLAYER-SAFE fullscreen battlemap viewer for /world.
+ *
+ * Like FullscreenImage, the GM projects this to the players' shared screen, so
+ * it NEVER renders the filename/title (a spoiler leak). Unlike FullscreenImage,
+ * a battlemap is meant to be interacted with at the table, so it adds:
+ *   - PAN (pointer drag) + ZOOM (wheel, clamped) of the map.
+ *   - A toggleable, adjustable square GRID OVERLAY that pans/zooms WITH the map.
+ *
+ * Player-safety replicated from FullscreenImage: the ref-counted
+ * html[data-projecting] flag (so background sonner toasts stay CSS-hidden while
+ * projecting) and close on Escape or the close affordance. The GM controls
+ * (grid toggle, cell +/-, close) DO show — a battlemap's grid is meant to be
+ * seen — but they carry no title text and stay tiny/cornered.
+ *
+ * Caller owns the object-URL lifecycle (like FullscreenImage's imageUrl prop).
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Grid3x3, Minus, Plus, X } from 'lucide-react';
+
+interface BattlemapViewerProps {
+  /** Resolved object URL (the caller owns the URL lifecycle/revocation). */
+  imageUrl: string;
+  onClose: () => void;
+}
+
+const MIN_ZOOM = 0.2;
+const MAX_ZOOM = 12;
+const ZOOM_STEP = 1.1;
+
+const MIN_CELL = 10;
+const MAX_CELL = 400;
+const CELL_STEP = 5;
+const DEFAULT_CELL = 50;
+
+/** Pixels the pointer must travel before a press counts as a pan (not a click). */
+const DRAG_THRESHOLD_PX = 3;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+interface Viewport {
+  x: number;
+  y: number;
+  k: number;
+}
+
+export function BattlemapViewer({ imageUrl, onClose }: BattlemapViewerProps) {
+  const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, k: 1 });
+  const [gridOn, setGridOn] = useState(false);
+  const [cellSize, setCellSize] = useState(DEFAULT_CELL);
+  // Grid offset in IMAGE space (pans/zooms with the map because it lives inside
+  // the same transformed layer). Alt-drag nudges it to align the grid to art.
+  const [gridOffset, setGridOffset] = useState({ x: 0, y: 0 });
+
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Escape closes (window-level, mirrors FullscreenImage).
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // PLAYER-SAFETY: ref-counted html[data-projecting] so background toasts stay
+  // hidden while a map is on the shared screen (see FullscreenImage.tsx).
+  useEffect(() => {
+    const root = document.documentElement;
+    const next = Number(root.dataset.projectingCount ?? '0') + 1;
+    root.dataset.projectingCount = String(next);
+    root.setAttribute('data-projecting', 'true');
+    return () => {
+      const left = Number(root.dataset.projectingCount ?? '1') - 1;
+      if (left <= 0) {
+        root.removeAttribute('data-projecting');
+        delete root.dataset.projectingCount;
+      } else {
+        root.dataset.projectingCount = String(left);
+      }
+    };
+  }, []);
+
+  // Wheel zoom-to-cursor. Native non-passive listener so preventDefault sticks
+  // (React delegates wheel as passive). Self-contained StarMap-style math.
+  useEffect(() => {
+    const el = contentRef.current?.parentElement;
+    if (!el) return;
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const px = event.clientX - rect.left;
+      const py = event.clientY - rect.top;
+      setViewport((v) => {
+        const factor = event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+        const nextK = clamp(v.k * factor, MIN_ZOOM, MAX_ZOOM);
+        const ratio = nextK / v.k;
+        // Keep the point under the cursor fixed while scaling.
+        return {
+          k: nextK,
+          x: px - (px - v.x) * ratio,
+          y: py - (py - v.y) * ratio,
+        };
+      });
+    };
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => el.removeEventListener('wheel', handleWheel);
+  }, []);
+
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+    moved: boolean;
+    grid: boolean;
+  } | null>(null);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      // Alt/Shift drag nudges the GRID OFFSET; a plain drag pans the map.
+      const grid = event.altKey || event.shiftKey;
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        originX: grid ? gridOffset.x : viewport.x,
+        originY: grid ? gridOffset.y : viewport.y,
+        moved: false,
+        grid,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [viewport.x, viewport.y, gridOffset.x, gridOffset.y]
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const dx = event.clientX - drag.startX;
+      const dy = event.clientY - drag.startY;
+      if (!drag.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+      drag.moved = true;
+      if (drag.grid) {
+        // Grid offset lives in image space -> divide screen delta by zoom.
+        setViewport((v) => {
+          setGridOffset({
+            x: drag.originX + dx / v.k,
+            y: drag.originY + dy / v.k,
+          });
+          return v;
+        });
+      } else {
+        setViewport((v) => ({ ...v, x: drag.originX + dx, y: drag.originY + dy }));
+      }
+    },
+    []
+  );
+
+  const handlePointerUp = useCallback((event: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+  }, []);
+
+  const adjustCell = useCallback((delta: number) => {
+    setCellSize((c) => clamp(c + delta, MIN_CELL, MAX_CELL));
+  }, []);
+
+  const patternId = 'battlemap-grid-pattern';
+
+  return (
+    <div
+      data-battlemap-viewer
+      className="fixed inset-0 z-[200] overflow-hidden bg-black"
+    >
+      {/* Map surface: pan/zoom happens here; the transformed layer holds both
+          the image and the grid so they move together. touch-none keeps the
+          browser from stealing drags for scroll/zoom gestures. */}
+      <div
+        className="absolute inset-0 cursor-grab touch-none active:cursor-grabbing"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        <div
+          ref={contentRef}
+          className="absolute top-0 left-0 origin-top-left"
+          style={{
+            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.k})`,
+          }}
+        >
+          {/* Plain <img>: object URLs need no next/image; alt stays empty on
+              purpose — no text may reach the shared screen. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt=""
+            draggable={false}
+            className="block max-w-none select-none"
+          />
+        </div>
+
+        {/* GRID OVERLAY: a full-viewport SVG whose pattern carries the SAME
+            pan/zoom as the image (scale k, translate = viewport + gridOffset*k),
+            so cells stay locked to the art. Kept OUTSIDE the transformed layer
+            so it always tiles the whole screen regardless of the image's
+            intrinsic size (a huge or not-yet-decoded map still shows a grid). */}
+        {gridOn && (
+          <svg
+            data-battlemap-grid
+            className="pointer-events-none absolute inset-0 h-full w-full"
+            width="100%"
+            height="100%"
+          >
+            <defs>
+              <pattern
+                id={patternId}
+                width={cellSize}
+                height={cellSize}
+                patternUnits="userSpaceOnUse"
+                patternTransform={`translate(${viewport.x + gridOffset.x * viewport.k}, ${
+                  viewport.y + gridOffset.y * viewport.k
+                }) scale(${viewport.k})`}
+              >
+                {/* Double stroke (dark under, light over) so lines read on any
+                    art — light or dark. Vector, so crisp at any zoom. */}
+                <path
+                  d={`M ${cellSize} 0 L 0 0 0 ${cellSize}`}
+                  fill="none"
+                  stroke="rgba(0,0,0,0.55)"
+                  strokeWidth={2}
+                />
+                <path
+                  d={`M ${cellSize} 0 L 0 0 0 ${cellSize}`}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.55)"
+                  strokeWidth={1}
+                />
+              </pattern>
+            </defs>
+            <rect width="100%" height="100%" fill={`url(#${patternId})`} />
+          </svg>
+        )}
+      </div>
+
+      {/* GM controls: tiny, cornered, semi-transparent. No title text. */}
+      <div className="absolute top-2 right-2 flex items-center gap-1 rounded-md bg-black/50 p-1 backdrop-blur-sm">
+        <button
+          type="button"
+          data-battlemap-grid-toggle
+          aria-pressed={gridOn}
+          aria-label={gridOn ? 'Ocultar cuadrícula' : 'Mostrar cuadrícula'}
+          onClick={() => setGridOn((on) => !on)}
+          className={`flex h-8 w-8 items-center justify-center rounded transition-colors ${
+            gridOn ? 'bg-white/25 text-white' : 'text-white/70 hover:bg-white/15'
+          }`}
+        >
+          <Grid3x3 className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          data-battlemap-cell-dec
+          aria-label="Reducir tamaño de celda"
+          disabled={!gridOn}
+          onClick={() => adjustCell(-CELL_STEP)}
+          className="flex h-8 w-8 items-center justify-center rounded text-white/70 transition-colors hover:bg-white/15 disabled:opacity-30"
+        >
+          <Minus className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          data-battlemap-cell-inc
+          aria-label="Aumentar tamaño de celda"
+          disabled={!gridOn}
+          onClick={() => adjustCell(CELL_STEP)}
+          className="flex h-8 w-8 items-center justify-center rounded text-white/70 transition-colors hover:bg-white/15 disabled:opacity-30"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          data-battlemap-close
+          aria-label="Cerrar mapa"
+          onClick={onClose}
+          className="flex h-8 w-8 items-center justify-center rounded text-white/70 transition-colors hover:bg-white/15"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/world/DiagnosticsPanel.tsx
+++ b/components/world/DiagnosticsPanel.tsx
@@ -27,7 +27,7 @@ export function DiagnosticsPanel({ problemas, onCopyReport }: DiagnosticsPanelPr
             : `${errores.length} ${errores.length === 1 ? 'error' : 'errores'} · ${avisos.length} ${avisos.length === 1 ? 'aviso' : 'avisos'}`}
         </div>
         <CardAction>
-          <Button variant="outline" size="sm" onClick={onCopyReport}>
+          <Button variant="outline" size="sm" onClick={onCopyReport} className="min-h-11">
             <Copy />
             Copiar informe
           </Button>

--- a/components/world/DiagnosticsPanel.tsx
+++ b/components/world/DiagnosticsPanel.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ValidationIssue } from '@/types/world';
+import { Button } from '@/components/ui/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { CheckCircle2, CircleAlert, Copy, TriangleAlert } from 'lucide-react';
+
+interface DiagnosticsPanelProps {
+  problemas: ValidationIssue[];
+  /** Copies the plain-text issue report (the app→agent bridge). */
+  onCopyReport: () => void;
+}
+
+export function DiagnosticsPanel({ problemas, onCopyReport }: DiagnosticsPanelProps) {
+  const errores = problemas.filter((issue) => issue.nivel === 'error');
+  const avisos = problemas.filter((issue) => issue.nivel === 'aviso');
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-diagnostics-panel>
+      <CardHeader className="border-b py-4">
+        <CardTitle className="text-base">Diagnóstico</CardTitle>
+        <div className="text-sm text-muted-foreground">
+          {problemas.length === 0
+            ? 'Sin problemas detectados.'
+            : `${errores.length} ${errores.length === 1 ? 'error' : 'errores'} · ${avisos.length} ${avisos.length === 1 ? 'aviso' : 'avisos'}`}
+        </div>
+        <CardAction>
+          <Button variant="outline" size="sm" onClick={onCopyReport}>
+            <Copy />
+            Copiar informe
+          </Button>
+        </CardAction>
+      </CardHeader>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <CardContent className="flex flex-col gap-4 py-4">
+          {problemas.length === 0 && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <CheckCircle2 className="size-4 text-emerald-500" aria-hidden />
+              El mundo se ha cargado sin errores ni avisos.
+            </div>
+          )}
+          {errores.length > 0 && (
+            <IssueList
+              title={`Errores (${errores.length})`}
+              icon={<CircleAlert className="size-4 text-destructive" aria-hidden />}
+              items={errores}
+            />
+          )}
+          {avisos.length > 0 && (
+            <IssueList
+              title={`Avisos (${avisos.length})`}
+              icon={<TriangleAlert className="size-4 text-amber-500" aria-hidden />}
+              items={avisos}
+            />
+          )}
+        </CardContent>
+      </ScrollArea>
+    </Card>
+  );
+}
+
+function IssueList({
+  title,
+  icon,
+  items,
+}: {
+  title: string;
+  icon: ReactNode;
+  items: ValidationIssue[];
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-1.5 text-sm font-semibold">
+        {icon}
+        {title}
+      </div>
+      <ul className="flex flex-col gap-2">
+        {items.map((issue, index) => (
+          <li
+            key={`${issue.archivo}-${index}`}
+            className="rounded-md border p-2 text-sm"
+            data-issue-level={issue.nivel}
+          >
+            <div className="font-mono text-xs break-all text-muted-foreground">{issue.archivo}</div>
+            <div>{issue.mensaje}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/world/EntityNode.tsx
+++ b/components/world/EntityNode.tsx
@@ -115,6 +115,16 @@ export function EntityNode({
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
     >
+      {/*
+       * Invisible screen-size hit disk (M3): at low zoom the painted glyph
+       * shrinks to a few pixels while the (pointer-events-none) label keeps
+       * its screen size, leaving a dead gap between them where clicks fall
+       * through to the map. This keeps the whole glyph+label block one big
+       * (~48px) tap target — plan Part B target-size requirement.
+       */}
+      <g transform={`scale(${1 / k})`}>
+        <circle r={Math.max(24, labelY)} className="fill-transparent" stroke="none" />
+      </g>
       {selected && (
         <circle
           r={NODE_RADIUS + 8}

--- a/components/world/EntityNode.tsx
+++ b/components/world/EntityNode.tsx
@@ -9,6 +9,27 @@ const NODE_RADIUS = 10;
 
 const DIAMOND_PATH = `M 0 ${-NODE_RADIUS} L ${NODE_RADIUS} 0 L 0 ${NODE_RADIUS} L ${-NODE_RADIUS} 0 Z`;
 
+/** Radius of the portal bracket arcs (between the faction ring and the selection ring). */
+const PORTAL_RADIUS = NODE_RADIUS + 6;
+
+function portalArc(startDeg: number, endDeg: number): string {
+  const point = (deg: number) => {
+    const rad = (deg * Math.PI) / 180;
+    const x = (PORTAL_RADIUS * Math.cos(rad)).toFixed(2);
+    const y = (PORTAL_RADIUS * Math.sin(rad)).toFixed(2);
+    return `${x} ${y}`;
+  };
+  // Spans stay under 180°, so large-arc is always 0; sweep 1 follows increasing angle.
+  return `M ${point(startDeg)} A ${PORTAL_RADIUS} ${PORTAL_RADIUS} 0 0 1 ${point(endDeg)}`;
+}
+
+/**
+ * Portal glyph (`acceso: portal`): two bracket arcs framing the node, with
+ * ring gaps at the top and bottom — reads as "step through here", and the
+ * gaps keep it distinct from the (closed) faction and selection rings.
+ */
+const PORTAL_ARCS = [portalArc(115, 245), portalArc(-65, 65)];
+
 /**
  * Knowledge visual encoding (plan Part B):
  * desconocido = 15%-opacity ghost, outline only · rumoreado = dashed, no fill,
@@ -44,6 +65,8 @@ interface EntityNodeProps {
   y: number;
   /** Defaults to diamond for tipo nodo/bolsillo, circle otherwise. */
   shape?: 'circle' | 'diamond';
+  /** `acceso: portal` marker: bracket arcs overlay around the node. */
+  portal?: boolean;
 }
 
 export function EntityNode({
@@ -59,6 +82,7 @@ export function EntityNode({
   x,
   y,
   shape,
+  portal,
 }: EntityNodeProps) {
   const k = useMapScale();
   const resolvedShape = shape ?? (tipo === 'nodo' || tipo === 'bolsillo' ? 'diamond' : 'circle');
@@ -107,6 +131,21 @@ export function EntityNode({
           strokeWidth={2}
           vectorEffect="non-scaling-stroke"
         />
+      )}
+      {portal && (
+        <g data-portal="true">
+          {PORTAL_ARCS.map((d) => (
+            <path
+              key={d}
+              d={d}
+              className="fill-none stroke-foreground"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              opacity={0.85}
+            />
+          ))}
+        </g>
       )}
       {resolvedShape === 'circle' ? (
         <circle

--- a/components/world/EntityNode.tsx
+++ b/components/world/EntityNode.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { MouseEvent as ReactMouseEvent } from 'react';
+import { MessageCircle, ShoppingCart } from 'lucide-react';
 import { Conocimiento } from '@/types/world';
 import { useMapScale } from './StarMap';
 
@@ -59,6 +60,12 @@ interface EntityNodeProps {
   faccionColor?: string;
   /** Actionable-leads count; > 0 renders the amber badge. */
   leadsCount?: number;
+  /**
+   * Semantic affordance badges above the node so the GM can scan a map and tell
+   * shops / info spots apart at a glance. Only pass for conocido/visitado nodes
+   * (the page gates on knowledge) — never reveal on ghost/rumor nodes.
+   */
+  affordances?: { shop?: boolean; info?: boolean };
   onSelect: (id: string) => void;
   onDrillIn: (id: string) => void;
   x: number;
@@ -77,6 +84,7 @@ export function EntityNode({
   selected,
   faccionColor,
   leadsCount,
+  affordances,
   onSelect,
   onDrillIn,
   x,
@@ -94,6 +102,32 @@ export function EntityNode({
   const screenRadius = NODE_RADIUS * k;
   const labelY = Math.max(screenRadius, 12) + 14;
   const badgeOffset = Math.max(screenRadius * 0.8, 10);
+
+  // Affordance badges: small colored discs with a lucide icon, centered ABOVE
+  // the node (label is below, amber leads badge is top-right — no overlap).
+  const affordanceBadges = [
+    affordances?.shop
+      ? {
+          key: 'shop',
+          Icon: ShoppingCart,
+          discClass: 'fill-emerald-500 stroke-background',
+        }
+      : null,
+    affordances?.info
+      ? {
+          key: 'info',
+          Icon: MessageCircle,
+          discClass: 'fill-sky-500 stroke-background',
+        }
+      : null,
+  ].filter((badge): badge is NonNullable<typeof badge> => badge !== null);
+  const AFFORDANCE_DISC_R = 8;
+  const AFFORDANCE_ICON = 11;
+  const AFFORDANCE_GAP = 3;
+  const affordanceStep = AFFORDANCE_DISC_R * 2 + AFFORDANCE_GAP;
+  // Center the row of discs above the glyph, clear of the top ring/badge.
+  const affordanceY = -(Math.max(screenRadius, 12) + AFFORDANCE_DISC_R + 6);
+  const affordanceStartX = -((affordanceBadges.length - 1) * affordanceStep) / 2;
 
   const handleClick = (event: ReactMouseEvent<SVGGElement>) => {
     event.stopPropagation();
@@ -199,6 +233,32 @@ export function EntityNode({
             </text>
           </g>
         )}
+        {affordanceBadges.map((badge, index) => {
+          const cx = affordanceStartX + index * affordanceStep;
+          const { Icon } = badge;
+          return (
+            <g
+              key={badge.key}
+              data-node-icon={badge.key}
+              transform={`translate(${cx} ${affordanceY})`}
+            >
+              <circle
+                r={AFFORDANCE_DISC_R}
+                className={badge.discClass}
+                strokeWidth={1.5}
+              />
+              <Icon
+                width={AFFORDANCE_ICON}
+                height={AFFORDANCE_ICON}
+                x={-AFFORDANCE_ICON / 2}
+                y={-AFFORDANCE_ICON / 2}
+                className="stroke-white"
+                strokeWidth={2}
+                aria-hidden
+              />
+            </g>
+          );
+        })}
       </g>
     </g>
   );

--- a/components/world/EntityNode.tsx
+++ b/components/world/EntityNode.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { Conocimiento } from '@/types/world';
+import { useMapScale } from './StarMap';
+
+/** Node glyph radius in world units (scales with zoom; labels/badges do not). */
+const NODE_RADIUS = 10;
+
+const DIAMOND_PATH = `M 0 ${-NODE_RADIUS} L ${NODE_RADIUS} 0 L 0 ${NODE_RADIUS} L ${-NODE_RADIUS} 0 Z`;
+
+/**
+ * Knowledge visual encoding (plan Part B):
+ * desconocido = 15%-opacity ghost, outline only · rumoreado = dashed, no fill,
+ * muted label · conocido = solid stroke, hollow · visitado = filled.
+ */
+const SHAPE_CLASS: Record<Conocimiento, string> = {
+  desconocido: 'fill-none stroke-foreground',
+  rumoreado: 'fill-none stroke-foreground',
+  conocido: 'fill-background stroke-foreground',
+  visitado: 'fill-primary stroke-primary',
+};
+
+const LABEL_CLASS: Record<Conocimiento, string> = {
+  desconocido: 'fill-muted-foreground',
+  rumoreado: 'fill-muted-foreground',
+  conocido: 'fill-foreground',
+  visitado: 'fill-foreground',
+};
+
+interface EntityNodeProps {
+  id: string;
+  nombre: string;
+  tipo: string;
+  conocimiento: Conocimiento;
+  selected: boolean;
+  /** Dominant-faction ring color; undefined = no ring. */
+  faccionColor?: string;
+  /** Actionable-leads count; > 0 renders the amber badge. */
+  leadsCount?: number;
+  onSelect: (id: string) => void;
+  onDrillIn: (id: string) => void;
+  x: number;
+  y: number;
+  /** Defaults to diamond for tipo nodo/bolsillo, circle otherwise. */
+  shape?: 'circle' | 'diamond';
+}
+
+export function EntityNode({
+  id,
+  nombre,
+  tipo,
+  conocimiento,
+  selected,
+  faccionColor,
+  leadsCount,
+  onSelect,
+  onDrillIn,
+  x,
+  y,
+  shape,
+}: EntityNodeProps) {
+  const k = useMapScale();
+  const resolvedShape = shape ?? (tipo === 'nodo' || tipo === 'bolsillo' ? 'diamond' : 'circle');
+  const shapeClass = SHAPE_CLASS[conocimiento];
+  const dashArray = conocimiento === 'rumoreado' ? '4 3' : undefined;
+
+  // Label/badge live in a counter-scaled (1/k) group, so their offsets are in
+  // screen pixels and must account for the on-screen size of the glyph (r·k).
+  const screenRadius = NODE_RADIUS * k;
+  const labelY = Math.max(screenRadius, 12) + 14;
+  const badgeOffset = Math.max(screenRadius * 0.8, 10);
+
+  const handleClick = (event: ReactMouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    onSelect(id);
+  };
+
+  const handleDoubleClick = (event: ReactMouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    onDrillIn(id);
+  };
+
+  return (
+    <g
+      data-entity-id={id}
+      data-knowledge={conocimiento}
+      transform={`translate(${x} ${y})`}
+      opacity={conocimiento === 'desconocido' ? 0.15 : 1}
+      className="cursor-pointer"
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+    >
+      {selected && (
+        <circle
+          r={NODE_RADIUS + 8}
+          className="fill-none stroke-ring"
+          strokeWidth={2}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+      {faccionColor && (
+        <circle
+          r={NODE_RADIUS + 4}
+          fill="none"
+          stroke={faccionColor}
+          strokeWidth={2}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+      {resolvedShape === 'circle' ? (
+        <circle
+          r={NODE_RADIUS}
+          className={shapeClass}
+          strokeWidth={2}
+          strokeDasharray={dashArray}
+          vectorEffect="non-scaling-stroke"
+        />
+      ) : (
+        <path
+          d={DIAMOND_PATH}
+          className={shapeClass}
+          strokeWidth={2}
+          strokeDasharray={dashArray}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+
+      {/* Counter-scaled overlay: constant screen-size label + leads badge. */}
+      <g transform={`scale(${1 / k})`} className="pointer-events-none select-none">
+        <text
+          y={labelY}
+          textAnchor="middle"
+          paintOrder="stroke"
+          strokeLinejoin="round"
+          strokeWidth={3}
+          className={`${LABEL_CLASS[conocimiento]} stroke-background text-[11px]`}
+        >
+          {nombre}
+        </text>
+        {leadsCount !== undefined && leadsCount > 0 && (
+          <g transform={`translate(${badgeOffset} ${-badgeOffset})`}>
+            <circle r={8} className="fill-amber-500 stroke-background" strokeWidth={1.5} />
+            <text
+              y={3}
+              textAnchor="middle"
+              className="fill-amber-950 text-[10px] font-semibold"
+            >
+              {leadsCount}
+            </text>
+          </g>
+        )}
+      </g>
+    </g>
+  );
+}

--- a/components/world/EntityPanel.tsx
+++ b/components/world/EntityPanel.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Star, User, X, ZoomIn } from 'lucide-react';
+import { Star, Store, User, X, ZoomIn } from 'lucide-react';
 
 const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
   desconocido: 'Desconocido',
@@ -50,6 +50,14 @@ export interface EntityPanelPersonaje {
   rol: NpcEntity['rol'];
   /** True when the party has not met the pnj yet (conocimiento desconocido). */
   desconocido: boolean;
+}
+
+/** One row of the "Tiendas" section: a shop located at this place. */
+export interface EntityPanelTienda {
+  id: string;
+  nombre: string;
+  /** Shopkeeper pnj display name, pre-resolved (optional). */
+  pnj?: string;
 }
 
 /**
@@ -128,6 +136,10 @@ interface EntityPanelProps {
   personajes?: EntityPanelPersonaje[];
   /** Click on a personaje row — the page switches the panel to its PnjCard. */
   onSelectPnj?: (id: string) => void;
+  /** Shops located at this place (feature — shop system); empty/undefined = no section. */
+  tiendas?: EntityPanelTienda[];
+  /** Click on a tienda row — the page swaps the panel to its ShopPanel. */
+  onSelectShop?: (id: string) => void;
   /** Resolves an entity image to an object URL (page-owned cache). */
   loadImageUrl?: (ref: FileReference) => Promise<string>;
   /** Opens the player-safe FullscreenImage viewer with a resolved URL. */
@@ -147,6 +159,8 @@ export function EntityPanel({
   isCurrentLocation = false,
   personajes = [],
   onSelectPnj,
+  tiendas = [],
+  onSelectShop,
   loadImageUrl,
   onImageZoom,
   onDrillIn,
@@ -274,6 +288,32 @@ export function EntityPanel({
                       <Badge variant="outline" className="ml-auto shrink-0 text-muted-foreground">
                         {pnj.rol}
                       </Badge>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {tiendas.length > 0 && onSelectShop && (
+            <Section title="Tiendas">
+              <ul className="flex flex-col gap-1">
+                {tiendas.map((tienda) => (
+                  <li key={tienda.id}>
+                    <button
+                      type="button"
+                      data-shop-link={tienda.id}
+                      onClick={() => onSelectShop(tienda.id)}
+                      // min-h-11 = 44px tap target (M5 sweep).
+                      className="flex min-h-11 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent"
+                    >
+                      <Store className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                      <span className="min-w-0 truncate">{tienda.nombre}</span>
+                      {tienda.pnj && (
+                        <Badge variant="outline" className="ml-auto shrink-0 text-muted-foreground">
+                          {tienda.pnj}
+                        </Badge>
+                      )}
                     </button>
                   </li>
                 ))}

--- a/components/world/EntityPanel.tsx
+++ b/components/world/EntityPanel.tsx
@@ -87,7 +87,8 @@ export function EntityPanel({
           )}
         </div>
         <CardAction>
-          <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Cerrar panel">
+          {/* size-11 = 44px tap target (M5 sweep). */}
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Cerrar panel" className="size-11">
             <X />
           </Button>
         </CardAction>
@@ -171,7 +172,7 @@ export function EntityPanel({
       {hasFooter && (
         <div className="flex items-center gap-2 border-t p-3">
           {onDrillIn && (
-            <Button variant="outline" size="sm" onClick={onDrillIn}>
+            <Button variant="outline" size="sm" onClick={onDrillIn} className="min-h-11">
               <ZoomIn />
               Entrar
             </Button>

--- a/components/world/EntityPanel.tsx
+++ b/components/world/EntityPanel.tsx
@@ -48,6 +48,11 @@ interface EntityPanelProps {
   /** Display names of factions present at the entity, pre-resolved. */
   factionNames: string[];
   leads: EntityPanelLead[];
+  /**
+   * Pistas at DESCENDANT places (for containers: sistemas / places with
+   * children) — matches the map badge, which also counts the interior.
+   */
+  interiorLeads?: EntityPanelLead[];
   onDrillIn?: () => void;
   onClose: () => void;
   /** Page-provided action buttons (Viajar / Entrar / Jugar). */
@@ -59,6 +64,7 @@ export function EntityPanel({
   childNames,
   factionNames,
   leads,
+  interiorLeads = [],
   onDrillIn,
   onClose,
   actions,
@@ -138,28 +144,13 @@ export function EntityPanel({
 
           {leads.length > 0 && (
             <Section title="Pistas">
-              <ul className="flex flex-col gap-1.5">
-                {leads.map((lead) => (
-                  <li key={lead.id} className="flex items-center gap-2 text-sm">
-                    {lead.accionable === true && (
-                      <Star
-                        className="size-3.5 shrink-0 fill-amber-400 text-amber-500"
-                        aria-label="Accionable"
-                      />
-                    )}
-                    <span className="min-w-0 truncate">{lead.nombre}</span>
-                    <Badge
-                      variant={lead.estadoPista === 'fallida' ? 'destructive' : 'outline'}
-                      className="ml-auto shrink-0"
-                    >
-                      {ESTADO_PISTA_LABEL[lead.estadoPista]}
-                    </Badge>
-                    {lead.accionable === 'manual' && (
-                      <span className="shrink-0 text-xs text-muted-foreground">según GM</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
+              <LeadList leads={leads} />
+            </Section>
+          )}
+
+          {interiorLeads.length > 0 && (
+            <Section title="Pistas en el interior">
+              <LeadList leads={interiorLeads} />
             </Section>
           )}
 
@@ -189,6 +180,33 @@ export function EntityPanel({
         </div>
       )}
     </Card>
+  );
+}
+
+function LeadList({ leads }: { leads: EntityPanelLead[] }) {
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {leads.map((lead) => (
+        <li key={lead.id} className="flex items-center gap-2 text-sm">
+          {lead.accionable === true && (
+            <Star
+              className="size-3.5 shrink-0 fill-amber-400 text-amber-500"
+              aria-label="Accionable"
+            />
+          )}
+          <span className="min-w-0 truncate">{lead.nombre}</span>
+          <Badge
+            variant={lead.estadoPista === 'fallida' ? 'destructive' : 'outline'}
+            className="ml-auto shrink-0"
+          >
+            {ESTADO_PISTA_LABEL[lead.estadoPista]}
+          </Badge>
+          {lead.accionable === 'manual' && (
+            <span className="shrink-0 text-xs text-muted-foreground">según GM</span>
+          )}
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/components/world/EntityPanel.tsx
+++ b/components/world/EntityPanel.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Conocimiento, Lead, PlaceEntity, WorldEntityBase } from '@/types/world';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Star, X, ZoomIn } from 'lucide-react';
+
+const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
+  desconocido: 'Desconocido',
+  rumoreado: 'Rumoreado',
+  conocido: 'Conocido',
+  visitado: 'Visitado',
+};
+
+const ESTADO_PISTA_LABEL: Record<Lead['estadoPista'], string> = {
+  rumor: 'Rumor',
+  activa: 'Activa',
+  en_curso: 'En curso',
+  resuelta: 'Resuelta',
+  fallida: 'Fallida',
+};
+
+const ACCESO_LABEL: Record<NonNullable<PlaceEntity['acceso']>, string> = {
+  normal: 'Acceso normal',
+  portal: 'Portal',
+  restringido: 'Restringido',
+};
+
+/** Any world entity; place-specific fields render when present. */
+export type EntityPanelEntity = WorldEntityBase &
+  Partial<Pick<PlaceEntity, 'servicios' | 'facciones' | 'acceso' | 'peligro' | 'en' | 'orbita'>>;
+
+export interface EntityPanelLead {
+  id: string;
+  nombre: string;
+  estadoPista: Lead['estadoPista'];
+  accionable: boolean | 'manual';
+}
+
+interface EntityPanelProps {
+  entity: EntityPanelEntity;
+  /** Display names of the entity's children (`en:` inverse), pre-resolved. */
+  childNames: string[];
+  /** Display names of factions present at the entity, pre-resolved. */
+  factionNames: string[];
+  leads: EntityPanelLead[];
+  onDrillIn?: () => void;
+  onClose: () => void;
+  /** Page-provided action buttons (Viajar / Entrar / Jugar). */
+  actions?: ReactNode;
+}
+
+export function EntityPanel({
+  entity,
+  childNames,
+  factionNames,
+  leads,
+  onDrillIn,
+  onClose,
+  actions,
+}: EntityPanelProps) {
+  const hasBody = entity.body.trim().length > 0;
+  const hasFooter = Boolean(onDrillIn) || Boolean(actions);
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-entity-panel={entity.id}>
+      <CardHeader className="border-b py-4">
+        <CardTitle className="text-base">{entity.nombre}</CardTitle>
+        <div className="flex flex-wrap items-center gap-1">
+          <Badge variant="secondary">{entity.tipo}</Badge>
+          <Badge variant="outline">{CONOCIMIENTO_LABEL[entity.conocimiento]}</Badge>
+          {entity.acceso && entity.acceso !== 'normal' && (
+            <Badge variant="outline">{ACCESO_LABEL[entity.acceso]}</Badge>
+          )}
+          {entity.peligro !== undefined && (
+            <Badge variant="outline">Peligro {entity.peligro}/5</Badge>
+          )}
+        </div>
+        <CardAction>
+          <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Cerrar panel">
+            <X />
+          </Button>
+        </CardAction>
+      </CardHeader>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <CardContent className="flex flex-col gap-4 py-4">
+          {entity.etiquetas.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {entity.etiquetas.map((etiqueta) => (
+                <Badge key={etiqueta} variant="outline" className="text-muted-foreground">
+                  {etiqueta}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {entity.servicios && entity.servicios.length > 0 && (
+            <Section title="Servicios">
+              <div className="flex flex-wrap gap-1">
+                {entity.servicios.map((servicio) => (
+                  <Badge key={servicio} variant="secondary">
+                    {servicio}
+                  </Badge>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {factionNames.length > 0 && (
+            <Section title="Facciones">
+              <div className="flex flex-wrap gap-1">
+                {factionNames.map((nombre) => (
+                  <Badge key={nombre} variant="outline">
+                    {nombre}
+                  </Badge>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {entity.resumen && <p className="text-sm text-muted-foreground">{entity.resumen}</p>}
+
+          {entity.estado && (
+            <div className="rounded-md border bg-muted/40 p-3">
+              <div className="mb-1 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                Situación
+              </div>
+              <p className="text-sm whitespace-pre-line">{entity.estado}</p>
+            </div>
+          )}
+
+          {hasBody && <MarkdownViewer content={entity.body} className="prose-sm" />}
+
+          {leads.length > 0 && (
+            <Section title="Pistas">
+              <ul className="flex flex-col gap-1.5">
+                {leads.map((lead) => (
+                  <li key={lead.id} className="flex items-center gap-2 text-sm">
+                    {lead.accionable === true && (
+                      <Star
+                        className="size-3.5 shrink-0 fill-amber-400 text-amber-500"
+                        aria-label="Accionable"
+                      />
+                    )}
+                    <span className="min-w-0 truncate">{lead.nombre}</span>
+                    <Badge
+                      variant={lead.estadoPista === 'fallida' ? 'destructive' : 'outline'}
+                      className="ml-auto shrink-0"
+                    >
+                      {ESTADO_PISTA_LABEL[lead.estadoPista]}
+                    </Badge>
+                    {lead.accionable === 'manual' && (
+                      <span className="shrink-0 text-xs text-muted-foreground">según GM</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {childNames.length > 0 && (
+            <Section title="Contiene">
+              <ul className="flex flex-col gap-1 text-sm">
+                {childNames.map((nombre) => (
+                  <li key={nombre} className="truncate">
+                    {nombre}
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          )}
+        </CardContent>
+      </ScrollArea>
+
+      {hasFooter && (
+        <div className="flex items-center gap-2 border-t p-3">
+          {onDrillIn && (
+            <Button variant="outline" size="sm" onClick={onDrillIn}>
+              <ZoomIn />
+              Entrar
+            </Button>
+          )}
+          {actions}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/components/world/EntityPanel.tsx
+++ b/components/world/EntityPanel.tsx
@@ -1,13 +1,15 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Conocimiento, Lead, PlaceEntity, WorldEntityBase } from '@/types/world';
+import type { FileReference } from '@/types';
+import { Conocimiento, Lead, NpcEntity, PlaceEntity, WorldEntityBase } from '@/types/world';
 import { MarkdownViewer } from '@/components/play/MarkdownViewer';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Star, X, ZoomIn } from 'lucide-react';
+import { Star, User, X, ZoomIn } from 'lucide-react';
 
 const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
   desconocido: 'Desconocido',
@@ -41,6 +43,70 @@ export interface EntityPanelLead {
   accionable: boolean | 'manual';
 }
 
+/** One row of the "Personajes" section: a pnj whose ubicacion is the entity. */
+export interface EntityPanelPersonaje {
+  id: string;
+  nombre: string;
+  rol: NpcEntity['rol'];
+  /** True when the party has not met the pnj yet (conocimiento desconocido). */
+  desconocido: boolean;
+}
+
+/**
+ * Rounded profile-image banner shared by EntityPanel and PnjCard: resolves
+ * the object URL through the page-owned cache (loadImageUrl) and opens the
+ * player-safe FullscreenImage viewer through onZoom. Renders nothing until
+ * the URL resolves (and nothing at all on a failed load).
+ */
+export function EntityImageBanner({
+  imagen,
+  nombre,
+  loadImageUrl,
+  onZoom,
+}: {
+  imagen: FileReference;
+  nombre: string;
+  loadImageUrl: (ref: FileReference) => Promise<string>;
+  onZoom: (url: string) => void;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setUrl(null);
+    loadImageUrl(imagen).then(
+      (resolved) => {
+        if (!cancelled) setUrl(resolved);
+      },
+      (error) => {
+        console.error(`Error al cargar la imagen ${imagen.path}:`, error);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [imagen, loadImageUrl]);
+
+  if (url === null) return null;
+
+  return (
+    <button
+      type="button"
+      aria-label={`Ampliar imagen de ${nombre}`}
+      className="block w-full cursor-zoom-in"
+      onClick={() => onZoom(url)}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element -- object URL */}
+      <img
+        src={url}
+        alt=""
+        data-entity-image
+        className="max-h-40 w-full rounded-lg object-cover"
+      />
+    </button>
+  );
+}
+
 interface EntityPanelProps {
   entity: EntityPanelEntity;
   /** Display names of the entity's children (`en:` inverse), pre-resolved. */
@@ -55,6 +121,17 @@ interface EntityPanelProps {
   interiorLeads?: EntityPanelLead[];
   /** True when the entity is the party's current location ("Estáis aquí"). */
   isCurrentLocation?: boolean;
+  /**
+   * Pnjs located AT the entity (ubicacion === entity.id) — GM-only view, so
+   * ALL of them list, with a muted "(desconocido)" hint on the unmet ones.
+   */
+  personajes?: EntityPanelPersonaje[];
+  /** Click on a personaje row — the page switches the panel to its PnjCard. */
+  onSelectPnj?: (id: string) => void;
+  /** Resolves an entity image to an object URL (page-owned cache). */
+  loadImageUrl?: (ref: FileReference) => Promise<string>;
+  /** Opens the player-safe FullscreenImage viewer with a resolved URL. */
+  onImageZoom?: (url: string) => void;
   onDrillIn?: () => void;
   onClose: () => void;
   /** Page-provided action buttons (Viajar / Entrar / Jugar). */
@@ -68,6 +145,10 @@ export function EntityPanel({
   leads,
   interiorLeads = [],
   isCurrentLocation = false,
+  personajes = [],
+  onSelectPnj,
+  loadImageUrl,
+  onImageZoom,
   onDrillIn,
   onClose,
   actions,
@@ -103,6 +184,15 @@ export function EntityPanel({
 
       <ScrollArea className="min-h-0 flex-1">
         <CardContent className="flex flex-col gap-4 py-4">
+          {entity.imagen && loadImageUrl && onImageZoom && (
+            <EntityImageBanner
+              imagen={entity.imagen}
+              nombre={entity.nombre}
+              loadImageUrl={loadImageUrl}
+              onZoom={onImageZoom}
+            />
+          )}
+
           {entity.etiquetas.length > 0 && (
             <div className="flex flex-wrap gap-1">
               {entity.etiquetas.map((etiqueta) => (
@@ -159,6 +249,35 @@ export function EntityPanel({
           {interiorLeads.length > 0 && (
             <Section title="Pistas en el interior">
               <LeadList leads={interiorLeads} />
+            </Section>
+          )}
+
+          {personajes.length > 0 && onSelectPnj && (
+            <Section title="Personajes">
+              <ul className="flex flex-col gap-1">
+                {personajes.map((pnj) => (
+                  <li key={pnj.id}>
+                    <button
+                      type="button"
+                      data-pnj-link={pnj.id}
+                      onClick={() => onSelectPnj(pnj.id)}
+                      // min-h-11 = 44px tap target (M5 sweep).
+                      className="flex min-h-11 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent"
+                    >
+                      <User className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                      <span className="min-w-0 truncate">{pnj.nombre}</span>
+                      {pnj.desconocido && (
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          (desconocido)
+                        </span>
+                      )}
+                      <Badge variant="outline" className="ml-auto shrink-0 text-muted-foreground">
+                        {pnj.rol}
+                      </Badge>
+                    </button>
+                  </li>
+                ))}
+              </ul>
             </Section>
           )}
 

--- a/components/world/EntityPanel.tsx
+++ b/components/world/EntityPanel.tsx
@@ -53,6 +53,8 @@ interface EntityPanelProps {
    * children) — matches the map badge, which also counts the interior.
    */
   interiorLeads?: EntityPanelLead[];
+  /** True when the entity is the party's current location ("Estáis aquí"). */
+  isCurrentLocation?: boolean;
   onDrillIn?: () => void;
   onClose: () => void;
   /** Page-provided action buttons (Viajar / Entrar / Jugar). */
@@ -65,6 +67,7 @@ export function EntityPanel({
   factionNames,
   leads,
   interiorLeads = [],
+  isCurrentLocation = false,
   onDrillIn,
   onClose,
   actions,
@@ -77,6 +80,10 @@ export function EntityPanel({
       <CardHeader className="border-b py-4">
         <CardTitle className="text-base">{entity.nombre}</CardTitle>
         <div className="flex flex-wrap items-center gap-1">
+          {isCurrentLocation && (
+            // Same badge language as the SiteList's current-location row.
+            <Badge data-entity-current>Estáis aquí</Badge>
+          )}
           <Badge variant="secondary">{entity.tipo}</Badge>
           <Badge variant="outline">{CONOCIMIENTO_LABEL[entity.conocimiento]}</Badge>
           {entity.acceso && entity.acceso !== 'normal' && (

--- a/components/world/EventDrawer.tsx
+++ b/components/world/EventDrawer.tsx
@@ -27,8 +27,17 @@
  * Bottom sheet: fixed bottom panel + translate-y transition, no new deps.
  * Test hooks: data-event-drawer (data-state open|closed), per-effect
  * data-event-effect-N (+ data-event-effect={N}), data-event-outcome on the
- * three outcome buttons (Complicación first expands the nota input; its
- * confirm button carries data-event-outcome-confirm), data-event-redraw.
+ * outcome buttons (En curso / Resuelto / Ignorado / Complicación; Complicación
+ * expands the nota input, its confirm button carries data-event-outcome-confirm),
+ * data-event-combat (Abrir combate), data-event-redraw.
+ *
+ * OUTCOMES (feature 1 "En curso"): the three closing outcomes (resuelto /
+ * ignorado / complicacion) journal the resolution AND close the drawer,
+ * dropping the event from the ongoing list. "En curso" instead PARKS the event
+ * (reports outcome en_curso, no nota) so the GM can reopen it later from the
+ * Eventos tab — it is set apart from the three closers on the outcome row.
+ * "Abrir combate" (feature 2) parks the event en_curso AND reveals the cockpit
+ * initiative affordance (onOpenCombat, wired by the page).
  *
  * draw === null while OPEN renders the empty state (data-event-empty): no
  * applicable table / empty pool — the button that opened the drawer stays
@@ -49,13 +58,15 @@ import {
   Dices,
   Image as ImageIcon,
   Music,
+  Pause,
   ScrollText,
   StickyNote,
+  Swords,
   TriangleAlert,
   X,
 } from 'lucide-react';
 
-export type EventOutcome = 'resuelto' | 'ignorado' | 'complicacion';
+export type EventOutcome = 'en_curso' | 'resuelto' | 'ignorado' | 'complicacion';
 
 export interface EventDrawerDraw {
   /** Display name of the table the event was drawn from. */
@@ -72,6 +83,11 @@ interface EventDrawerProps {
   onRedraw: () => void;
   /** Journal the resolution; nota only accompanies 'complicacion'. */
   onOutcome: (outcome: EventOutcome, nota?: string) => void;
+  /**
+   * Bridge to combat (feature 2): parks the draw en_curso, reveals the cockpit
+   * initiative affordance and closes the drawer. The page owns all three.
+   */
+  onOpenCombat: () => void;
   /** Convert one `:::efecto` line into a journal entry (caller owns makeEntry). */
   onApplyEffect: (effect: EventEffect) => void;
   /** Indexes into draw.event.efectos already applied (check + disabled). */
@@ -256,6 +272,7 @@ export function EventDrawer({
   draw,
   onRedraw,
   onOutcome,
+  onOpenCombat,
   onApplyEffect,
   appliedEffects,
   canRedraw,
@@ -289,6 +306,12 @@ export function EventDrawer({
 
   const resolve = (outcome: EventOutcome, outcomeNota?: string) => {
     onOutcome(outcome, outcomeNota);
+    onOpenChange(false);
+  };
+
+  /** Park as ongoing (no nota) and close — the thread stays reopenable. */
+  const park = () => {
+    onOutcome('en_curso');
     onOpenChange(false);
   };
 
@@ -406,8 +429,33 @@ export function EventDrawer({
             </div>
 
             <footer className="border-t px-4 py-3">
-              {/* min-h-11 = 44px tap targets on the outcome row (M5 sweep). */}
-              <div className="flex flex-wrap items-center justify-end gap-2">
+              {/* min-h-11 = 44px tap targets on the outcome row (M5 sweep).
+                  Left group PARKS the thread (En curso / Abrir combate); right
+                  group CLOSES it (Resuelto / Ignorado / Complicación). */}
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    data-event-outcome="en_curso"
+                    onClick={park}
+                    className="min-h-11"
+                  >
+                    <Pause aria-hidden />
+                    En curso
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    data-event-combat
+                    onClick={onOpenCombat}
+                    className="min-h-11"
+                  >
+                    <Swords aria-hidden />
+                    Abrir combate
+                  </Button>
+                </div>
+                <div className="flex flex-wrap items-center justify-end gap-2">
                 <Button
                   type="button"
                   data-event-outcome="resuelto"
@@ -436,6 +484,7 @@ export function EventDrawer({
                   <TriangleAlert aria-hidden />
                   Complicación
                 </Button>
+                </div>
               </div>
               {complicacionOpen && (
                 <div className="mt-2 flex items-center gap-2">

--- a/components/world/EventDrawer.tsx
+++ b/components/world/EventDrawer.tsx
@@ -1,0 +1,453 @@
+'use client';
+
+/**
+ * EventDrawer — bottom sheet showing a drawn world event (M4).
+ *
+ * Pure and props-driven: the page (via eventEngine) hands in the draw
+ * ({ tableNombre, event }); the drawer renders the event and hands back
+ * intents — onApplyEffect converts an `:::efecto` line to a journal entry
+ * (makeEntry lives with the caller), onOutcome journals the resolution,
+ * onRedraw asks the engine for another weighted draw.
+ *
+ * Rendering route for `cuerpo` (documented per the M4 task): ActPanels
+ * (components/play/ActPanels.tsx) does NOT export its internal block
+ * renderers (ReadAloud/GmNote/ActionCard are module-private; only ActPanels
+ * itself is exported), and modifying it is off-limits. So the cuerpo is
+ * parsed with the EXISTING parseAct from lib/actFormat.ts and rendered here
+ * with local callouts that mirror the ActPanels look one-for-one:
+ *   - :::leer  -> border-l-4 border-l-primary bg-primary/5 box
+ *   - :::info  -> border-l-4 border-l-muted-foreground/40 bg-muted/30 box
+ *   - :::gm    -> dashed border bg-muted/25 note
+ *   - :::accion-> rounded card with Dice5 name + field list
+ *   - :::recurso -> muted chip
+ * `:::efecto` blocks are NOT an actFormat type (parseAct would render their
+ * lines as prose), so they are stripped from the cuerpo before parsing —
+ * the effects arrive pre-parsed in event.efectos and render as buttons.
+ *
+ * Bottom sheet: fixed bottom panel + translate-y transition, no new deps.
+ * Test hooks: data-event-drawer (data-state open|closed), per-effect
+ * data-event-effect-N (+ data-event-effect={N}), data-event-outcome on the
+ * three outcome buttons (Complicación first expands the nota input; its
+ * confirm button carries data-event-outcome-confirm), data-event-redraw.
+ *
+ * draw === null while OPEN renders the empty state (data-event-empty): no
+ * applicable table / empty pool — the button that opened the drawer stays
+ * enabled by design so the GM discovers why here.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { parseAct } from '@/lib/actFormat';
+import type { ActBlock } from '@/lib/actFormat';
+import type { EventEffect, WorldEvent } from '@/types/world';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Check,
+  Dice5,
+  Dices,
+  Image as ImageIcon,
+  Music,
+  ScrollText,
+  StickyNote,
+  TriangleAlert,
+  X,
+} from 'lucide-react';
+
+export type EventOutcome = 'resuelto' | 'ignorado' | 'complicacion';
+
+export interface EventDrawerDraw {
+  /** Display name of the table the event was drawn from. */
+  tableNombre: string;
+  event: WorldEvent;
+}
+
+interface EventDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Current draw; null renders an empty (closed) sheet. */
+  draw: EventDrawerDraw | null;
+  /** Ask the engine for another weighted draw (shown only when canRedraw). */
+  onRedraw: () => void;
+  /** Journal the resolution; nota only accompanies 'complicacion'. */
+  onOutcome: (outcome: EventOutcome, nota?: string) => void;
+  /** Convert one `:::efecto` line into a journal entry (caller owns makeEntry). */
+  onApplyEffect: (effect: EventEffect) => void;
+  /** Indexes into draw.event.efectos already applied (check + disabled). */
+  appliedEffects: number[];
+  canRedraw: boolean;
+}
+
+/** `:::efecto` is not an actFormat block type — remove it before parseAct. */
+function stripEfectoBlocks(cuerpo: string): string {
+  return cuerpo.replace(/^:::efecto[^\n]*$[\s\S]*?^:::[ \t]*$/gm, '').trim();
+}
+
+function capitalize(text: string): string {
+  return text ? text.charAt(0).toUpperCase() + text.slice(1) : text;
+}
+
+/** Split an efecto value on its first `|`: machine part + free comment. */
+function splitComentario(value: string): { main: string; comentario?: string } {
+  const idx = value.indexOf('|');
+  if (idx === -1) return { main: value.trim() };
+  const comentario = value.slice(idx + 1).trim();
+  return { main: value.slice(0, idx).trim(), comentario: comentario || undefined };
+}
+
+/**
+ * Humanized one-tap button label per the M4 spec:
+ * gasto 100 -> "-100 créditos" · medidor "combustible -1" -> "Combustible -1"
+ * · sabe "nodo_central rumoreado" -> "Sabe: nodo_central rumoreado" ·
+ * pista "id estado" -> "Pista: id → estado" · nota -> "Nota: …".
+ * Unknown keys degrade to "Clave: valor" (never hides a line).
+ */
+export function effectLabel(effect: EventEffect): string {
+  const { main } = splitComentario(effect.value);
+  switch (effect.key) {
+    case 'gasto':
+      return `-${main} créditos`;
+    case 'ganancia':
+      return `+${main} créditos`;
+    case 'medidor': {
+      const match = main.match(/^(\S+)\s+([+-]?\d+)$/);
+      if (!match) return `Medidor: ${main}`;
+      const delta = Number(match[2]);
+      return `${capitalize(match[1])} ${delta >= 0 ? '+' : ''}${delta}`;
+    }
+    case 'sabe':
+      return `Sabe: ${main}`;
+    case 'pista': {
+      const match = main.match(/^(\S+)\s+(\S+)$/);
+      return match ? `Pista: ${match[1]} → ${match[2]}` : `Pista: ${main}`;
+    }
+    case 'nota':
+      return `Nota: ${main}`;
+    default:
+      return `${capitalize(effect.key)}: ${main}`;
+  }
+}
+
+// ── Act-block callouts (mirror the ActPanels module-private renderers) ──────
+
+function Md({ children, className = '' }: { children: string; className?: string }) {
+  return <MarkdownViewer content={children} className={`prose-sm ${className}`} />;
+}
+
+function ReadAloudBox({ block }: { block: ActBlock }) {
+  const isInfo = block.type === 'info';
+  return (
+    <div
+      className={`rounded-lg border-l-4 p-3 ${
+        isInfo ? 'border-l-muted-foreground/40 bg-muted/30' : 'border-l-primary bg-primary/5'
+      }`}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <ScrollText className="h-3 w-3" aria-hidden />
+        {isInfo ? 'Si preguntan' : 'Leer en voz alta'}
+      </div>
+      <Md>{block.body}</Md>
+    </div>
+  );
+}
+
+function GmNoteBox({ block }: { block: ActBlock }) {
+  return (
+    <div className="rounded-md border border-dashed bg-muted/25 px-3 py-2">
+      <div className="mb-1 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        <StickyNote className="h-3 w-3" aria-hidden /> Guía GM
+      </div>
+      <Md className="text-muted-foreground">{block.body}</Md>
+    </div>
+  );
+}
+
+function ActionCardBox({ block }: { block: ActBlock }) {
+  return (
+    <div className="space-y-2 rounded-lg border bg-card p-3 text-sm">
+      {block.name && (
+        <div className="flex items-center gap-1.5 font-semibold">
+          <Dice5 className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <span>{block.name}</span>
+        </div>
+      )}
+      {block.fields && block.fields.length > 0 ? (
+        <dl className="space-y-1.5">
+          {block.fields.map((field, i) => (
+            <div key={i} className="grid grid-cols-[5.5rem_1fr] gap-x-2">
+              <dt className="pt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                {field.key}
+              </dt>
+              <dd className="leading-snug">{field.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <Md>{block.body}</Md>
+      )}
+    </div>
+  );
+}
+
+function ResourceChipBox({ block }: { block: ActBlock }) {
+  const isMusic = block.attrs.tipo === 'musica';
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border bg-muted/60 px-2.5 py-1 text-xs text-muted-foreground">
+      {isMusic ? <Music className="h-3 w-3" aria-hidden /> : <ImageIcon className="h-3 w-3" aria-hidden />}
+      {block.body}
+    </span>
+  );
+}
+
+function BlockView({ block }: { block: ActBlock }) {
+  switch (block.type) {
+    case 'gm':
+      return <GmNoteBox block={block} />;
+    case 'accion':
+      return <ActionCardBox block={block} />;
+    case 'recurso':
+      return <ResourceChipBox block={block} />;
+    default:
+      return <ReadAloudBox block={block} />;
+  }
+}
+
+/** Event cuerpo through parseAct: preface, act-scoped blocks, then sections in order. */
+function EventBody({ cuerpo }: { cuerpo: string }) {
+  const model = useMemo(() => parseAct(stripEfectoBlocks(cuerpo)), [cuerpo]);
+  return (
+    <div className="space-y-3">
+      {model.preface && <Md className="text-muted-foreground">{model.preface}</Md>}
+      {model.actBlocks.map((block, i) => (
+        <BlockView key={`b-${i}`} block={block} />
+      ))}
+      {model.sections.map((section) => (
+        <section key={section.id} className="space-y-2">
+          <h4 className="text-sm font-semibold">{section.title}</h4>
+          {section.content.map((item, i) => {
+            if (item.kind === 'heading') {
+              return (
+                <h5 key={i} className="text-sm font-medium text-muted-foreground">
+                  {item.text}
+                </h5>
+              );
+            }
+            if (item.kind === 'prose') {
+              return (
+                <Md key={i} className="text-muted-foreground">
+                  {item.text}
+                </Md>
+              );
+            }
+            return <BlockView key={i} block={item.block} />;
+          })}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+// ── The drawer ──────────────────────────────────────────────────────────────
+
+export function EventDrawer({
+  open,
+  onOpenChange,
+  draw,
+  onRedraw,
+  onOutcome,
+  onApplyEffect,
+  appliedEffects,
+  canRedraw,
+}: EventDrawerProps) {
+  const [complicacionOpen, setComplicacionOpen] = useState(false);
+  const [nota, setNota] = useState('');
+
+  // Fresh outcome state per draw (and whenever the sheet reopens).
+  const eventId = draw?.event.id ?? null;
+  useEffect(() => {
+    setComplicacionOpen(false);
+    setNota('');
+  }, [eventId, open]);
+
+  // Escape closes (the sheet is modal-ish but keeps the page interactive).
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onOpenChange(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, onOpenChange]);
+
+  const resolve = (outcome: EventOutcome, outcomeNota?: string) => {
+    onOutcome(outcome, outcomeNota);
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <div
+        aria-hidden
+        onClick={() => onOpenChange(false)}
+        className={`fixed inset-0 z-40 bg-black/40 transition-opacity duration-300 ${
+          open ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+      />
+      <div
+        data-event-drawer
+        data-state={open ? 'open' : 'closed'}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Evento"
+        className={`fixed inset-x-0 bottom-0 z-50 mx-auto flex max-h-[75vh] w-full max-w-3xl transform-gpu flex-col rounded-t-xl border border-b-0 bg-background shadow-lg transition-transform duration-300 ${
+          open ? 'translate-y-0' : 'pointer-events-none translate-y-full'
+        }`}
+      >
+        {draw === null ? (
+          <div data-event-empty className="flex flex-col gap-3 px-4 py-6">
+            <p className="text-sm text-muted-foreground">
+              Sin tablas de eventos aplicables aquí.
+            </p>
+            <div className="flex justify-end">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cerrar
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <header className="flex items-start gap-2 border-b px-4 py-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold">{draw.event.titulo}</h3>
+                  <Badge variant="secondary" data-event-table>
+                    {draw.tableNombre}
+                  </Badge>
+                  {draw.event.etiquetas.map((etiqueta) => (
+                    <Badge key={etiqueta} variant="outline" className="text-muted-foreground">
+                      {etiqueta}
+                    </Badge>
+                  ))}
+                </div>
+                {canRedraw && (
+                  <button
+                    type="button"
+                    data-event-redraw
+                    onClick={onRedraw}
+                    className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                  >
+                    <Dices className="size-3.5" aria-hidden />
+                    Otra tirada
+                  </button>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Cerrar evento"
+                onClick={() => onOpenChange(false)}
+                className="shrink-0"
+              >
+                <X />
+              </Button>
+            </header>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+              <EventBody cuerpo={draw.event.cuerpo} />
+
+              {draw.event.efectos.length > 0 && (
+                <div className="mt-4">
+                  <p className="mb-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                    Efectos
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {draw.event.efectos.map((efecto, index) => {
+                      const applied = appliedEffects.includes(index);
+                      const { comentario } = splitComentario(efecto.value);
+                      return (
+                        <Button
+                          key={index}
+                          type="button"
+                          variant={applied ? 'secondary' : 'outline'}
+                          size="sm"
+                          disabled={applied}
+                          title={comentario}
+                          data-event-effect={index}
+                          {...{ [`data-event-effect-${index}`]: 'true' }}
+                          onClick={() => onApplyEffect(efecto)}
+                        >
+                          {applied && <Check className="text-emerald-600 dark:text-emerald-400" />}
+                          {effectLabel(efecto)}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <footer className="border-t px-4 py-3">
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                <Button
+                  type="button"
+                  data-event-outcome="resuelto"
+                  onClick={() => resolve('resuelto')}
+                >
+                  Resuelto
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  data-event-outcome="ignorado"
+                  onClick={() => resolve('ignorado')}
+                >
+                  Ignorado
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  data-event-outcome="complicacion"
+                  aria-expanded={complicacionOpen}
+                  onClick={() => setComplicacionOpen((prev) => !prev)}
+                  className="border-amber-500/40 text-amber-700 dark:text-amber-400"
+                >
+                  <TriangleAlert aria-hidden />
+                  Complicación
+                </Button>
+              </div>
+              {complicacionOpen && (
+                <div className="mt-2 flex items-center gap-2">
+                  <Input
+                    value={nota}
+                    onChange={(event) => setNota(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.preventDefault();
+                        resolve('complicacion', nota.trim() || undefined);
+                      }
+                    }}
+                    placeholder="¿Qué se complica?"
+                    aria-label="Nota de la complicación"
+                    autoFocus
+                    data-event-complicacion-nota
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    data-event-outcome-confirm="complicacion"
+                    onClick={() => resolve('complicacion', nota.trim() || undefined)}
+                    className="shrink-0"
+                  >
+                    Confirmar
+                  </Button>
+                </div>
+              )}
+            </footer>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/world/EventDrawer.tsx
+++ b/components/world/EventDrawer.tsx
@@ -270,15 +270,22 @@ export function EventDrawer({
     setNota('');
   }, [eventId, open]);
 
-  // Escape closes (the sheet is modal-ish but keeps the page interactive).
+  // Escape closes (the sheet is modal-ish but keeps the page interactive) —
+  // but with the complicación row open it only collapses THAT first: closing
+  // the whole drawer would discard the drawn event and the typed nota.
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onOpenChange(false);
+      if (event.key !== 'Escape') return;
+      if (complicacionOpen) {
+        setComplicacionOpen(false);
+        return;
+      }
+      onOpenChange(false);
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [open, onOpenChange]);
+  }, [open, onOpenChange, complicacionOpen]);
 
   const resolve = (outcome: EventOutcome, outcomeNota?: string) => {
     onOutcome(outcome, outcomeNota);
@@ -439,6 +446,12 @@ export function EventDrawer({
                       if (event.key === 'Enter') {
                         event.preventDefault();
                         resolve('complicacion', nota.trim() || undefined);
+                      } else if (event.key === 'Escape') {
+                        // Collapse the row only; the window handler is
+                        // stopped so the drawer (and the draw) survive.
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setComplicacionOpen(false);
                       }
                     }}
                     placeholder="¿Qué se complica?"

--- a/components/world/EventDrawer.tsx
+++ b/components/world/EventDrawer.tsx
@@ -96,7 +96,7 @@ interface EventDrawerProps {
 }
 
 /** `:::efecto` is not an actFormat block type — remove it before parseAct. */
-function stripEfectoBlocks(cuerpo: string): string {
+export function stripEfectoBlocks(cuerpo: string): string {
   return cuerpo.replace(/^:::efecto[^\n]*$[\s\S]*?^:::[ \t]*$/gm, '').trim();
 }
 
@@ -105,7 +105,7 @@ function capitalize(text: string): string {
 }
 
 /** Split an efecto value on its first `|`: machine part + free comment. */
-function splitComentario(value: string): { main: string; comentario?: string } {
+export function splitComentario(value: string): { main: string; comentario?: string } {
   const idx = value.indexOf('|');
   if (idx === -1) return { main: value.trim() };
   const comentario = value.slice(idx + 1).trim();

--- a/components/world/EventDrawer.tsx
+++ b/components/world/EventDrawer.tsx
@@ -310,7 +310,12 @@ export function EventDrawer({
               Sin tablas de eventos aplicables aquí.
             </p>
             <div className="flex justify-end">
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                className="min-h-11"
+              >
                 Cerrar
               </Button>
             </div>
@@ -335,7 +340,9 @@ export function EventDrawer({
                     type="button"
                     data-event-redraw
                     onClick={onRedraw}
-                    className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                    // before: pseudo extends the tap area to ~44px without
+                    // moving the header layout (M5 tap-target sweep).
+                    className="relative mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 before:absolute before:-inset-x-2 before:-inset-y-3.5 before:content-[''] hover:text-foreground hover:underline"
                   >
                     <Dices className="size-3.5" aria-hidden />
                     Otra tirada
@@ -348,7 +355,8 @@ export function EventDrawer({
                 size="icon"
                 aria-label="Cerrar evento"
                 onClick={() => onOpenChange(false)}
-                className="shrink-0"
+                // size-11 = 44px tap target (M5 sweep).
+                className="size-11 shrink-0"
               >
                 <X />
               </Button>
@@ -377,6 +385,8 @@ export function EventDrawer({
                           data-event-effect={index}
                           {...{ [`data-event-effect-${index}`]: 'true' }}
                           onClick={() => onApplyEffect(efecto)}
+                          // min-h-11 = 44px tap target (M5 sweep).
+                          className="min-h-11"
                         >
                           {applied && <Check className="text-emerald-600 dark:text-emerald-400" />}
                           {effectLabel(efecto)}
@@ -389,11 +399,13 @@ export function EventDrawer({
             </div>
 
             <footer className="border-t px-4 py-3">
+              {/* min-h-11 = 44px tap targets on the outcome row (M5 sweep). */}
               <div className="flex flex-wrap items-center justify-end gap-2">
                 <Button
                   type="button"
                   data-event-outcome="resuelto"
                   onClick={() => resolve('resuelto')}
+                  className="min-h-11"
                 >
                   Resuelto
                 </Button>
@@ -402,6 +414,7 @@ export function EventDrawer({
                   variant="outline"
                   data-event-outcome="ignorado"
                   onClick={() => resolve('ignorado')}
+                  className="min-h-11"
                 >
                   Ignorado
                 </Button>
@@ -411,7 +424,7 @@ export function EventDrawer({
                   data-event-outcome="complicacion"
                   aria-expanded={complicacionOpen}
                   onClick={() => setComplicacionOpen((prev) => !prev)}
-                  className="border-amber-500/40 text-amber-700 dark:text-amber-400"
+                  className="min-h-11 border-amber-500/40 text-amber-700 dark:text-amber-400"
                 >
                   <TriangleAlert aria-hidden />
                   Complicación
@@ -438,7 +451,7 @@ export function EventDrawer({
                     variant="outline"
                     data-event-outcome-confirm="complicacion"
                     onClick={() => resolve('complicacion', nota.trim() || undefined)}
-                    className="shrink-0"
+                    className="min-h-11 shrink-0"
                   >
                     Confirmar
                   </Button>

--- a/components/world/EventosPanel.tsx
+++ b/components/world/EventosPanel.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * EventosPanel — the "En curso" right-panel tab (feature 1).
+ *
+ * Pure and props-driven: the page derives the ongoing (parked) events from the
+ * live session journal (deriveOngoing over session.entries + model.tablas) and
+ * hands them here. Each row surfaces a parked event — a fight that started, a
+ * negotiation in progress — the GM can REOPEN to apply more efectos or pick a
+ * final outcome (which drops it from this list).
+ *
+ * Row contract (test hooks): the row carries data-ongoing-event="<tabla>#<id>"
+ * and data-ongoing-open; clicking it calls onReopen(tabla, id). An optional
+ * onResolveQuick renders a small "Resolver" shortcut (data-ongoing-resolve)
+ * that closes the thread without reopening the drawer. Empty state renders
+ * data-eventos-empty with a Spanish hint.
+ */
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Check, Clock, Swords } from 'lucide-react';
+import type { OngoingEvent } from '@/lib/world/ongoingEvents';
+
+export interface EventosPanelProps {
+  eventos: OngoingEvent[];
+  /** Reopen the parked event in the EventDrawer (apply more / final outcome). */
+  onReopen: (tabla: string, id: string) => void;
+  /** Optional one-tap resolution shortcut (closes the thread, no drawer). */
+  onResolveQuick?: (tabla: string, id: string) => void;
+}
+
+export function EventosPanel({ eventos, onReopen, onResolveQuick }: EventosPanelProps) {
+  if (eventos.length === 0) {
+    return (
+      <div
+        data-eventos-panel
+        data-eventos-empty
+        className="flex flex-1 flex-col items-center justify-center gap-2 rounded-lg border bg-card py-10 text-center"
+      >
+        <Swords className="size-6 text-muted-foreground" aria-hidden />
+        <p className="px-4 text-sm text-muted-foreground">Sin eventos en curso.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-eventos-panel className="flex min-h-0 flex-1 flex-col overflow-y-auto rounded-lg border bg-card">
+      <ul className="divide-y">
+        {eventos.map((evento) => (
+          <li key={`${evento.tabla}#${evento.id}`}>
+            <div className="flex items-start gap-2 px-3 py-2">
+              {/* The row body opens the event; a corner action closes it. */}
+              <button
+                type="button"
+                data-ongoing-event={`${evento.tabla}#${evento.id}`}
+                data-ongoing-open
+                onClick={() => onReopen(evento.tabla, evento.id)}
+                className="min-h-11 flex-1 rounded-md px-1 py-1 text-left transition-colors hover:bg-muted/60"
+              >
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-sm font-medium">{evento.titulo}</span>
+                  <Badge variant="secondary" className="text-[10px]">
+                    {evento.tablaNombre}
+                  </Badge>
+                </div>
+                <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                  <Clock className="size-3" aria-hidden />
+                  {evento.hora}
+                </div>
+              </button>
+              {onResolveQuick && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Resolver ${evento.titulo}`}
+                  title="Resolver"
+                  data-ongoing-resolve={`${evento.tabla}#${evento.id}`}
+                  onClick={() => onResolveQuick(evento.tabla, evento.id)}
+                  className="size-11 shrink-0"
+                >
+                  <Check className="text-emerald-600 dark:text-emerald-400" />
+                </Button>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/world/FullscreenImage.tsx
+++ b/components/world/FullscreenImage.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * FullscreenImage — PLAYER-SAFE fullscreen image viewer for /world.
+ *
+ * The GM projects this to the players' shared screen, so the overlay renders
+ * the image and ABSOLUTELY NOTHING ELSE: no title, no filename, no captions,
+ * no buttons, no chrome — solid black behind the image (the play-mode
+ * ImageViewer overlays the filename, which leaks GM-only info; that component
+ * stays untouched for /play). Keep it that way: any visible text added here
+ * is a spoiler on the table's screen.
+ *
+ * Closing: any click on the overlay or the Escape key. The affordance is
+ * documented for assistive tech via the overlay's aria-label ONLY (aria-label
+ * never renders visually, so the player screen stays clean).
+ */
+
+import { useEffect } from 'react';
+
+interface FullscreenImageProps {
+  /** Resolved object URL (the caller owns the URL lifecycle/revocation). */
+  imageUrl: string;
+  onClose: () => void;
+}
+
+export function FullscreenImage({ imageUrl, onClose }: FullscreenImageProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // PLAYER-SAFETY: while an image is projected to the table, mark the document
+  // so GM-only chrome that escapes the z-[200] overlay is suppressed — sonner
+  // toasts render at z-index 999999999 (above everything), so a background
+  // write/debounce firing a toast would leak onto the screen. A CSS rule in
+  // globals.css hides [data-sonner-toaster] under html[data-projecting]. A
+  // ref-count on the element keeps it correct if two viewers ever overlap.
+  useEffect(() => {
+    const root = document.documentElement;
+    const next = Number(root.dataset.projectingCount ?? '0') + 1;
+    root.dataset.projectingCount = String(next);
+    root.setAttribute('data-projecting', 'true');
+    return () => {
+      const left = Number(root.dataset.projectingCount ?? '1') - 1;
+      if (left <= 0) {
+        root.removeAttribute('data-projecting');
+        delete root.dataset.projectingCount;
+      } else {
+        root.dataset.projectingCount = String(left);
+      }
+    };
+  }, []);
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events -- Escape is handled at window level above.
+    <div
+      data-fullscreen-image
+      role="button"
+      aria-label="Imagen a pantalla completa — cierra con un clic o con Escape"
+      className="fixed inset-0 z-[200] flex cursor-pointer items-center justify-center bg-black"
+      onClick={onClose}
+    >
+      {/* Plain <img>: object URLs need no next/image pipeline, and alt stays
+          empty on purpose — no text may reach the shared screen. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={imageUrl} alt="" className="max-h-full max-w-full object-contain" />
+    </div>
+  );
+}

--- a/components/world/HilosBoard.tsx
+++ b/components/world/HilosBoard.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+/**
+ * HilosBoard — the "Hilos" (story threads) right-panel tab: the campaign's
+ * tramas (story arcs) with their child pistas, key places, factions, clock
+ * beats, plus a "Ver en el mapa" toggle that paints the trama's narrative web
+ * on the sector map. The in-app live version of the campaign's
+ * _MAPA_DE_HILOS.md cheat-sheet.
+ *
+ * Pure and props-driven (mirrors LeadsBoard): the page passes the scanned
+ * tramas, the focused trama id, a focus toggle and a place-name resolver.
+ * Tramas group by rol (principal, then secundaria, then ambiental) with a rol
+ * color accent shared with the map ThreadLayer (TRAMA_ROL_COLOR), so the tab
+ * and the painted web match.
+ *
+ * Test hooks: data-hilos-panel, data-hilo-id, data-hilo-focus (the map toggle,
+ * highlighted when focusTramaId === id), data-hilo-pista.
+ */
+
+import type { Trama } from '@/types/world';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { TRAMA_ROL_COLOR } from '@/lib/world/threads';
+import { Clock, MapPin, Star, Users } from 'lucide-react';
+
+const ROL_ORDER: Trama['rol'][] = ['principal', 'secundaria', 'ambiental'];
+
+const ROL_LABEL: Record<Trama['rol'], string> = {
+  principal: 'Principal',
+  secundaria: 'Secundaria',
+  ambiental: 'Ambiental',
+};
+
+const ESTADO_TRAMA_LABEL: Record<Trama['estadoTrama'], string> = {
+  latente: 'Latente',
+  activa: 'Activa',
+  cerrada: 'Cerrada',
+};
+
+const ESTADO_TRAMA_CLASS: Record<Trama['estadoTrama'], string> = {
+  latente: 'border-transparent bg-muted text-muted-foreground',
+  activa: 'border-transparent bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+  cerrada: 'border-transparent bg-muted text-muted-foreground line-through',
+};
+
+const ESTADO_PISTA_LABEL: Record<string, string> = {
+  rumor: 'Rumor',
+  activa: 'Activa',
+  en_curso: 'En curso',
+  resuelta: 'Resuelta',
+  fallida: 'Fallida',
+};
+
+interface HilosBoardProps {
+  tramas: Trama[];
+  /** Currently painted trama; drives the "Ver en el mapa" active state. */
+  focusTramaId: string | null;
+  /** Toggle the map web for a trama (page wires the uiStore focusTrama). */
+  onFocusTrama: (id: string) => void;
+  /** Resolves a lugar id to its display name (falls back to the id). */
+  placeNombre?: (id: string) => string | undefined;
+}
+
+export function HilosBoard({ tramas, focusTramaId, onFocusTrama, placeNombre }: HilosBoardProps) {
+  const groups = ROL_ORDER.map((rol) => ({
+    rol,
+    tramas: tramas.filter((t) => t.rol === rol),
+  })).filter((g) => g.tramas.length > 0);
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-hilos-panel>
+      {tramas.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          No hay tramas en este mundo.
+        </p>
+      ) : (
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-2">
+          {groups.map((group) => (
+            <div key={group.rol} data-hilos-group={group.rol}>
+              <p className="mb-1 px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                {ROL_LABEL[group.rol]}
+              </p>
+              <div className="space-y-2">
+                {group.tramas.map((trama) => (
+                  <TramaCard
+                    key={trama.id}
+                    trama={trama}
+                    focused={focusTramaId === trama.id}
+                    onFocusTrama={onFocusTrama}
+                    placeNombre={placeNombre}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+interface TramaCardProps {
+  trama: Trama;
+  focused: boolean;
+  onFocusTrama: (id: string) => void;
+  placeNombre?: (id: string) => string | undefined;
+}
+
+function TramaCard({ trama, focused, onFocusTrama, placeNombre }: TramaCardProps) {
+  const accent = TRAMA_ROL_COLOR[trama.rol];
+  const hasBody = trama.body.trim().length > 0;
+  const nombre = (id: string) => placeNombre?.(id) ?? id;
+
+  return (
+    <div
+      data-hilo-id={trama.id}
+      className="rounded-md border-l-4 border border-l-current bg-card p-3"
+      style={{ borderLeftColor: accent }}
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="break-words text-sm font-semibold">{trama.nombre}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            <Badge className={ESTADO_TRAMA_CLASS[trama.estadoTrama]}>
+              {ESTADO_TRAMA_LABEL[trama.estadoTrama]}
+            </Badge>
+            {trama.reloj && (
+              <span
+                data-hilo-reloj
+                className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground"
+              >
+                <Clock className="size-3 shrink-0" aria-hidden />
+                {trama.reloj.actual}/{trama.reloj.max}
+              </span>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant={focused ? 'secondary' : 'outline'}
+          size="sm"
+          data-hilo-focus={trama.id}
+          aria-pressed={focused}
+          onClick={() => onFocusTrama(trama.id)}
+          className="min-h-11 shrink-0 px-2 text-xs"
+          title="Pintar la trama en el mapa del sector"
+        >
+          <MapPin className="size-3.5" aria-hidden />
+          {focused ? 'En el mapa' : 'Ver en el mapa'}
+        </Button>
+      </div>
+
+      {trama.estado && trama.estado.trim().length > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">{trama.estado}</p>
+      )}
+
+      {trama.pistas.length > 0 && (
+        <ul className="mt-2 flex flex-col gap-1">
+          {trama.pistas.map((pista) => (
+            <li
+              key={pista.id}
+              data-hilo-pista={pista.id}
+              className="flex items-start gap-1.5 text-xs"
+            >
+              {pista.accionable === true && (
+                <Star
+                  className="mt-0.5 size-3 shrink-0 fill-amber-400 text-amber-400"
+                  aria-label="Accionable"
+                />
+              )}
+              <span className="min-w-0 flex-1 break-words">
+                {pista.nombre}
+                {pista.donde && (
+                  <span className="text-muted-foreground"> · en {nombre(pista.donde)}</span>
+                )}
+              </span>
+              <Badge variant="outline" className="shrink-0 text-[10px] text-muted-foreground">
+                {ESTADO_PISTA_LABEL[pista.estadoPista] ?? pista.estadoPista}
+              </Badge>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(trama.lugaresClave.length > 0 || trama.facciones.length > 0) && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {trama.lugaresClave.map((id) => (
+            <span
+              key={`lugar-${id}`}
+              data-hilo-lugar={id}
+              className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground"
+            >
+              <MapPin className="size-3 shrink-0" aria-hidden />
+              {nombre(id)}
+            </span>
+          ))}
+          {trama.facciones.map((id) => (
+            <span
+              key={`faccion-${id}`}
+              data-hilo-faccion={id}
+              className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground"
+            >
+              <Users className="size-3 shrink-0" aria-hidden />
+              {nombre(id)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {hasBody && (
+        <div className="mt-2 border-t pt-2">
+          <MarkdownViewer content={trama.body} className="prose-sm" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/world/JournalPanel.tsx
+++ b/components/world/JournalPanel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+/**
+ * JournalPanel — today's session entries in the right tab stack (M3, plan
+ * Part B). Read-only list (newest at the BOTTOM, auto-scrolled) plus the one
+ * editing affordance the plan allows: "Deshacer última" (the page replays the
+ * remaining entries over the session-start snapshot and rewrites the file).
+ */
+
+import { useEffect, useRef } from 'react';
+import { JournalEntry, JournalEntryType } from '@/types/world';
+import { Button } from '@/components/ui/button';
+import {
+  CalendarDays,
+  Eye,
+  Flag,
+  Gauge,
+  LucideIcon,
+  MapPin,
+  Moon,
+  Navigation,
+  Play,
+  StickyNote,
+  Target,
+  TrendingDown,
+  TrendingUp,
+  Undo2,
+  Zap,
+} from 'lucide-react';
+
+const TIPO_ICONS: Record<JournalEntryType, LucideIcon> = {
+  inicio: Play,
+  fin: Flag,
+  rumbo: Navigation,
+  llegada: MapPin,
+  gasto: TrendingDown,
+  ganancia: TrendingUp,
+  medidor: Gauge,
+  pista: Target,
+  sabe: Eye,
+  evento: Zap,
+  descanso: Moon,
+  dia: CalendarDays,
+  nota: StickyNote,
+};
+
+interface JournalPanelProps {
+  /** Today's entries, chronological (oldest first — rendered top to bottom). */
+  entries: JournalEntry[];
+  canUndo: boolean;
+  onUndo: () => void;
+  sessionActive: boolean;
+  /** Epoch ms of session start; null when no session ran yet. */
+  startedAt: number | null;
+}
+
+export function JournalPanel({
+  entries,
+  canUndo,
+  onUndo,
+  sessionActive,
+  startedAt,
+}: JournalPanelProps) {
+  const endRef = useRef<HTMLDivElement>(null);
+
+  // Newest entry lives at the bottom: keep it in view as entries append.
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [entries.length]);
+
+  return (
+    <div data-journal-panel className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Diario de sesión</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {sessionActive && startedAt !== null
+              ? `Sesión iniciada a las ${formatStartTime(startedAt)}`
+              : 'Sin sesión activa'}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-journal-undo
+          disabled={!canUndo}
+          onClick={onUndo}
+          className="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+        >
+          <Undo2 />
+          Deshacer última
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {entries.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">Sin registros aún.</p>
+        ) : (
+          <ul className="space-y-1 p-2">
+            {entries.map((entry, index) => (
+              <EntryRow key={`${index}-${entry.hora}-${entry.tipo}`} entry={entry} />
+            ))}
+          </ul>
+        )}
+        <div ref={endRef} aria-hidden />
+      </div>
+    </div>
+  );
+}
+
+function formatStartTime(startedAt: number): string {
+  return new Date(startedAt).toLocaleTimeString('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function EntryRow({ entry }: { entry: JournalEntry }) {
+  const Icon = TIPO_ICONS[entry.tipo] ?? StickyNote;
+  // Notas carry their text in `comentario` (payload empty): promote it to the
+  // main line so the row never renders blank.
+  const mainText = entry.payload || entry.comentario || '';
+  const secondary = entry.payload ? entry.comentario : undefined;
+
+  return (
+    <li
+      data-journal-entry={entry.tipo}
+      className="flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted/50"
+    >
+      <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="flex items-baseline gap-2">
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{entry.hora}</span>
+          <span
+            className={`min-w-0 break-words text-sm ${entry.payload ? 'font-mono text-[13px]' : ''}`}
+          >
+            {mainText}
+          </span>
+        </p>
+        {secondary && (
+          <p className="mt-0.5 break-words text-xs text-muted-foreground">{secondary}</p>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/components/world/JournalPanel.tsx
+++ b/components/world/JournalPanel.tsx
@@ -86,7 +86,7 @@ export function JournalPanel({
           data-journal-undo
           disabled={!canUndo}
           onClick={onUndo}
-          className="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          className="min-h-11 shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
         >
           <Undo2 />
           Deshacer última

--- a/components/world/JournalPanel.tsx
+++ b/components/world/JournalPanel.tsx
@@ -5,10 +5,25 @@
  * Part B). Read-only list (newest at the BOTTOM, auto-scrolled) plus the one
  * editing affordance the plan allows: "Deshacer última" (the page replays the
  * remaining entries over the session-start snapshot and rewrites the file).
+ *
+ * Rows render a HUMANIZED Spanish main line per entry type ("Gasto −100 cr",
+ * "Medidor víveres 3 → 1") with the raw machine payload kept as the mono
+ * secondary line — the file format is untouched, only the display changes.
  */
 
 import { useEffect, useRef } from 'react';
 import { JournalEntry, JournalEntryType } from '@/types/world';
+import {
+  parseCantidadPayload,
+  parseDescansoPayload,
+  parseDiaPayload,
+  parseEventoPayload,
+  parseInicioFinPayload,
+  parseLlegadaPayload,
+  parseMedidorPayload,
+  parseRumboPayload,
+  parseTransicionPayload,
+} from '@/lib/world/logEntries';
 import { Button } from '@/components/ui/button';
 import {
   CalendarDays,
@@ -44,11 +59,88 @@ const TIPO_ICONS: Record<JournalEntryType, LucideIcon> = {
   nota: StickyNote,
 };
 
+const MEDIDOR_LABELS: Record<string, string> = {
+  viveres: 'víveres',
+  combustible: 'combustible',
+  nave: 'nave',
+};
+
+function medidorLabel(nombre: string): string {
+  return MEDIDOR_LABELS[nombre] ?? nombre;
+}
+
+function sinUnderscores(value: string): string {
+  return value.replace(/_/g, ' ');
+}
+
+/**
+ * Humanized Spanish main line per entry type; null = no humanization (the raw
+ * payload renders as before). Unparseable payloads also fall back to raw.
+ */
+function humanizeEntry(entry: JournalEntry): string | null {
+  switch (entry.tipo) {
+    case 'gasto': {
+      const n = parseCantidadPayload(entry.payload);
+      return n === null ? null : `Gasto −${n} cr`;
+    }
+    case 'ganancia': {
+      const n = parseCantidadPayload(entry.payload);
+      return n === null ? null : `Ganancia +${n} cr`;
+    }
+    case 'medidor': {
+      const m = parseMedidorPayload(entry.payload);
+      return m === null ? null : `Medidor ${medidorLabel(m.nombre)} ${m.from} → ${m.to}`;
+    }
+    case 'pista': {
+      const t = parseTransicionPayload(entry.payload);
+      return t === null
+        ? null
+        : `Pista ${t.id} ${sinUnderscores(t.from)} → ${sinUnderscores(t.to)}`;
+    }
+    case 'sabe': {
+      const t = parseTransicionPayload(entry.payload);
+      return t === null ? null : `Sabe ${t.id} ${t.from} → ${t.to}`;
+    }
+    case 'llegada': {
+      const l = parseLlegadaPayload(entry.payload);
+      return l === null ? null : `Llegada a ${l.lugarId} — día ${l.dia}`;
+    }
+    case 'rumbo': {
+      const r = parseRumboPayload(entry.payload);
+      return r === null
+        ? null
+        : `Rumbo a ${r.destino} — ${r.dias} ${r.dias === 1 ? 'día' : 'días'}, llegada día ${r.llegadaDia}`;
+    }
+    case 'dia': {
+      const d = parseDiaPayload(entry.payload);
+      return d === null ? null : `Día ${d.from} → ${d.to}`;
+    }
+    case 'descanso': {
+      const d = parseDescansoPayload(entry.payload);
+      return d === null ? null : `Descanso ${d.dias} ${d.dias === 1 ? 'día' : 'días'}`;
+    }
+    case 'inicio':
+    case 'fin': {
+      const i = parseInicioFinPayload(entry.payload);
+      if (i === null) return null;
+      return `${entry.tipo === 'inicio' ? 'Inicio' : 'Fin'} — día ${i.dia} @ ${i.lugarId}`;
+    }
+    case 'evento': {
+      const e = parseEventoPayload(entry.payload);
+      return e === null ? null : `Evento ${e.tablaId} #${e.eventoId}`;
+    }
+    case 'nota':
+      return null; // nota's text lives in comentario (promoted below)
+  }
+}
+
 interface JournalPanelProps {
   /** Today's entries, chronological (oldest first — rendered top to bottom). */
   entries: JournalEntry[];
   canUndo: boolean;
   onUndo: () => void;
+  /** Tooltip explaining WHY undo is unavailable (mid-travel, empty, no session). */
+  undoDisabledTitle?: string;
   sessionActive: boolean;
   /** Epoch ms of session start; null when no session ran yet. */
   startedAt: number | null;
@@ -58,6 +150,7 @@ export function JournalPanel({
   entries,
   canUndo,
   onUndo,
+  undoDisabledTitle,
   sessionActive,
   startedAt,
 }: JournalPanelProps) {
@@ -79,18 +172,21 @@ export function JournalPanel({
               : 'Sin sesión activa'}
           </p>
         </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          data-journal-undo
-          disabled={!canUndo}
-          onClick={onUndo}
-          className="min-h-11 shrink-0 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
-        >
-          <Undo2 />
-          Deshacer última
-        </Button>
+        {/* Disabled buttons drop pointer events; the wrapper keeps the hint. */}
+        <span title={canUndo ? undefined : undoDisabledTitle} className="shrink-0">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-journal-undo
+            disabled={!canUndo}
+            onClick={onUndo}
+            className="min-h-11 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          >
+            <Undo2 />
+            Deshacer última
+          </Button>
+        </span>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -118,10 +214,13 @@ function formatStartTime(startedAt: number): string {
 
 function EntryRow({ entry }: { entry: JournalEntry }) {
   const Icon = TIPO_ICONS[entry.tipo] ?? StickyNote;
+  const human = humanizeEntry(entry);
   // Notas carry their text in `comentario` (payload empty): promote it to the
   // main line so the row never renders blank.
-  const mainText = entry.payload || entry.comentario || '';
-  const secondary = entry.payload ? entry.comentario : undefined;
+  const mainText = human ?? entry.payload ?? '';
+  const fallbackMain = mainText || entry.comentario || '';
+  const showRawPayload = human !== null && entry.payload !== '';
+  const comentario = entry.tipo === 'nota' ? undefined : entry.comentario;
 
   return (
     <li
@@ -133,13 +232,21 @@ function EntryRow({ entry }: { entry: JournalEntry }) {
         <p className="flex items-baseline gap-2">
           <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{entry.hora}</span>
           <span
-            className={`min-w-0 break-words text-sm ${entry.payload ? 'font-mono text-[13px]' : ''}`}
+            className={`min-w-0 break-words text-sm ${
+              human === null && entry.payload ? 'font-mono text-[13px]' : ''
+            }`}
           >
-            {mainText}
+            {fallbackMain}
           </span>
         </p>
-        {secondary && (
-          <p className="mt-0.5 break-words text-xs text-muted-foreground">{secondary}</p>
+        {(showRawPayload || comentario) && (
+          <p className="mt-0.5 break-words text-xs text-muted-foreground">
+            {showRawPayload && (
+              <span className="font-mono">{entry.payload}</span>
+            )}
+            {showRawPayload && comentario && ' · '}
+            {comentario}
+          </p>
         )}
       </div>
     </li>

--- a/components/world/LeadsBoard.tsx
+++ b/components/world/LeadsBoard.tsx
@@ -185,7 +185,7 @@ export function LeadsBoard({
             data-leads-tab={f.id}
             aria-selected={filter === f.id}
             onClick={() => setFilter(f.id)}
-            className={`flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-xs transition-colors ${
+            className={`flex min-h-11 flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-xs transition-colors ${
               filter === f.id
                 ? 'bg-background font-medium shadow-sm'
                 : 'text-muted-foreground hover:text-foreground'
@@ -269,7 +269,9 @@ function LeadRow({
                 type="button"
                 data-lead-donde={pista.donde}
                 onClick={() => onSelectPlace(pista.donde!)}
-                className="inline-flex max-w-full items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                // before: pseudo extends the tap area to ~44px without inflating
+                // the chip visually (M5 tap-target sweep).
+                className="relative inline-flex max-w-full items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors before:absolute before:-inset-x-1 before:-inset-y-2.5 before:content-[''] hover:bg-accent hover:text-foreground"
               >
                 <MapPin className="size-3 shrink-0" aria-hidden />
                 <span className="truncate">{placeNombre?.(pista.donde) ?? pista.donde}</span>
@@ -313,7 +315,9 @@ function LeadRow({
               disabled={!sessionActive}
               title={sessionActive ? undefined : 'Inicia sesión para registrar'}
               onClick={() => onTransition(pista.id, pista.estadoPista, to)}
-              className={`h-6 px-2 text-xs ${
+              // min-h-11 = 44px tap target (M5 sweep) — these are the one-tap
+              // transitions the GM hits mid-session on a tablet.
+              className={`min-h-11 px-3 text-xs ${
                 to === 'fallida' ? 'border-destructive/40 text-destructive' : ''
               }`}
             >

--- a/components/world/LeadsBoard.tsx
+++ b/components/world/LeadsBoard.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+/**
+ * LeadsBoard — full pistas board for the cockpit's right-panel "Pistas" tab
+ * (M4; replaces the page-local LeadsListCard placeholder from M3).
+ *
+ * Pure and props-driven: the page passes the scanned pistas/tramas plus
+ * diaMundo; transitions come back as (id, from, to) for the page to journal
+ * via makeEntry.pista. Clicking a "donde" chip hands the lugar id back
+ * through onSelectPlace (the page navigates the map).
+ *
+ * Filter tabs: Accionables (star) / Activas / Rumores / Cerradas, each with
+ * a count. UNIFIED badge semantics (M2 verifier TODO): the Accionables tab
+ * and every count use `accionable === true` ONLY — `accionable === 'manual'`
+ * renders the "según GM" badge on its row but never counts as accionable.
+ *
+ * Rows group by trama (trama nombre as header, in the tramas prop order);
+ * pistas without trama (or with a dangling trama id) land in a final
+ * "Sueltas" group. Allowed one-tap transitions per estado come from the
+ * exported PISTA_TRANSITIONS map (the M3 page replicated this locally — the
+ * page should now import it from here).
+ *
+ * Test hooks kept from the M3 placeholder so its e2e selectors stay valid:
+ * data-leads-panel, data-lead-id, data-lead-estado, data-lead-transition.
+ * New: data-leads-tab on the filter tabs, data-lead-donde on the place chip.
+ */
+
+import { useMemo, useState } from 'react';
+import type { Lead, Trama } from '@/types/world';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Clock, MapPin, Star } from 'lucide-react';
+
+/** Allowed one-tap estado transitions per current estado (plan Part A workflow). */
+export const PISTA_TRANSITIONS: Record<Lead['estadoPista'], Lead['estadoPista'][]> = {
+  rumor: ['activa'],
+  activa: ['en_curso', 'fallida'],
+  en_curso: ['resuelta', 'fallida'],
+  resuelta: [],
+  fallida: [],
+};
+
+export const PISTA_ESTADO_LABEL: Record<Lead['estadoPista'], string> = {
+  rumor: 'Rumor',
+  activa: 'Activa',
+  en_curso: 'En curso',
+  resuelta: 'Resuelta',
+  fallida: 'Fallida',
+};
+
+/** Estado chip color per estado (Badge className overrides). */
+const ESTADO_CHIP_CLASS: Record<Lead['estadoPista'], string> = {
+  rumor: 'border-transparent bg-muted text-muted-foreground',
+  activa: 'border-transparent bg-sky-500/15 text-sky-700 dark:text-sky-300',
+  en_curso: 'border-transparent bg-amber-500/15 text-amber-700 dark:text-amber-300',
+  resuelta: 'border-transparent bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+  fallida: 'border-transparent bg-red-500/15 text-red-700 dark:text-red-300',
+};
+
+const PISTA_ESTADO_ORDER: Record<Lead['estadoPista'], number> = {
+  activa: 0,
+  en_curso: 1,
+  rumor: 2,
+  resuelta: 3,
+  fallida: 4,
+};
+
+export type LeadsFilter = 'accionables' | 'activas' | 'rumores' | 'cerradas';
+
+const FILTERS: { id: LeadsFilter; label: string; empty: string; match: (pista: Lead) => boolean }[] = [
+  {
+    id: 'accionables',
+    label: 'Accionables',
+    empty: 'Nada accionable ahora mismo.',
+    match: (pista) => pista.accionable === true,
+  },
+  {
+    id: 'activas',
+    label: 'Activas',
+    empty: 'Sin pistas activas.',
+    match: (pista) => pista.estadoPista === 'activa' || pista.estadoPista === 'en_curso',
+  },
+  {
+    id: 'rumores',
+    label: 'Rumores',
+    empty: 'Sin rumores.',
+    match: (pista) => pista.estadoPista === 'rumor',
+  },
+  {
+    id: 'cerradas',
+    label: 'Cerradas',
+    empty: 'Sin pistas cerradas.',
+    match: (pista) => pista.estadoPista === 'resuelta' || pista.estadoPista === 'fallida',
+  },
+];
+
+interface LeadsBoardProps {
+  pistas: Lead[];
+  /** Grouping order + group headers; dangling/absent trama ids fall to "Sueltas". */
+  tramas: Trama[];
+  /** Current world day — plazo chips turn red once diaMundo > plazo. */
+  diaMundo: number;
+  /** Transitions are journaled: disabled (with a hint) until a session runs. */
+  sessionActive: boolean;
+  /** Re-render key: pista estado/accionable are mutated in place on the model. */
+  modelRev?: number;
+  onTransition: (id: string, from: Lead['estadoPista'], to: Lead['estadoPista']) => void;
+  /** Click on the donde chip — the page navigates the map to the lugar. */
+  onSelectPlace: (id: string) => void;
+  /** Resolves a lugar id to its display name for the donde chip (falls back to the id). */
+  placeNombre?: (id: string) => string | undefined;
+}
+
+interface LeadGroup {
+  key: string;
+  header: string;
+  pistas: Lead[];
+}
+
+export function LeadsBoard({
+  pistas,
+  tramas,
+  diaMundo,
+  sessionActive,
+  modelRev,
+  onTransition,
+  onSelectPlace,
+  placeNombre,
+}: LeadsBoardProps) {
+  const [filter, setFilter] = useState<LeadsFilter>('accionables');
+
+  const counts = useMemo(() => {
+    void modelRev;
+    const result = {} as Record<LeadsFilter, number>;
+    for (const f of FILTERS) result[f.id] = pistas.filter(f.match).length;
+    return result;
+  }, [pistas, modelRev]);
+
+  const activeFilter = FILTERS.find((f) => f.id === filter) ?? FILTERS[0];
+
+  const groups = useMemo<LeadGroup[]>(() => {
+    void modelRev;
+    const matched = pistas.filter(activeFilter.match).sort((a, b) => {
+      const accA = a.accionable === true ? 0 : 1;
+      const accB = b.accionable === true ? 0 : 1;
+      if (accA !== accB) return accA - accB;
+      const orderDelta = PISTA_ESTADO_ORDER[a.estadoPista] - PISTA_ESTADO_ORDER[b.estadoPista];
+      if (orderDelta !== 0) return orderDelta;
+      return a.nombre.localeCompare(b.nombre, 'es');
+    });
+    const byTrama = new Map<string, Lead[]>();
+    const sueltas: Lead[] = [];
+    const tramaIds = new Set(tramas.map((trama) => trama.id));
+    for (const pista of matched) {
+      if (pista.trama && tramaIds.has(pista.trama)) {
+        const bucket = byTrama.get(pista.trama);
+        if (bucket) bucket.push(pista);
+        else byTrama.set(pista.trama, [pista]);
+      } else {
+        sueltas.push(pista);
+      }
+    }
+    const result: LeadGroup[] = [];
+    for (const trama of tramas) {
+      const bucket = byTrama.get(trama.id);
+      if (bucket) result.push({ key: trama.id, header: trama.nombre, pistas: bucket });
+    }
+    if (sueltas.length > 0) result.push({ key: '__sueltas', header: 'Sueltas', pistas: sueltas });
+    return result;
+  }, [pistas, tramas, activeFilter, modelRev]);
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-leads-panel>
+      <div
+        role="tablist"
+        aria-label="Filtro de pistas"
+        className="flex shrink-0 gap-1 border-b bg-muted/40 p-1"
+      >
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            role="tab"
+            data-leads-tab={f.id}
+            aria-selected={filter === f.id}
+            onClick={() => setFilter(f.id)}
+            className={`flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-xs transition-colors ${
+              filter === f.id
+                ? 'bg-background font-medium shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {f.id === 'accionables' && (
+              <Star className="size-3 shrink-0 fill-amber-400 text-amber-400" aria-hidden />
+            )}
+            <span className="truncate">{f.label}</span>
+            <span className="text-[10px] tabular-nums text-muted-foreground">{counts[f.id]}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
+        {groups.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">{activeFilter.empty}</p>
+        ) : (
+          groups.map((group) => (
+            <div key={group.key} data-leads-group={group.key}>
+              <p className="mb-1 px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                {group.header}
+              </p>
+              <div className="space-y-1">
+                {group.pistas.map((pista) => (
+                  <LeadRow
+                    key={pista.id}
+                    pista={pista}
+                    diaMundo={diaMundo}
+                    sessionActive={sessionActive}
+                    onTransition={onTransition}
+                    onSelectPlace={onSelectPlace}
+                    placeNombre={placeNombre}
+                  />
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
+  );
+}
+
+interface LeadRowProps {
+  pista: Lead;
+  diaMundo: number;
+  sessionActive: boolean;
+  onTransition: (id: string, from: Lead['estadoPista'], to: Lead['estadoPista']) => void;
+  onSelectPlace: (id: string) => void;
+  placeNombre?: (id: string) => string | undefined;
+}
+
+function LeadRow({
+  pista,
+  diaMundo,
+  sessionActive,
+  onTransition,
+  onSelectPlace,
+  placeNombre,
+}: LeadRowProps) {
+  const vencida = pista.plazo !== undefined && diaMundo > pista.plazo;
+  return (
+    <div
+      data-lead-id={pista.id}
+      data-lead-estado={pista.estadoPista}
+      className="rounded-md border px-3 py-2"
+    >
+      <div className="flex items-start gap-2">
+        {pista.accionable === true && (
+          <Star
+            className="mt-0.5 size-4 shrink-0 fill-amber-400 text-amber-400"
+            aria-label="Accionable"
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="break-words text-sm font-medium">{pista.nombre}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5">
+            {pista.donde && (
+              <button
+                type="button"
+                data-lead-donde={pista.donde}
+                onClick={() => onSelectPlace(pista.donde!)}
+                className="inline-flex max-w-full items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <MapPin className="size-3 shrink-0" aria-hidden />
+                <span className="truncate">{placeNombre?.(pista.donde) ?? pista.donde}</span>
+              </button>
+            )}
+            {pista.plazo !== undefined && (
+              <span
+                data-lead-plazo={pista.plazo}
+                className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${
+                  vencida
+                    ? 'border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400'
+                    : 'bg-muted/40 text-muted-foreground'
+                }`}
+              >
+                <Clock className="size-3 shrink-0" aria-hidden />
+                Día {pista.plazo}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <Badge className={ESTADO_CHIP_CLASS[pista.estadoPista]}>
+            {PISTA_ESTADO_LABEL[pista.estadoPista]}
+          </Badge>
+          {pista.accionable === 'manual' && (
+            <Badge variant="outline" className="text-muted-foreground">
+              según GM
+            </Badge>
+          )}
+        </div>
+      </div>
+      {PISTA_TRANSITIONS[pista.estadoPista].length > 0 && (
+        <div className="mt-1.5 flex flex-wrap justify-end gap-1">
+          {PISTA_TRANSITIONS[pista.estadoPista].map((to) => (
+            <Button
+              key={to}
+              type="button"
+              variant="outline"
+              size="sm"
+              data-lead-transition={to}
+              disabled={!sessionActive}
+              title={sessionActive ? undefined : 'Inicia sesión para registrar'}
+              onClick={() => onTransition(pista.id, pista.estadoPista, to)}
+              className={`h-6 px-2 text-xs ${
+                to === 'fallida' ? 'border-destructive/40 text-destructive' : ''
+              }`}
+            >
+              {PISTA_ESTADO_LABEL[to]}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/world/LeadsBoard.tsx
+++ b/components/world/LeadsBoard.tsx
@@ -23,14 +23,26 @@
  * Test hooks kept from the M3 placeholder so its e2e selectors stay valid:
  * data-leads-panel, data-lead-id, data-lead-estado, data-lead-transition.
  * New: data-leads-tab on the filter tabs, data-lead-donde on the place chip.
+ *
+ * DETAIL VIEW: clicking a row body (data-lead-open) swaps the LIST for a
+ * LeadDetail view (data-lead-detail) below the filter tabs — chips for
+ * estado/donde/plazo, human-readable requisitos (`manual:` -> "Según GM: …";
+ * condition-grammar strings verbatim in mono), the recompensa callout and
+ * the pista BODY through MarkdownViewer (previously invisible to the GM).
+ * Back button: data-lead-back. The detail state is local, so it clears when
+ * the board unmounts (panel tab switch, entity selection — both flip
+ * panelTab away from 'pistas') and explicitly on a filter-tab click. The
+ * row's transition buttons and donde chip stopPropagation so they keep
+ * working without opening the detail.
  */
 
 import { useMemo, useState } from 'react';
 import type { Lead, Trama } from '@/types/world';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Clock, MapPin, Star } from 'lucide-react';
+import { ArrowLeft, Clock, Gift, MapPin, Star } from 'lucide-react';
 
 /** Allowed one-tap estado transitions per current estado (plan Part A workflow). */
 export const PISTA_TRANSITIONS: Record<Lead['estadoPista'], Lead['estadoPista'][]> = {
@@ -129,6 +141,9 @@ export function LeadsBoard({
   placeNombre,
 }: LeadsBoardProps) {
   const [filter, setFilter] = useState<LeadsFilter>('accionables');
+  // Open detail (null = list). Local on purpose: the board unmounts when the
+  // GM leaves the Pistas tab or selects an entity, clearing it for free.
+  const [detailId, setDetailId] = useState<string | null>(null);
 
   const counts = useMemo(() => {
     void modelRev;
@@ -138,6 +153,9 @@ export function LeadsBoard({
   }, [pistas, modelRev]);
 
   const activeFilter = FILTERS.find((f) => f.id === filter) ?? FILTERS[0];
+
+  // A stale id (re-scan replaced the pistas array) degrades to the list.
+  const detailPista = detailId ? (pistas.find((p) => p.id === detailId) ?? null) : null;
 
   const groups = useMemo<LeadGroup[]>(() => {
     void modelRev;
@@ -184,7 +202,10 @@ export function LeadsBoard({
             role="tab"
             data-leads-tab={f.id}
             aria-selected={filter === f.id}
-            onClick={() => setFilter(f.id)}
+            onClick={() => {
+              setFilter(f.id);
+              setDetailId(null); // a different tab clears the open detail
+            }}
             className={`flex min-h-11 flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-xs transition-colors ${
               filter === f.id
                 ? 'bg-background font-medium shadow-sm'
@@ -200,32 +221,48 @@ export function LeadsBoard({
         ))}
       </div>
 
-      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
-        {groups.length === 0 ? (
-          <p className="py-8 text-center text-sm text-muted-foreground">{activeFilter.empty}</p>
-        ) : (
-          groups.map((group) => (
-            <div key={group.key} data-leads-group={group.key}>
-              <p className="mb-1 px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                {group.header}
-              </p>
-              <div className="space-y-1">
-                {group.pistas.map((pista) => (
-                  <LeadRow
-                    key={pista.id}
-                    pista={pista}
-                    diaMundo={diaMundo}
-                    sessionActive={sessionActive}
-                    onTransition={onTransition}
-                    onSelectPlace={onSelectPlace}
-                    placeNombre={placeNombre}
-                  />
-                ))}
+      {detailPista ? (
+        <LeadDetail
+          pista={detailPista}
+          tramaNombre={
+            detailPista.trama
+              ? (tramas.find((t) => t.id === detailPista.trama)?.nombre ?? detailPista.trama)
+              : undefined
+          }
+          diaMundo={diaMundo}
+          onBack={() => setDetailId(null)}
+          onSelectPlace={onSelectPlace}
+          placeNombre={placeNombre}
+        />
+      ) : (
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
+          {groups.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">{activeFilter.empty}</p>
+          ) : (
+            groups.map((group) => (
+              <div key={group.key} data-leads-group={group.key}>
+                <p className="mb-1 px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {group.header}
+                </p>
+                <div className="space-y-1">
+                  {group.pistas.map((pista) => (
+                    <LeadRow
+                      key={pista.id}
+                      pista={pista}
+                      diaMundo={diaMundo}
+                      sessionActive={sessionActive}
+                      onOpen={setDetailId}
+                      onTransition={onTransition}
+                      onSelectPlace={onSelectPlace}
+                      placeNombre={placeNombre}
+                    />
+                  ))}
+                </div>
               </div>
-            </div>
-          ))
-        )}
-      </div>
+            ))
+          )}
+        </div>
+      )}
     </Card>
   );
 }
@@ -234,6 +271,8 @@ interface LeadRowProps {
   pista: Lead;
   diaMundo: number;
   sessionActive: boolean;
+  /** Row-body click: open the detail view for this pista. */
+  onOpen: (id: string) => void;
   onTransition: (id: string, from: Lead['estadoPista'], to: Lead['estadoPista']) => void;
   onSelectPlace: (id: string) => void;
   placeNombre?: (id: string) => string | undefined;
@@ -243,16 +282,30 @@ function LeadRow({
   pista,
   diaMundo,
   sessionActive,
+  onOpen,
   onTransition,
   onSelectPlace,
   placeNombre,
 }: LeadRowProps) {
   const vencida = pista.plazo !== undefined && diaMundo > pista.plazo;
   return (
+    // The whole row body opens the detail; the interactive children below
+    // (donde chip, transition buttons) stopPropagation to keep their own
+    // behavior without triggering it.
     <div
       data-lead-id={pista.id}
       data-lead-estado={pista.estadoPista}
-      className="rounded-md border px-3 py-2"
+      data-lead-open
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(pista.id)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onOpen(pista.id);
+        }
+      }}
+      className="cursor-pointer rounded-md border px-3 py-2 transition-colors hover:bg-accent/40"
     >
       <div className="flex items-start gap-2">
         {pista.accionable === true && (
@@ -268,7 +321,10 @@ function LeadRow({
               <button
                 type="button"
                 data-lead-donde={pista.donde}
-                onClick={() => onSelectPlace(pista.donde!)}
+                onClick={(event) => {
+                  event.stopPropagation(); // navigate, don't open the detail
+                  onSelectPlace(pista.donde!);
+                }}
                 // before: pseudo extends the tap area to ~44px without inflating
                 // the chip visually (M5 tap-target sweep).
                 className="relative inline-flex max-w-full items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors before:absolute before:-inset-x-1 before:-inset-y-2.5 before:content-[''] hover:bg-accent hover:text-foreground"
@@ -314,7 +370,10 @@ function LeadRow({
               data-lead-transition={to}
               disabled={!sessionActive}
               title={sessionActive ? undefined : 'Inicia sesión para registrar'}
-              onClick={() => onTransition(pista.id, pista.estadoPista, to)}
+              onClick={(event) => {
+                event.stopPropagation(); // transition, don't open the detail
+                onTransition(pista.id, pista.estadoPista, to);
+              }}
               // min-h-11 = 44px tap target (M5 sweep) — these are the one-tap
               // transitions the GM hits mid-session on a tablet.
               className={`min-h-11 px-3 text-xs ${
@@ -326,6 +385,142 @@ function LeadRow({
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+/** `manual: <texto>` requisito — never evaluated by the app, the GM decides. */
+const MANUAL_REQUISITO = /^manual\s*:\s*/;
+
+interface LeadDetailProps {
+  pista: Lead;
+  /** Display name of the pista's trama (raw id fallback); absent = suelta. */
+  tramaNombre?: string;
+  diaMundo: number;
+  onBack: () => void;
+  onSelectPlace: (id: string) => void;
+  placeNombre?: (id: string) => string | undefined;
+}
+
+/**
+ * Full pista view (replaces the list inside the Pistas tab): everything the
+ * row shows PLUS the markdown body and recompensa the GM could not see
+ * before. Requisitos render human-readable: `manual:` entries as
+ * "Según GM: …", condition-grammar strings verbatim in mono.
+ */
+function LeadDetail({
+  pista,
+  tramaNombre,
+  diaMundo,
+  onBack,
+  onSelectPlace,
+  placeNombre,
+}: LeadDetailProps) {
+  const vencida = pista.plazo !== undefined && diaMundo > pista.plazo;
+  const hasBody = pista.body.trim().length > 0;
+
+  return (
+    <div data-lead-detail={pista.id} className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b px-2 py-1.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-lead-back
+          onClick={onBack}
+          className="min-h-11"
+        >
+          <ArrowLeft />
+          Pistas
+        </Button>
+        {tramaNombre && (
+          <span className="min-w-0 truncate text-xs text-muted-foreground">{tramaNombre}</span>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-3">
+        <div className="flex items-start gap-2">
+          {pista.accionable === true && (
+            <Star
+              className="mt-0.5 size-4 shrink-0 fill-amber-400 text-amber-400"
+              aria-label="Accionable"
+            />
+          )}
+          <h3 className="min-w-0 flex-1 break-words text-base font-semibold">{pista.nombre}</h3>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge className={ESTADO_CHIP_CLASS[pista.estadoPista]}>
+            {PISTA_ESTADO_LABEL[pista.estadoPista]}
+          </Badge>
+          {pista.accionable === 'manual' && (
+            <Badge variant="outline" className="text-muted-foreground">
+              según GM
+            </Badge>
+          )}
+          {pista.donde && (
+            <button
+              type="button"
+              data-lead-donde={pista.donde}
+              onClick={() => onSelectPlace(pista.donde!)}
+              className="relative inline-flex max-w-full items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground transition-colors before:absolute before:-inset-x-1 before:-inset-y-2.5 before:content-[''] hover:bg-accent hover:text-foreground"
+            >
+              <MapPin className="size-3 shrink-0" aria-hidden />
+              <span className="truncate">{placeNombre?.(pista.donde) ?? pista.donde}</span>
+            </button>
+          )}
+          {pista.plazo !== undefined && (
+            <span
+              data-lead-plazo={pista.plazo}
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${
+                vencida
+                  ? 'border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400'
+                  : 'bg-muted/40 text-muted-foreground'
+              }`}
+            >
+              <Clock className="size-3 shrink-0" aria-hidden />
+              Día {pista.plazo}
+            </span>
+          )}
+        </div>
+
+        {pista.requisitos.length > 0 && (
+          <div>
+            <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              Requisitos
+            </p>
+            <ul className="flex flex-col gap-1 text-sm">
+              {pista.requisitos.map((req) => {
+                const trimmed = req.trim();
+                const manual = MANUAL_REQUISITO.test(trimmed);
+                return (
+                  <li key={req} className="break-words">
+                    {manual ? (
+                      <>Según GM: {trimmed.replace(MANUAL_REQUISITO, '')}</>
+                    ) : (
+                      <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                        {trimmed}
+                      </code>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        {pista.recompensa && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+            <div className="mb-1 flex items-center gap-1 text-xs font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-300">
+              <Gift className="size-3.5 shrink-0" aria-hidden />
+              Recompensa
+            </div>
+            <p className="text-sm">{pista.recompensa}</p>
+          </div>
+        )}
+
+        {hasBody && <MarkdownViewer content={pista.body} className="prose-sm" />}
+      </div>
     </div>
   );
 }

--- a/components/world/MoverDialog.tsx
+++ b/components/world/MoverDialog.tsx
@@ -17,6 +17,7 @@ import { Conocimiento } from '@/types/world';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -107,6 +108,9 @@ export function MoverDialog({
       <DialogContent className="max-w-lg" data-mover-dialog>
         <DialogHeader>
           <DialogTitle>Mover al grupo</DialogTitle>
+          <DialogDescription className="sr-only">
+            Elige el destino del grupo. Enter selecciona el primer resultado.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
           <Input

--- a/components/world/MoverDialog.tsx
+++ b/components/world/MoverDialog.tsx
@@ -96,9 +96,12 @@ export function MoverDialog({
   };
 
   // Enter picks the first movable candidate (recientes first) — 2-tap flow.
+  // Only once something was typed: a stray Enter right after opening used to
+  // journal an accidental llegada to the first Reciente.
   const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter') return;
     event.preventDefault();
+    if (query.trim() === '') return;
     const first = [...recientes, ...resto].find((lugar) => lugar.id !== currentId);
     if (first) handleMove(first.id);
   };

--- a/components/world/MoverDialog.tsx
+++ b/components/world/MoverDialog.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+/**
+ * MoverDialog — destination picker for the quick-log "Mover" action (M3).
+ * Pure and props-driven: the page passes the candidate lugares (already
+ * filtered to conocimiento != desconocido), the recent-destination ids and
+ * the current location; onMove hands back the chosen id (the page journals
+ * the llegada and applies state).
+ *
+ * Search is a simple accent-folded `includes` over nombre/id — a picker over
+ * a few dozen names needs no lunr.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { Conocimiento } from '@/types/world';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { History, MapPin } from 'lucide-react';
+
+const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
+  desconocido: 'Desconocido',
+  rumoreado: 'Rumoreado',
+  conocido: 'Conocido',
+  visitado: 'Visitado',
+};
+
+/** NFD-decompose + strip combining marks: "Estación" -> "Estacion". */
+function foldDiacritics(text: string): string {
+  return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+export interface MoverDialogLugar {
+  id: string;
+  nombre: string;
+  tipo: string;
+  conocimiento: Conocimiento;
+}
+
+interface MoverDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Candidate destinations (page passes non-desconocido lugares + sistemas). */
+  lugares: MoverDialogLugar[];
+  /** Most-recent-first destination ids; rendered as the "Recientes" section. */
+  recentIds: string[];
+  /** Current party location: rendered disabled with "Estáis aquí". */
+  currentId: string | null;
+  onMove: (id: string) => void;
+}
+
+export function MoverDialog({
+  open,
+  onOpenChange,
+  lugares,
+  recentIds,
+  currentId,
+  onMove,
+}: MoverDialogProps) {
+  const [query, setQuery] = useState('');
+
+  // Fresh search each time the dialog opens.
+  useEffect(() => {
+    if (open) setQuery('');
+  }, [open]);
+
+  const { recientes, resto } = useMemo(() => {
+    const folded = foldDiacritics(query.trim().toLowerCase());
+    const matches = (lugar: MoverDialogLugar) =>
+      folded === '' ||
+      foldDiacritics(lugar.nombre.toLowerCase()).includes(folded) ||
+      lugar.id.includes(folded);
+
+    const byId = new Map(lugares.map((lugar) => [lugar.id, lugar]));
+    const recientes = recentIds
+      .map((id) => byId.get(id))
+      .filter((lugar): lugar is MoverDialogLugar => lugar !== undefined && matches(lugar));
+    const recentSet = new Set(recientes.map((lugar) => lugar.id));
+    const resto = lugares
+      .filter((lugar) => !recentSet.has(lugar.id) && matches(lugar))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'));
+    return { recientes, resto };
+  }, [lugares, recentIds, query]);
+
+  const handleMove = (id: string) => {
+    onMove(id);
+    onOpenChange(false);
+  };
+
+  // Enter picks the first movable candidate (recientes first) — 2-tap flow.
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    const first = [...recientes, ...resto].find((lugar) => lugar.id !== currentId);
+    if (first) handleMove(first.id);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" data-mover-dialog>
+        <DialogHeader>
+          <DialogTitle>Mover al grupo</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <Input
+            placeholder="Buscar destino…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            autoFocus
+            aria-label="Buscar destino"
+          />
+
+          {recientes.length === 0 && resto.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              Sin destinos que coincidan
+            </p>
+          ) : (
+            <ScrollArea className="max-h-[50vh]">
+              <div className="space-y-3 pr-3">
+                {recientes.length > 0 && (
+                  <Section
+                    icon={<History className="size-3.5" aria-hidden />}
+                    title="Recientes"
+                    lugares={recientes}
+                    currentId={currentId}
+                    onMove={handleMove}
+                  />
+                )}
+                {resto.length > 0 && (
+                  <Section
+                    icon={<MapPin className="size-3.5" aria-hidden />}
+                    title="Todos los destinos"
+                    lugares={resto}
+                    currentId={currentId}
+                    onMove={handleMove}
+                  />
+                )}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface SectionProps {
+  icon: ReactNode;
+  title: string;
+  lugares: MoverDialogLugar[];
+  currentId: string | null;
+  onMove: (id: string) => void;
+}
+
+function Section({ icon, title, lugares, currentId, onMove }: SectionProps) {
+  return (
+    <div>
+      <p className="mb-1 flex items-center gap-1.5 px-1 text-xs font-medium text-muted-foreground">
+        {icon}
+        {title}
+      </p>
+      <div className="space-y-1">
+        {lugares.map((lugar) => {
+          const isCurrent = lugar.id === currentId;
+          return (
+            <button
+              key={lugar.id}
+              type="button"
+              data-mover-id={lugar.id}
+              disabled={isCurrent}
+              onClick={() => onMove(lugar.id)}
+              className="flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-60"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">{lugar.nombre}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {CONOCIMIENTO_LABEL[lugar.conocimiento]}
+                </span>
+              </span>
+              <Badge variant="secondary" className="shrink-0">
+                {lugar.tipo}
+              </Badge>
+              {isCurrent && (
+                <Badge variant="outline" className="shrink-0 text-muted-foreground">
+                  Estáis aquí
+                </Badge>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/world/MoverDialog.tsx
+++ b/components/world/MoverDialog.tsx
@@ -23,7 +23,6 @@ import {
 } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { History, MapPin } from 'lucide-react';
 
 const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
@@ -130,7 +129,9 @@ export function MoverDialog({
               Sin destinos que coincidan
             </p>
           ) : (
-            <ScrollArea className="max-h-[50vh]">
+            // Native scroll: the shadcn ScrollArea root has no overflow-hidden,
+            // so a long destination list visually bled through the dialog.
+            <div className="max-h-[50vh] overflow-y-auto">
               <div className="space-y-3 pr-3">
                 {recientes.length > 0 && (
                   <Section
@@ -151,7 +152,7 @@ export function MoverDialog({
                   />
                 )}
               </div>
-            </ScrollArea>
+            </div>
           )}
         </div>
       </DialogContent>

--- a/components/world/PartyMarker.tsx
+++ b/components/world/PartyMarker.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface PartyMarkerProps {
+  x: number;
+  y: number;
+}
+
+/** Pulsing double-circle marking the party's current map position. */
+export function PartyMarker({ x, y }: PartyMarkerProps) {
+  return (
+    <g
+      data-party-marker="true"
+      transform={`translate(${x} ${y})`}
+      className="pointer-events-none text-primary"
+    >
+      <circle r={14} fill="none" stroke="currentColor" strokeWidth={2} opacity={0.7}>
+        <animate attributeName="r" values="14;26" dur="1.8s" repeatCount="indefinite" />
+        <animate attributeName="opacity" values="0.7;0" dur="1.8s" repeatCount="indefinite" />
+      </circle>
+      <circle r={14} fill="none" stroke="currentColor" strokeWidth={1.5} opacity={0.45} />
+      <circle r={4} fill="currentColor" />
+    </g>
+  );
+}

--- a/components/world/PartyStatusBar.tsx
+++ b/components/world/PartyStatusBar.tsx
@@ -75,6 +75,8 @@ interface PartyStatusBarProps {
   /** Missing handler keeps the Iniciar button disabled (unwired page). */
   onStartSession?: () => void;
   onEndSession?: () => void;
+  /** Discards a TEST session: deletes its journal + rolls estado back. */
+  onDiscardSession?: () => void;
   /** Elapsed session time; the page owns the ticking interval. */
   sessionElapsedMs?: number;
   writeStatus?: SessionRuntime['writeStatus'];
@@ -96,6 +98,7 @@ export function PartyStatusBar({
   sessionActive = false,
   onStartSession,
   onEndSession,
+  onDiscardSession,
   sessionElapsedMs = 0,
   writeStatus = 'ok',
   onRetryWrites,
@@ -231,7 +234,11 @@ export function PartyStatusBar({
                 Reintentar
               </Button>
             )}
-            <EndSessionButton onEndSession={onEndSession} endSummaryPreview={endSummaryPreview} />
+            <EndSessionButton
+              onEndSession={onEndSession}
+              onDiscardSession={onDiscardSession}
+              endSummaryPreview={endSummaryPreview}
+            />
           </>
         ) : (
           <Button
@@ -253,11 +260,12 @@ export function PartyStatusBar({
 
 interface EndSessionButtonProps {
   onEndSession?: () => void;
+  onDiscardSession?: () => void;
   endSummaryPreview?: string;
 }
 
 /** "Terminar sesión" with an upward confirm popover (summary + Terminar/Cancelar). */
-function EndSessionButton({ onEndSession, endSummaryPreview }: EndSessionButtonProps) {
+function EndSessionButton({ onEndSession, onDiscardSession, endSummaryPreview }: EndSessionButtonProps) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -302,28 +310,40 @@ function EndSessionButton({ onEndSession, endSummaryPreview }: EndSessionButtonP
           {endSummaryPreview && (
             <p className="mt-1 text-xs text-muted-foreground">{endSummaryPreview}</p>
           )}
-          <div className="mt-3 flex justify-end gap-2">
+          <div className="mt-3 flex flex-col gap-2">
             <Button
               type="button"
-              variant="outline"
               size="sm"
-              onClick={() => setConfirmOpen(false)}
-              className="min-h-11"
-            >
-              Cancelar
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              data-session-end-confirm-button
+              data-session-save
               onClick={() => {
                 setConfirmOpen(false);
                 onEndSession?.();
               }}
-              className="min-h-11"
+              className="min-h-11 w-full"
             >
-              Terminar
+              Guardar sesión
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-session-discard
+              onClick={() => {
+                setConfirmOpen(false);
+                onDiscardSession?.();
+              }}
+              className="min-h-11 w-full border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              Descartar (prueba)
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirmOpen(false)}
+              className="min-h-11 w-full"
+            >
+              Cancelar
             </Button>
           </div>
         </div>

--- a/components/world/PartyStatusBar.tsx
+++ b/components/world/PartyStatusBar.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+/**
+ * PartyStatusBar — top cockpit band over the world view. READ-ONLY in M2:
+ * the layout already reserves every interaction slot (breadcrumb taps work;
+ * credits popover, gauge taps and the session button arrive in M3, which
+ * only swaps handlers in — no re-layout).
+ */
+
+import { Fragment } from 'react';
+import { PartyState } from '@/types/world';
+import { Button } from '@/components/ui/button';
+import { CalendarDays, ChevronRight, Coins, MapPin, Play } from 'lucide-react';
+
+const GAUGES: { key: string; label: string }[] = [
+  { key: 'viveres', label: 'Víveres' },
+  { key: 'combustible', label: 'Combustible' },
+  { key: 'nave', label: 'Nave' },
+];
+
+interface PartyStatusBarProps {
+  /** Party state from estado/grupo.md; null renders the slim hint bar. */
+  estado: PartyState | null;
+  /** Preformatted in-world date (page derives it from dia_mundo + manifest calendar). */
+  fecha: string;
+  /** Current location display name; fallback when no breadcrumb chain resolves. */
+  locationName: string | null;
+  /** Breadcrumb chain root -> current; each crumb taps through to the map. */
+  locationPath: { id: string; label: string }[];
+  onLocationClick: (id: string) => void;
+  /** Pips per gauge row. */
+  medidoresMax?: number;
+}
+
+export function PartyStatusBar({
+  estado,
+  fecha,
+  locationName,
+  locationPath,
+  onLocationClick,
+  medidoresMax = 5,
+}: PartyStatusBarProps) {
+  if (!estado) {
+    return (
+      <div
+        data-party-bar
+        className="flex min-h-9 items-center gap-2 border-b bg-muted/40 px-3 py-1 text-xs text-muted-foreground"
+      >
+        <MapPin className="size-3.5 shrink-0" aria-hidden />
+        <span>
+          Sin <code className="rounded bg-muted px-1">estado/grupo.md</code> — no hay datos del
+          grupo.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-party-bar
+      className="flex min-h-12 flex-wrap items-center gap-x-5 gap-y-1 border-b bg-background px-3 py-1.5"
+    >
+      {/* Ubicación */}
+      <div className="flex min-w-0 items-center gap-1.5">
+        <MapPin className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        {locationPath.length > 0 ? (
+          <nav aria-label="Ubicación" className="flex min-w-0 items-center gap-0.5">
+            {locationPath.map((crumb, index) => (
+              <Fragment key={crumb.id}>
+                {index > 0 && (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground/60" aria-hidden />
+                )}
+                <button
+                  type="button"
+                  onClick={() => onLocationClick(crumb.id)}
+                  className={`max-w-44 truncate text-sm hover:underline ${
+                    index === locationPath.length - 1
+                      ? 'font-medium'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  {crumb.label}
+                </button>
+              </Fragment>
+            ))}
+          </nav>
+        ) : (
+          <span className="truncate text-sm font-medium">
+            {locationName ?? 'Ubicación desconocida'}
+          </span>
+        )}
+      </div>
+
+      {/* Fecha */}
+      <div className="flex items-center gap-1.5 text-sm">
+        <CalendarDays className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <span>{fecha}</span>
+        <span className="text-muted-foreground" data-dia={estado.diaMundo}>
+          · día {estado.diaMundo}
+        </span>
+      </div>
+
+      {/* Créditos */}
+      <div className="flex items-center gap-1.5 text-sm">
+        <Coins className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="font-medium tabular-nums" data-creditos={estado.creditos}>
+          {estado.creditos.toLocaleString('es-ES')}
+        </span>
+        <span className="text-xs text-muted-foreground">cr</span>
+      </div>
+
+      {/* Medidores */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        {GAUGES.map((gauge) => (
+          <GaugeRow
+            key={gauge.key}
+            name={gauge.key}
+            label={gauge.label}
+            value={estado.medidores[gauge.key] ?? 0}
+            max={medidoresMax}
+          />
+        ))}
+      </div>
+
+      {/* M3 slot: Iniciar/Terminar sesión + timer + write-status dot. */}
+      <span className="ml-auto" title="Disponible en M3">
+        <Button variant="outline" size="sm" disabled>
+          <Play />
+          Iniciar sesión
+        </Button>
+      </span>
+    </div>
+  );
+}
+
+interface GaugeRowProps {
+  name: string;
+  label: string;
+  value: number;
+  max: number;
+}
+
+/** 5-pip gauge row: filled/hollow pips, amber at <=2, destructive at <=1. */
+function GaugeRow({ name, label, value, max }: GaugeRowProps) {
+  const clamped = Math.max(0, Math.min(Math.round(value), max));
+  const labelClass =
+    clamped <= 1 ? 'text-destructive' : clamped <= 2 ? 'text-amber-500' : 'text-muted-foreground';
+  const filledClass =
+    clamped <= 1 ? 'bg-destructive' : clamped <= 2 ? 'bg-amber-500' : 'bg-primary';
+
+  return (
+    <div
+      className="flex items-center gap-1.5"
+      data-medidor={name}
+      data-valor={clamped}
+      title={`${label}: ${clamped}/${max}`}
+    >
+      <span className={`text-xs font-medium ${labelClass}`}>{label}</span>
+      <div className="flex items-center gap-0.5" role="meter" aria-label={label} aria-valuenow={clamped} aria-valuemin={0} aria-valuemax={max}>
+        {Array.from({ length: max }, (_, index) => (
+          <span
+            key={index}
+            className={`size-2 rounded-full ${
+              index < clamped ? filledClass : 'border border-muted-foreground/40'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/world/PartyStatusBar.tsx
+++ b/components/world/PartyStatusBar.tsx
@@ -54,6 +54,11 @@ function formatElapsed(ms: number): string {
 interface PartyStatusBarProps {
   /** Party state from estado/grupo.md; null renders the slim hint bar. */
   estado: PartyState | null;
+  /**
+   * Creates estado/grupo.md with the defaults (B1 fix: without the file the
+   * whole cockpit is dead-ended). Rendered as a CTA on the null-estado bar.
+   */
+  onCreateEstado?: () => void;
   /** Preformatted in-world date (page derives it from dia_mundo + manifest calendar). */
   fecha: string;
   /** Current location display name; fallback when no breadcrumb chain resolves. */
@@ -81,6 +86,7 @@ interface PartyStatusBarProps {
 
 export function PartyStatusBar({
   estado,
+  onCreateEstado,
   fecha,
   locationName,
   locationPath,
@@ -99,13 +105,27 @@ export function PartyStatusBar({
     return (
       <div
         data-party-bar
-        className="flex min-h-9 items-center gap-2 border-b bg-muted/40 px-3 py-1 text-xs text-muted-foreground"
+        className="flex min-h-9 flex-wrap items-center gap-x-2 gap-y-1 border-b bg-muted/40 px-3 py-1 text-xs text-muted-foreground"
       >
         <MapPin className="size-3.5 shrink-0" aria-hidden />
         <span>
           Sin <code className="rounded bg-muted px-1">estado/grupo.md</code> — no hay datos del
-          grupo.
+          grupo ni registro de sesión.
         </span>
+        {onCreateEstado && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-create-estado
+            onClick={onCreateEstado}
+            // min-h-11 = 44px tap target (M5 sweep) — this unblocks the cockpit.
+            className="min-h-11"
+          >
+            <Play />
+            Crear estado/grupo.md
+          </Button>
+        )}
       </div>
     );
   }

--- a/components/world/PartyStatusBar.tsx
+++ b/components/world/PartyStatusBar.tsx
@@ -1,22 +1,55 @@
 'use client';
 
 /**
- * PartyStatusBar — top cockpit band over the world view. READ-ONLY in M2:
- * the layout already reserves every interaction slot (breadcrumb taps work;
- * credits popover, gauge taps and the session button arrive in M3, which
- * only swaps handlers in — no re-layout).
+ * PartyStatusBar — top cockpit band over the world view. M3 upgrade over the
+ * M2 read-only layout (markup + data-attributes preserved): gauges are now
+ * manifest-driven, and the right edge hosts the live session controls —
+ * Iniciar/Terminar sesión (with confirm popover), elapsed timer, write-status
+ * dot and the Reintentar chip on permission loss. Gauges stay read-only here;
+ * edits happen in the QuickLogBar.
+ *
+ * All M3 props are optional with idle defaults so the component keeps
+ * rendering (button disabled) until the page wires the session store in.
  */
 
-import { Fragment } from 'react';
-import { PartyState } from '@/types/world';
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { PartyState, SessionRuntime } from '@/types/world';
 import { Button } from '@/components/ui/button';
-import { CalendarDays, ChevronRight, Coins, MapPin, Play } from 'lucide-react';
+import { CalendarDays, ChevronRight, Coins, MapPin, Play, RotateCw, Square, Timer } from 'lucide-react';
 
-const GAUGES: { key: string; label: string }[] = [
-  { key: 'viveres', label: 'Víveres' },
-  { key: 'combustible', label: 'Combustible' },
-  { key: 'nave', label: 'Nave' },
-];
+const DEFAULT_MEDIDOR_NAMES = ['viveres', 'combustible', 'nave'];
+
+const MEDIDOR_LABELS: Record<string, string> = {
+  viveres: 'Víveres',
+  combustible: 'Combustible',
+  nave: 'Nave',
+};
+
+function medidorLabel(nombre: string): string {
+  return MEDIDOR_LABELS[nombre] ?? nombre.charAt(0).toUpperCase() + nombre.slice(1);
+}
+
+const WRITE_STATUS_TITLES: Record<SessionRuntime['writeStatus'], string> = {
+  ok: 'Escritura al día',
+  pending: 'Guardando cambios…',
+  denied: 'Permisos de escritura perdidos',
+};
+
+const WRITE_STATUS_DOT: Record<SessionRuntime['writeStatus'], string> = {
+  ok: 'bg-emerald-500',
+  pending: 'bg-amber-500',
+  denied: 'bg-destructive',
+};
+
+/** mm:ss under an hour, h:mm from there on. */
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}:${String(minutes).padStart(2, '0')}`;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
 
 interface PartyStatusBarProps {
   /** Party state from estado/grupo.md; null renders the slim hint bar. */
@@ -28,8 +61,22 @@ interface PartyStatusBarProps {
   /** Breadcrumb chain root -> current; each crumb taps through to the map. */
   locationPath: { id: string; label: string }[];
   onLocationClick: (id: string) => void;
+  /** Gauge names from the world manifest (order preserved). */
+  medidorNames?: string[];
   /** Pips per gauge row. */
   medidoresMax?: number;
+  /** True while a session records; flips the button to Terminar sesión. */
+  sessionActive?: boolean;
+  /** Missing handler keeps the Iniciar button disabled (unwired page). */
+  onStartSession?: () => void;
+  onEndSession?: () => void;
+  /** Elapsed session time; the page owns the ticking interval. */
+  sessionElapsedMs?: number;
+  writeStatus?: SessionRuntime['writeStatus'];
+  /** Re-request write permission; rendered as the red Reintentar chip when denied. */
+  onRetryWrites?: () => void;
+  /** Summary counts shown inside the Terminar confirm popover. */
+  endSummaryPreview?: string;
 }
 
 export function PartyStatusBar({
@@ -38,7 +85,15 @@ export function PartyStatusBar({
   locationName,
   locationPath,
   onLocationClick,
+  medidorNames = DEFAULT_MEDIDOR_NAMES,
   medidoresMax = 5,
+  sessionActive = false,
+  onStartSession,
+  onEndSession,
+  sessionElapsedMs = 0,
+  writeStatus = 'ok',
+  onRetryWrites,
+  endSummaryPreview,
 }: PartyStatusBarProps) {
   if (!estado) {
     return (
@@ -109,26 +164,144 @@ export function PartyStatusBar({
         <span className="text-xs text-muted-foreground">cr</span>
       </div>
 
-      {/* Medidores */}
+      {/* Medidores (read-only; edits live in the QuickLogBar) */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
-        {GAUGES.map((gauge) => (
+        {medidorNames.map((nombre) => (
           <GaugeRow
-            key={gauge.key}
-            name={gauge.key}
-            label={gauge.label}
-            value={estado.medidores[gauge.key] ?? 0}
+            key={nombre}
+            name={nombre}
+            label={medidorLabel(nombre)}
+            value={estado.medidores[nombre] ?? 0}
             max={medidoresMax}
           />
         ))}
       </div>
 
-      {/* M3 slot: Iniciar/Terminar sesión + timer + write-status dot. */}
-      <span className="ml-auto" title="Disponible en M3">
-        <Button variant="outline" size="sm" disabled>
-          <Play />
-          Iniciar sesión
-        </Button>
-      </span>
+      {/* Session controls */}
+      <div className="ml-auto flex items-center gap-2">
+        {sessionActive ? (
+          <>
+            <span
+              data-session-timer
+              className="flex items-center gap-1 text-sm tabular-nums text-muted-foreground"
+              title="Tiempo de sesión"
+            >
+              <Timer className="size-4" aria-hidden />
+              {formatElapsed(sessionElapsedMs)}
+            </span>
+            <span
+              data-write-status={writeStatus}
+              role="status"
+              title={WRITE_STATUS_TITLES[writeStatus]}
+              className={`size-2 shrink-0 rounded-full ${WRITE_STATUS_DOT[writeStatus]}`}
+            />
+            {writeStatus === 'denied' && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                data-session-retry
+                onClick={onRetryWrites}
+                className="h-6 gap-1 border-destructive/40 px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <RotateCw className="size-3" aria-hidden />
+                Reintentar
+              </Button>
+            )}
+            <EndSessionButton onEndSession={onEndSession} endSummaryPreview={endSummaryPreview} />
+          </>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            data-session-start
+            disabled={!onStartSession}
+            onClick={onStartSession}
+          >
+            <Play />
+            Iniciar sesión
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface EndSessionButtonProps {
+  onEndSession?: () => void;
+  endSummaryPreview?: string;
+}
+
+/** "Terminar sesión" with an upward confirm popover (summary + Terminar/Cancelar). */
+function EndSessionButton({ onEndSession, endSummaryPreview }: EndSessionButtonProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!confirmOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setConfirmOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setConfirmOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [confirmOpen]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        data-session-end
+        aria-expanded={confirmOpen}
+        onClick={() => setConfirmOpen((open) => !open)}
+        className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+      >
+        <Square />
+        Terminar sesión
+      </Button>
+      {confirmOpen && (
+        <div
+          data-session-end-confirm
+          className="absolute right-0 top-full z-50 mt-2 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md"
+        >
+          <p className="text-sm font-medium">¿Terminar la sesión?</p>
+          {endSummaryPreview && (
+            <p className="mt-1 text-xs text-muted-foreground">{endSummaryPreview}</p>
+          )}
+          <div className="mt-3 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmOpen(false)}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              data-session-end-confirm-button
+              onClick={() => {
+                setConfirmOpen(false);
+                onEndSession?.();
+              }}
+            >
+              Terminar
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/world/PartyStatusBar.tsx
+++ b/components/world/PartyStatusBar.tsx
@@ -128,7 +128,9 @@ export function PartyStatusBar({
                 <button
                   type="button"
                   onClick={() => onLocationClick(crumb.id)}
-                  className={`max-w-44 truncate text-sm hover:underline ${
+                  // before: pseudo extends the tap area to ~44px without
+                  // growing the compact bar (M5 tap-target sweep).
+                  className={`relative max-w-44 truncate text-sm before:absolute before:-inset-x-1 before:-inset-y-3 before:content-[''] hover:underline ${
                     index === locationPath.length - 1
                       ? 'font-medium'
                       : 'text-muted-foreground'
@@ -202,7 +204,8 @@ export function PartyStatusBar({
                 size="sm"
                 data-session-retry
                 onClick={onRetryWrites}
-                className="h-6 gap-1 border-destructive/40 px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+                // min-h-11 = 44px tap target (M5 sweep) — recovery must be easy.
+                className="min-h-11 gap-1 border-destructive/40 px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
               >
                 <RotateCw className="size-3" aria-hidden />
                 Reintentar
@@ -217,6 +220,7 @@ export function PartyStatusBar({
             data-session-start
             disabled={!onStartSession}
             onClick={onStartSession}
+            className="min-h-11"
           >
             <Play />
             Iniciar sesión
@@ -264,7 +268,7 @@ function EndSessionButton({ onEndSession, endSummaryPreview }: EndSessionButtonP
         data-session-end
         aria-expanded={confirmOpen}
         onClick={() => setConfirmOpen((open) => !open)}
-        className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+        className="min-h-11 border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
       >
         <Square />
         Terminar sesión
@@ -284,6 +288,7 @@ function EndSessionButton({ onEndSession, endSummaryPreview }: EndSessionButtonP
               variant="outline"
               size="sm"
               onClick={() => setConfirmOpen(false)}
+              className="min-h-11"
             >
               Cancelar
             </Button>
@@ -296,6 +301,7 @@ function EndSessionButton({ onEndSession, endSummaryPreview }: EndSessionButtonP
                 setConfirmOpen(false);
                 onEndSession?.();
               }}
+              className="min-h-11"
             >
               Terminar
             </Button>

--- a/components/world/PlaceView.test.ts
+++ b/components/world/PlaceView.test.ts
@@ -1,0 +1,68 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { PlaceEntity } from '@/types/world';
+import { placeFitRadius } from './PlaceView';
+
+/** Minimal PlaceEntity with an optional local poi coord. */
+function poiChild(id: string, poi?: { x: number; y: number }): PlaceEntity {
+    return {
+        id,
+        tipo: 'estructura',
+        nombre: id,
+        filePath: `mundo/lugares/${id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        en: 'plano_p',
+        poi,
+        servicios: [],
+        facciones: [],
+        acceso: 'normal',
+    };
+}
+
+describe('placeFitRadius', () => {
+    // HALF_EXTENT 220, FIT_MARGIN 50. The dashed "sin ubicar" ring sits just
+    // outside the diagonal POI reach: UNPLACED_RADIUS = √2·220 + 60.
+    const POI_REACH = Math.SQRT2 * 220; // diagonal corner reach
+    const FIT_MARGIN = 50;
+    const UNPLACED_RADIUS = Math.SQRT2 * 220 + 60;
+
+    test('all children placed -> diagonal POI reach + margin', () => {
+        const children = [poiChild('a', { x: 0, y: 0 }), poiChild('b', { x: 100, y: 100 })];
+        expect(placeFitRadius(children)).toBeCloseTo(POI_REACH + FIT_MARGIN, 5);
+    });
+
+    test('any unplaced child -> the dashed "sin ubicar" ring is the outermost content', () => {
+        const children = [poiChild('a', { x: 50, y: 50 }), poiChild('b' /* no poi */)];
+        // The unplaced ring clears the diagonal POI reach, so it (plus margin)
+        // is the outermost content and strictly larger than the placed-only case.
+        expect(placeFitRadius(children)).toBeCloseTo(UNPLACED_RADIUS + FIT_MARGIN, 5);
+        expect(placeFitRadius(children)).toBeGreaterThan(POI_REACH + FIT_MARGIN);
+    });
+
+    test('corner POIs + an unplaced child -> the larger reach wins (no clipping)', () => {
+        const children = [
+            poiChild('corner', { x: 100, y: 100 }), // diagonal reach ≈ 311
+            poiChild('unplaced' /* no poi */), // ring ≈ 371
+        ];
+        const r = placeFitRadius(children);
+        expect(r).toBeGreaterThanOrEqual(POI_REACH + FIT_MARGIN);
+        expect(r).toBeCloseTo(UNPLACED_RADIUS + FIT_MARGIN, 5);
+    });
+
+    test('empty children (hub only) still returns the placed-only radius', () => {
+        expect(placeFitRadius([])).toBeCloseTo(POI_REACH + FIT_MARGIN, 5);
+    });
+
+    test('radius is stable regardless of how many placed children there are', () => {
+        const one = [poiChild('a', { x: 10, y: 90 })];
+        const many = [
+            poiChild('a', { x: 10, y: 90 }),
+            poiChild('b', { x: 80, y: 30 }),
+            poiChild('c', { x: 55, y: 55 }),
+        ];
+        expect(placeFitRadius(one)).toBeCloseTo(placeFitRadius(many), 5);
+    });
+});

--- a/components/world/PlaceView.tsx
+++ b/components/world/PlaceView.tsx
@@ -2,6 +2,7 @@
 
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import { PlaceEntity } from '@/types/world';
+import type { NodeAffordances } from '@/lib/world/shops';
 import { EntityNode } from './EntityNode';
 import { PartyMarker } from './PartyMarker';
 import { useMapScale } from './StarMap';
@@ -89,6 +90,8 @@ interface PlaceViewProps {
   leadsBadgeCounts: Map<string, number>;
   /** Dominant-faction ring color per entity id; undefined = no ring. */
   factionColor: (id: string) => string | undefined;
+  /** Semantic affordance badges (shop/info) per entity id; undefined = none. */
+  nodeIconsFor: (id: string) => NodeAffordances | undefined;
   /** When false, `conocimiento: desconocido` entities are hidden (screen-share mode). */
   showUnknown: boolean;
   onSelect: (id: string) => void;
@@ -118,6 +121,7 @@ export function PlaceView({
   partyLocationId,
   leadsBadgeCounts,
   factionColor,
+  nodeIconsFor,
   showUnknown,
   onSelect,
   onDrillIn,
@@ -231,6 +235,7 @@ export function PlaceView({
           selected={lugar.id === selectedId}
           faccionColor={factionColor(lugar.id)}
           leadsCount={leadsBadgeCounts.get(lugar.id)}
+          affordances={nodeIconsFor(lugar.id)}
           onSelect={onSelect}
           onDrillIn={onDrillIn}
           x={x}

--- a/components/world/PlaceView.tsx
+++ b/components/world/PlaceView.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { PlaceEntity } from '@/types/world';
+import { EntityNode } from './EntityNode';
+import { PartyMarker } from './PartyMarker';
+import { useMapScale } from './StarMap';
+
+/** Central hub glyph radius (map units, scales with zoom like EntityNode glyphs). */
+const HUB_RADIUS = 30;
+
+/**
+ * Half the map-unit extent of the local POI grid. A POI's `poi:{x,y}` runs
+ * 0..100 on each axis; this maps it onto [-HALF_EXTENT, +HALF_EXTENT] around a
+ * hub at (0,0), so {50,50} lands at the center. 220 keeps POIs in the same
+ * ~110..250 band SystemView uses for its orbital rings, so the sistema -> place
+ * tier transition feels spatially consistent.
+ */
+const HALF_EXTENT = 220;
+
+/**
+ * Radius of the dashed "sin ubicar" ring for POI-less children (no `poi:`
+ * coords). Sits just OUTSIDE the diagonal reach of the placed POI grid
+ * (√2·HALF_EXTENT ≈ 311) so unplaced children never overlap the placed
+ * floor-plan region — the ring is a true outer boundary.
+ */
+const UNPLACED_RADIUS = Math.SQRT2 * HALF_EXTENT + 60;
+
+/** Extra radius past the outermost content for labels + the party-marker pulse. */
+const FIT_MARGIN = 50;
+
+/** Map coords for a POI's 0..100 local coords, centered on the hub at (0,0). */
+function poiToMap(poi: { x: number; y: number }): { x: number; y: number } {
+  return {
+    x: ((poi.x - 50) / 50) * HALF_EXTENT,
+    y: ((poi.y - 50) / 50) * HALF_EXTENT,
+  };
+}
+
+/**
+ * Stable angular position for an unplaced child on the dashed outer ring,
+ * derived from an FNV-1a 32-bit hash of the entity id mapped onto [0, 2π).
+ * Same rationale as SystemView.angleForId: hashing the id (not array order)
+ * keeps every node at the same angle across scans and sibling churn.
+ */
+function angleForId(id: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // >>> 0 coerces to uint32; divide by 2^32 for a stable fraction of the circle.
+  return ((hash >>> 0) / 0x100000000) * 2 * Math.PI;
+}
+
+/**
+ * Outermost content radius of a place view, for the page's fit-to-view math.
+ * The hub sits at (0,0); placed POIs reach at most HALF_EXTENT along an axis
+ * (and √2·HALF_EXTENT diagonally at the {0,0}/{100,100} corners). When any
+ * child lacks `poi:` coords the dashed "sin ubicar" ring at UNPLACED_RADIUS
+ * (which clears the diagonal reach) is the outermost content. Takes the max of
+ * the applicable contributions so a mix of corner POIs + unplaced children is
+ * never clipped.
+ */
+export function placeFitRadius(children: PlaceEntity[]): number {
+  const hasUnplaced = children.some((lugar) => lugar.poi === undefined);
+  // Diagonal reach of the placed POI grid ({0,0}/{100,100} corners). Always a
+  // floor: the fit view must frame the full grid even with no placed children.
+  const poiReach = Math.SQRT2 * HALF_EXTENT;
+  const outermost = hasUnplaced ? Math.max(poiReach, UNPLACED_RADIUS) : poiReach;
+  return outermost + FIT_MARGIN;
+}
+
+interface PlacedNode {
+  lugar: PlaceEntity;
+  x: number;
+  y: number;
+}
+
+interface PlaceViewProps {
+  /** The lugar whose interior (Plano) is being rendered as the hub. */
+  place: PlaceEntity;
+  /** The lugares whose `en === place.id` (direct children only). */
+  children: PlaceEntity[];
+  selectedId: string | null;
+  /** Entity id where the party is; marker renders if it is the place or a POI child. */
+  partyLocationId: string | null;
+  /** Actionable-leads count per entity id (amber badge when > 0). */
+  leadsBadgeCounts: Map<string, number>;
+  /** Dominant-faction ring color per entity id; undefined = no ring. */
+  factionColor: (id: string) => string | undefined;
+  /** When false, `conocimiento: desconocido` entities are hidden (screen-share mode). */
+  showUnknown: boolean;
+  onSelect: (id: string) => void;
+  /** Drill into a POI that itself has children (nested list/plano). */
+  onDrillIn: (id: string) => void;
+  /** Back out to the system tier (double-click on the central hub). */
+  onBack: () => void;
+}
+
+/**
+ * PlaceView — the third SPATIAL map tier (the "Plano"): a place's interior
+ * floor-plan. A central hub glyph stands for the place itself; its child
+ * lugares carrying local `poi:{x,y}` coords (0..100) render as EntityNodes at
+ * their mapped positions, mirroring SystemView's node treatment (knowledge
+ * styling, faction ring, leads badge, drill-in). Children WITHOUT `poi:` coords
+ * are not lost — they sit on a dashed "sin ubicar" outer ring, angle-hashed
+ * like SystemView's unranked places.
+ *
+ * The page renders this only for a place that HAS at least one poi-coord child
+ * (a plano-eligible place); places without any land in SiteList instead. A
+ * double-click on the hub backs out to the system tier.
+ */
+export function PlaceView({
+  place,
+  children,
+  selectedId,
+  partyLocationId,
+  leadsBadgeCounts,
+  factionColor,
+  showUnknown,
+  onSelect,
+  onDrillIn,
+  onBack,
+}: PlaceViewProps) {
+  const k = useMapScale();
+
+  const visible = showUnknown
+    ? children
+    : children.filter((lugar) => lugar.conocimiento !== 'desconocido');
+
+  const placed = visible.filter((lugar) => lugar.poi !== undefined);
+  const unplaced = visible.filter((lugar) => lugar.poi === undefined);
+
+  const nodes: PlacedNode[] = [
+    ...placed.map((lugar) => {
+      const { x, y } = poiToMap(lugar.poi!);
+      return { lugar, x, y };
+    }),
+    ...unplaced.map((lugar) => {
+      const angle = angleForId(lugar.id);
+      return {
+        lugar,
+        x: Math.cos(angle) * UNPLACED_RADIUS,
+        y: Math.sin(angle) * UNPLACED_RADIUS,
+      };
+    }),
+  ];
+
+  const partyNode =
+    partyLocationId === null ? undefined : nodes.find((node) => node.lugar.id === partyLocationId);
+  const partyAtHub = partyLocationId === place.id;
+
+  const hubGradientId = `plano-glow-${place.id}`;
+  const hubLabelY = Math.max(HUB_RADIUS * k, 12) + 16;
+
+  const handleHubClick = (event: ReactMouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    onSelect(place.id);
+  };
+
+  const handleHubDoubleClick = (event: ReactMouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    onBack();
+  };
+
+  return (
+    <g data-tier="place">
+      <defs>
+        <radialGradient id={hubGradientId}>
+          <stop offset="0%" stopColor="var(--foreground)" stopOpacity={0.9} />
+          <stop offset="55%" stopColor="var(--primary)" stopOpacity={0.55} />
+          <stop offset="100%" stopColor="var(--primary)" stopOpacity={0} />
+        </radialGradient>
+      </defs>
+
+      {/* Dashed "sin ubicar" ring: only when some child lacks poi coords. */}
+      {unplaced.length > 0 && (
+        <circle
+          data-plano-ring="sin-ubicar"
+          r={UNPLACED_RADIUS}
+          className="fill-none stroke-border"
+          strokeWidth={1}
+          strokeDasharray="6 6"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+
+      {/* Central hub: click selects the place, double-click backs out to the system. */}
+      <g
+        data-entity-id={place.id}
+        data-knowledge={place.conocimiento}
+        className="cursor-pointer"
+        onClick={handleHubClick}
+        onDoubleClick={handleHubDoubleClick}
+      >
+        {selectedId === place.id && (
+          <circle
+            r={HUB_RADIUS + 8}
+            className="fill-none stroke-ring"
+            strokeWidth={2}
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+        <circle r={HUB_RADIUS} fill={`url(#${hubGradientId})`} />
+        <g transform={`scale(${1 / k})`} className="pointer-events-none select-none">
+          <text
+            y={hubLabelY}
+            textAnchor="middle"
+            paintOrder="stroke"
+            strokeLinejoin="round"
+            strokeWidth={3}
+            className="fill-foreground stroke-background text-[12px] font-medium"
+          >
+            {place.nombre}
+          </text>
+        </g>
+      </g>
+
+      {(partyAtHub || partyNode) && (
+        <PartyMarker x={partyAtHub ? 0 : partyNode!.x} y={partyAtHub ? 0 : partyNode!.y} />
+      )}
+
+      {nodes.map(({ lugar, x, y }) => (
+        <EntityNode
+          key={lugar.id}
+          id={lugar.id}
+          nombre={lugar.nombre}
+          tipo={lugar.tipo}
+          conocimiento={lugar.conocimiento}
+          selected={lugar.id === selectedId}
+          faccionColor={factionColor(lugar.id)}
+          leadsCount={leadsBadgeCounts.get(lugar.id)}
+          onSelect={onSelect}
+          onDrillIn={onDrillIn}
+          x={x}
+          y={y}
+          shape={lugar.acceso === 'portal' ? 'diamond' : undefined}
+          portal={lugar.acceso === 'portal'}
+        />
+      ))}
+    </g>
+  );
+}

--- a/components/world/PnjCard.tsx
+++ b/components/world/PnjCard.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * PnjCard — right-panel dossier view for a selected PNJ (GM-only).
+ *
+ * Rendered by /world in place of the EntityPanel when the selection is a pnj
+ * (pnjs ARE entities in the entidades map — the page reuses selectedEntityId,
+ * see the page module doc). Reached from the "Personajes" section of a place
+ * panel (or search / ?e= deep link); the back button returns to the pnj's
+ * ubicacion place.
+ *
+ * Portrait: same EntityImageBanner + player-safe FullscreenImage behavior as
+ * the EntityPanel thumbnail when the pnj carries `imagen`.
+ */
+
+import type { FileReference } from '@/types';
+import type { Conocimiento, NpcEntity } from '@/types/world';
+import { EntityImageBanner } from '@/components/world/EntityPanel';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ArrowLeft } from 'lucide-react';
+
+const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
+  desconocido: 'Desconocido',
+  rumoreado: 'Rumoreado',
+  conocido: 'Conocido',
+  visitado: 'Visitado',
+};
+
+interface PnjCardProps {
+  pnj: NpcEntity;
+  /** Display name of the pnj's faccion, pre-resolved (raw id as fallback). */
+  faccionNombre?: string;
+  /** Resolves the portrait to an object URL (page-owned cache). */
+  loadImageUrl?: (ref: FileReference) => Promise<string>;
+  /** Opens the player-safe FullscreenImage viewer with a resolved URL. */
+  onImageZoom?: (url: string) => void;
+  /** Back to where the pnj lives (its ubicacion place panel). */
+  onBack: () => void;
+}
+
+export function PnjCard({ pnj, faccionNombre, loadImageUrl, onImageZoom, onBack }: PnjCardProps) {
+  const hasBody = pnj.body.trim().length > 0;
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-pnj-card={pnj.id}>
+      <CardHeader className="border-b py-4">
+        <CardTitle className="text-base">{pnj.nombre}</CardTitle>
+        <div className="flex flex-wrap items-center gap-1">
+          <Badge variant="secondary">{pnj.rol}</Badge>
+          {faccionNombre && <Badge variant="outline">{faccionNombre}</Badge>}
+          <Badge variant="outline">{CONOCIMIENTO_LABEL[pnj.conocimiento]}</Badge>
+        </div>
+        <CardAction>
+          {/* size/min-h 11 = 44px tap target (M5 sweep). */}
+          <Button
+            variant="ghost"
+            size="sm"
+            data-pnj-back
+            onClick={onBack}
+            aria-label="Volver al lugar"
+            className="min-h-11"
+          >
+            <ArrowLeft />
+            Volver
+          </Button>
+        </CardAction>
+      </CardHeader>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <CardContent className="flex flex-col gap-4 py-4">
+          {pnj.imagen && loadImageUrl && onImageZoom && (
+            <EntityImageBanner
+              imagen={pnj.imagen}
+              nombre={pnj.nombre}
+              loadImageUrl={loadImageUrl}
+              onZoom={onImageZoom}
+            />
+          )}
+
+          {pnj.resumen && <p className="text-sm text-muted-foreground">{pnj.resumen}</p>}
+
+          {pnj.estado && (
+            <div className="rounded-md border bg-muted/40 p-3">
+              <div className="mb-1 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                Situación
+              </div>
+              <p className="text-sm whitespace-pre-line">{pnj.estado}</p>
+            </div>
+          )}
+
+          {hasBody && <MarkdownViewer content={pnj.body} className="prose-sm" />}
+        </CardContent>
+      </ScrollArea>
+    </Card>
+  );
+}

--- a/components/world/QuickLogBar.tsx
+++ b/components/world/QuickLogBar.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 /**
- * QuickLogBar — bottom cockpit action band (M3, plan Part B). Eight large
+ * QuickLogBar — bottom cockpit action band (M3, plan Part B). Nine large
  * one-tap buttons; every logging path is at most 2 interactions. Pure and
  * props-driven: the page owns the store and passes callbacks. Disabled as a
- * whole until the session is active.
+ * whole until the session is active, with two exceptions:
+ *   - «Pista» only switches the right panel to the Pistas tab (it logs
+ *     nothing), so it stays enabled even without a session — same as the tab.
+ *   - «Descansar» and «Evento» additionally disable MID-TRAVEL: the stepper
+ *     owns day advancement and the viaje event draw there.
  *
- * Popovers (créditos amounts, medidor pips) are hand-rolled (relative anchor +
- * absolute panel opening upward) instead of ui/dropdown-menu because the
- * créditos panel embeds a free-text input and Radix menus fight keyboard
- * focus inside items.
+ * Popovers (créditos amounts, medidor pips, descanso days) are hand-rolled
+ * (relative anchor + absolute panel opening upward) instead of
+ * ui/dropdown-menu because the créditos panel embeds a free-text input and
+ * Radix menus fight keyboard focus inside items.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -23,6 +27,7 @@ import {
   Gauge,
   LucideIcon,
   MapPin,
+  Moon,
   Rocket,
   StickyNote,
   Target,
@@ -56,13 +61,19 @@ interface QuickLogBarProps {
   medidores: Record<string, number>;
   /** Gauge names from the world manifest (order preserved). */
   medidorNames: string[];
+  /** Current dia_mundo — shown under «Descansar». */
+  diaMundo: number;
   /** Opens the MoverDialog (page-owned). */
   onMover: () => void;
   /** Signed credit delta, already confirmed by the GM. */
   onCreditos: (delta: number) => void;
   /** Absolute new value 0-5 for the named gauge. */
   onMedidor: (nombre: string, to: number) => void;
-  /** Opens the leads tab/dialog (page-owned). */
+  /** Rest N days (> 0); the page advances dia_mundo + víveres ticks. */
+  onDescanso: (dias: number) => void;
+  /** True mid-travel: the stepper owns day advancement then. */
+  descansoDisabled?: boolean;
+  /** Opens the leads tab/dialog (page-owned). Never session-gated: logs nothing. */
   onPista: () => void;
   /**
    * Opens the estancia EventDrawer (page-owned). Enabled whenever the session
@@ -70,20 +81,29 @@ interface QuickLogBarProps {
    * of disabling the button (the GM discovers why there).
    */
   onEvento: () => void;
+  /** True mid-travel: the estancia pool would anchor on the origin already left. */
+  eventoDisabled?: boolean;
   /** Freeform note text (non-empty, trimmed). */
   onNota: (text: string) => void;
 }
+
+const MID_TRAVEL_DESCANSO_TITLE = 'El viaje en curso ya avanza los días — usa «Continuar»';
+const MID_TRAVEL_EVENTO_TITLE = 'Durante un viaje usa «Tirar evento de viaje»';
 
 export function QuickLogBar({
   enabled,
   creditos,
   medidores,
   medidorNames,
+  diaMundo,
   onMover,
   onCreditos,
   onMedidor,
+  onDescanso,
+  descansoDisabled = false,
   onPista,
   onEvento,
+  eventoDisabled = false,
   onNota,
 }: QuickLogBarProps) {
   /** Which popover is open: 'creditos' | medidor name | null. */
@@ -211,11 +231,37 @@ export function QuickLogBar({
         );
       })}
 
+      {/* Descansar: +1/+3/custom days popover (calendar drives víveres). */}
+      <PopoverAnchor
+        open={openPopover === 'descanso'}
+        onClose={() => setOpenPopover(null)}
+        panel={
+          <DescansoPanel
+            onDescanso={(dias) => {
+              onDescanso(dias);
+              setOpenPopover(null);
+            }}
+          />
+        }
+      >
+        <ActionButton
+          id="descanso"
+          icon={Moon}
+          label="Descansar"
+          sub={`día ${diaMundo}`}
+          enabled={enabled && !descansoDisabled}
+          disabledTitle={enabled ? MID_TRAVEL_DESCANSO_TITLE : DISABLED_TITLE}
+          active={openPopover === 'descanso'}
+          onClick={() => setOpenPopover(openPopover === 'descanso' ? null : 'descanso')}
+        />
+      </PopoverAnchor>
+
+      {/* Pista never logs anything — it stays available as a shortcut to the tab. */}
       <ActionButton
         id="pista"
         icon={Target}
         label="Pista"
-        enabled={enabled}
+        enabled
         onClick={() => {
           setOpenPopover(null);
           onPista();
@@ -226,7 +272,8 @@ export function QuickLogBar({
         id="evento"
         icon={Zap}
         label="Evento"
-        enabled={enabled}
+        enabled={enabled && !eventoDisabled}
+        disabledTitle={enabled ? MID_TRAVEL_EVENTO_TITLE : DISABLED_TITLE}
         onClick={() => {
           setOpenPopover(null);
           onEvento();
@@ -244,7 +291,7 @@ export function QuickLogBar({
             value={notaText}
             onChange={(event) => setNotaText(event.target.value)}
             onKeyDown={handleNotaKeyDown}
-            placeholder="Nota rápida… (Enter registra)"
+            placeholder="Nota rápida…"
             className="h-8 border-none bg-transparent px-1 shadow-none focus-visible:ring-0 dark:bg-transparent"
             aria-label="Nota rápida"
           />
@@ -371,7 +418,8 @@ function CreditosPanel({ onDelta }: { onDelta: (delta: number) => void }) {
   const [custom, setCustom] = useState('');
 
   const submitCustom = () => {
-    const amount = Number.parseInt(custom, 10);
+    // Tolerate the Unicode minus (−) some keyboards produce.
+    const amount = Number.parseInt(custom.replace(/−/g, '-'), 10);
     if (!Number.isFinite(amount) || amount === 0) return;
     onDelta(amount);
     setCustom('');
@@ -405,10 +453,60 @@ function CreditosPanel({ onDelta }: { onDelta: (delta: number) => void }) {
             submitCustom();
           }
         }}
-        placeholder="Cantidad… (−400)"
+        placeholder="Cantidad… (-400)"
         inputMode="numeric"
         className="h-8"
         aria-label="Cantidad de créditos"
+      />
+    </div>
+  );
+}
+
+const DESCANSO_DELTAS = [1, 3];
+
+/** +1 / +3 days one-tap, or a custom positive number (Enter confirms). */
+function DescansoPanel({ onDescanso }: { onDescanso: (dias: number) => void }) {
+  const [custom, setCustom] = useState('');
+
+  const submitCustom = () => {
+    const dias = Number.parseInt(custom.replace(/−/g, '-'), 10);
+    if (!Number.isFinite(dias) || dias <= 0) return;
+    onDescanso(dias);
+    setCustom('');
+  };
+
+  return (
+    <div className="w-44 space-y-2" data-quicklog-descanso-menu>
+      <div className="grid grid-cols-2 gap-1">
+        {DESCANSO_DELTAS.map((dias) => (
+          <Button
+            key={dias}
+            type="button"
+            variant="secondary"
+            size="sm"
+            data-quicklog-descanso-dias={dias}
+            onClick={() => onDescanso(dias)}
+            // h-11 = 44px tap target (M5 sweep).
+            className="h-11 tabular-nums"
+          >
+            +{dias} {dias === 1 ? 'día' : 'días'}
+          </Button>
+        ))}
+      </div>
+      <Input
+        data-quicklog-descanso-custom
+        value={custom}
+        onChange={(event) => setCustom(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            submitCustom();
+          }
+        }}
+        placeholder="Días… (5)"
+        inputMode="numeric"
+        className="h-8"
+        aria-label="Días de descanso"
       />
     </div>
   );

--- a/components/world/QuickLogBar.tsx
+++ b/components/world/QuickLogBar.tsx
@@ -1,14 +1,20 @@
 'use client';
 
 /**
- * QuickLogBar — bottom cockpit action band (M3, plan Part B). Nine large
- * one-tap buttons; every logging path is at most 2 interactions. Pure and
+ * QuickLogBar — bottom cockpit action band (M3, plan Part B). Large one-tap
+ * buttons; every logging path is at most 2 interactions. Pure and
  * props-driven: the page owns the store and passes callbacks. Disabled as a
- * whole until the session is active, with two exceptions:
+ * whole until the session is active, with these exceptions:
  *   - «Pista» only switches the right panel to the Pistas tab (it logs
  *     nothing), so it stays enabled even without a session — same as the tab.
  *   - «Descansar» and «Evento» additionally disable MID-TRAVEL: the stepper
  *     owns day advancement and the viaje event draw there.
+ *   - «Música» and «Combate» are NEVER session-gated (feature 3): music and
+ *     the initiative tracker work anytime, so they toggle regardless of the
+ *     session. They carry an `activo` visual state driven by musicaOpen /
+ *     combatOpen. Etched here instead of floating page overlays so they stop
+ *     "flying over" the map/panels. The Combate button keeps the historical
+ *     data-combat-open attribute so existing e2e still finds the affordance.
  *
  * Popovers (créditos amounts, medidor pips, descanso days) are hand-rolled
  * (relative anchor + absolute panel opening upward) instead of
@@ -28,8 +34,10 @@ import {
   LucideIcon,
   MapPin,
   Moon,
+  Music,
   Rocket,
   StickyNote,
+  Swords,
   Target,
   Zap,
 } from 'lucide-react';
@@ -85,6 +93,14 @@ interface QuickLogBarProps {
   eventoDisabled?: boolean;
   /** Freeform note text (non-empty, trimmed). */
   onNota: (text: string) => void;
+  /** Toggles the world audio dock (feature 3). NOT session-gated. */
+  onMusica: () => void;
+  /** True while the audio dock is open — drives the button's active state. */
+  musicaOpen?: boolean;
+  /** Toggles + force-opens the initiative tracker (feature 3). NOT session-gated. */
+  onCombat: () => void;
+  /** True while the initiative tracker is revealed — drives the active state. */
+  combatOpen?: boolean;
 }
 
 const MID_TRAVEL_DESCANSO_TITLE = 'El viaje en curso ya avanza los días — usa «Continuar»';
@@ -105,6 +121,10 @@ export function QuickLogBar({
   onEvento,
   eventoDisabled = false,
   onNota,
+  onMusica,
+  musicaOpen = false,
+  onCombat,
+  combatOpen = false,
 }: QuickLogBarProps) {
   /** Which popover is open: 'creditos' | medidor name | null. */
   const [openPopover, setOpenPopover] = useState<string | null>(null);
@@ -309,6 +329,34 @@ export function QuickLogBar({
           }}
         />
       )}
+
+      {/* Música + Combate (feature 3): etched into the band, never
+          session-gated. The Combate button keeps data-combat-open so existing
+          e2e still finds the affordance. */}
+      <ActionButton
+        id="musica"
+        icon={Music}
+        label="Música"
+        enabled
+        active={musicaOpen}
+        onClick={() => {
+          setOpenPopover(null);
+          onMusica();
+        }}
+      />
+
+      <ActionButton
+        id="combate"
+        icon={Swords}
+        label="Combate"
+        enabled
+        active={combatOpen}
+        extraAttrs={{ 'data-combat-open': true }}
+        onClick={() => {
+          setOpenPopover(null);
+          onCombat();
+        }}
+      />
     </div>
   );
 }
@@ -329,6 +377,8 @@ interface ActionButtonProps {
   active?: boolean;
   disabledTitle?: string;
   onClick: () => void;
+  /** Extra data attributes spread onto the button (e.g. data-combat-open). */
+  extraAttrs?: Record<string, string | boolean | undefined>;
 }
 
 /** Large (min-h-12) vertical icon+label button; disabled state keeps its tooltip. */
@@ -341,6 +391,7 @@ function ActionButton({
   active = false,
   disabledTitle = DISABLED_TITLE,
   onClick,
+  extraAttrs,
 }: ActionButtonProps) {
   const button = (
     <Button
@@ -353,6 +404,7 @@ function ActionButton({
       className={`h-auto min-h-12 w-full flex-col gap-0.5 px-2 py-1.5 ${
         active ? 'bg-accent text-accent-foreground' : ''
       }`}
+      {...extraAttrs}
     >
       <Icon aria-hidden />
       <span className="text-xs leading-none">{label}</span>

--- a/components/world/QuickLogBar.tsx
+++ b/components/world/QuickLogBar.tsx
@@ -388,7 +388,8 @@ function CreditosPanel({ onDelta }: { onDelta: (delta: number) => void }) {
             size="sm"
             data-quicklog-delta={delta}
             onClick={() => onDelta(delta)}
-            className={`tabular-nums ${delta < 0 ? 'text-destructive' : ''}`}
+            // h-11 = 44px tap target (M5 sweep).
+            className={`h-11 tabular-nums ${delta < 0 ? 'text-destructive' : ''}`}
           >
             {delta > 0 ? `+${delta}` : delta}
           </Button>
@@ -430,7 +431,8 @@ function PipRow({ nombre, current, onPick }: PipRowProps) {
           data-quicklog-pip={value}
           aria-pressed={value === current}
           onClick={() => onPick(value)}
-          className={`flex size-9 items-center justify-center rounded-full border text-sm tabular-nums transition-colors hover:bg-accent hover:text-accent-foreground ${
+          // size-11 = 44px tap target (M5 sweep).
+          className={`flex size-11 items-center justify-center rounded-full border text-sm tabular-nums transition-colors hover:bg-accent hover:text-accent-foreground ${
             value === current
               ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
               : value < current

--- a/components/world/QuickLogBar.tsx
+++ b/components/world/QuickLogBar.tsx
@@ -5,8 +5,6 @@
  * buttons; every logging path is at most 2 interactions. Pure and
  * props-driven: the page owns the store and passes callbacks. Disabled as a
  * whole until the session is active, with these exceptions:
- *   - «Pista» only switches the right panel to the Pistas tab (it logs
- *     nothing), so it stays enabled even without a session — same as the tab.
  *   - «Descansar» and «Evento» additionally disable MID-TRAVEL: the stepper
  *     owns day advancement and the viaje event draw there.
  *   - «Música» and «Combate» are NEVER session-gated (feature 3): music and
@@ -38,7 +36,6 @@ import {
   Rocket,
   StickyNote,
   Swords,
-  Target,
   Zap,
 } from 'lucide-react';
 
@@ -81,8 +78,6 @@ interface QuickLogBarProps {
   onDescanso: (dias: number) => void;
   /** True mid-travel: the stepper owns day advancement then. */
   descansoDisabled?: boolean;
-  /** Opens the leads tab/dialog (page-owned). Never session-gated: logs nothing. */
-  onPista: () => void;
   /**
    * Opens the estancia EventDrawer (page-owned). Enabled whenever the session
    * runs — with no applicable tables the drawer shows its empty state instead
@@ -117,7 +112,6 @@ export function QuickLogBar({
   onMedidor,
   onDescanso,
   descansoDisabled = false,
-  onPista,
   onEvento,
   eventoDisabled = false,
   onNota,
@@ -275,18 +269,6 @@ export function QuickLogBar({
           onClick={() => setOpenPopover(openPopover === 'descanso' ? null : 'descanso')}
         />
       </PopoverAnchor>
-
-      {/* Pista never logs anything — it stays available as a shortcut to the tab. */}
-      <ActionButton
-        id="pista"
-        icon={Target}
-        label="Pista"
-        enabled
-        onClick={() => {
-          setOpenPopover(null);
-          onPista();
-        }}
-      />
 
       <ActionButton
         id="evento"

--- a/components/world/QuickLogBar.tsx
+++ b/components/world/QuickLogBar.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+/**
+ * QuickLogBar — bottom cockpit action band (M3, plan Part B). Eight large
+ * one-tap buttons; every logging path is at most 2 interactions. Pure and
+ * props-driven: the page owns the store and passes callbacks. Disabled as a
+ * whole until the session is active.
+ *
+ * Popovers (créditos amounts, medidor pips) are hand-rolled (relative anchor +
+ * absolute panel opening upward) instead of ui/dropdown-menu because the
+ * créditos panel embeds a free-text input and Radix menus fight keyboard
+ * focus inside items.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Apple,
+  Coins,
+  Fuel,
+  Gauge,
+  LucideIcon,
+  MapPin,
+  Rocket,
+  StickyNote,
+  Target,
+  Zap,
+} from 'lucide-react';
+
+const DISABLED_TITLE = 'Inicia sesión para registrar';
+const EVENTO_TITLE = 'Disponible en M4';
+const MEDIDOR_MAX = 5;
+
+const MEDIDOR_ICONS: Record<string, LucideIcon> = {
+  viveres: Apple,
+  combustible: Fuel,
+  nave: Rocket,
+};
+
+const MEDIDOR_LABELS: Record<string, string> = {
+  viveres: 'Víveres',
+  combustible: 'Combustible',
+  nave: 'Nave',
+};
+
+function medidorLabel(nombre: string): string {
+  return MEDIDOR_LABELS[nombre] ?? nombre.charAt(0).toUpperCase() + nombre.slice(1);
+}
+
+interface QuickLogBarProps {
+  /** False until "Iniciar sesión": every button disabled with a hint tooltip. */
+  enabled: boolean;
+  creditos: number;
+  /** Current gauge values keyed by manifest name. */
+  medidores: Record<string, number>;
+  /** Gauge names from the world manifest (order preserved). */
+  medidorNames: string[];
+  /** Opens the MoverDialog (page-owned). */
+  onMover: () => void;
+  /** Signed credit delta, already confirmed by the GM. */
+  onCreditos: (delta: number) => void;
+  /** Absolute new value 0-5 for the named gauge. */
+  onMedidor: (nombre: string, to: number) => void;
+  /** Opens the leads tab/dialog (page-owned). */
+  onPista: () => void;
+  /** Freeform note text (non-empty, trimmed). */
+  onNota: (text: string) => void;
+}
+
+export function QuickLogBar({
+  enabled,
+  creditos,
+  medidores,
+  medidorNames,
+  onMover,
+  onCreditos,
+  onMedidor,
+  onPista,
+  onNota,
+}: QuickLogBarProps) {
+  /** Which popover is open: 'creditos' | medidor name | null. */
+  const [openPopover, setOpenPopover] = useState<string | null>(null);
+  const [notaOpen, setNotaOpen] = useState(false);
+  const [notaText, setNotaText] = useState('');
+  const notaInputRef = useRef<HTMLInputElement>(null);
+
+  // Collapse everything when the session ends.
+  useEffect(() => {
+    if (!enabled) {
+      setOpenPopover(null);
+      setNotaOpen(false);
+    }
+  }, [enabled]);
+
+  // "n" focuses the nota input when enabled and no other input holds focus.
+  useEffect(() => {
+    if (!enabled) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'n' || event.metaKey || event.ctrlKey || event.altKey) return;
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLElement &&
+        (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)
+      ) {
+        return;
+      }
+      event.preventDefault();
+      setNotaOpen(true);
+      // Focus after the conditional input mounts (autoFocus covers first open;
+      // this covers "already open but blurred").
+      requestAnimationFrame(() => notaInputRef.current?.focus());
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [enabled]);
+
+  const submitNota = () => {
+    const text = notaText.trim();
+    if (text) onNota(text);
+    setNotaText('');
+    setNotaOpen(false);
+  };
+
+  const handleNotaKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submitNota();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setNotaOpen(false);
+    }
+  };
+
+  return (
+    <div
+      data-quicklog-bar
+      className="flex flex-wrap items-stretch gap-2 border-t bg-background px-3 py-2"
+    >
+      <ActionButton
+        id="mover"
+        icon={MapPin}
+        label="Mover"
+        enabled={enabled}
+        onClick={() => {
+          setOpenPopover(null);
+          onMover();
+        }}
+      />
+
+      {/* ± Créditos: amount popover (fixed deltas + custom, negative allowed). */}
+      <PopoverAnchor
+        open={openPopover === 'creditos'}
+        onClose={() => setOpenPopover(null)}
+        panel={
+          <CreditosPanel
+            onDelta={(delta) => {
+              onCreditos(delta);
+              setOpenPopover(null);
+            }}
+          />
+        }
+      >
+        <ActionButton
+          id="creditos"
+          icon={Coins}
+          label="± Créditos"
+          sub={`${creditos.toLocaleString('es-ES')} cr`}
+          enabled={enabled}
+          active={openPopover === 'creditos'}
+          onClick={() => setOpenPopover(openPopover === 'creditos' ? null : 'creditos')}
+        />
+      </PopoverAnchor>
+
+      {/* One gauge button per manifest medidor: 6-pip (0-5) popover. */}
+      {medidorNames.map((nombre) => {
+        const value = clampPip(medidores[nombre] ?? 0);
+        return (
+          <PopoverAnchor
+            key={nombre}
+            open={openPopover === nombre}
+            onClose={() => setOpenPopover(null)}
+            panel={
+              <PipRow
+                nombre={nombre}
+                current={value}
+                onPick={(to) => {
+                  onMedidor(nombre, to);
+                  setOpenPopover(null);
+                }}
+              />
+            }
+          >
+            <ActionButton
+              id={nombre}
+              icon={MEDIDOR_ICONS[nombre] ?? Gauge}
+              label={medidorLabel(nombre)}
+              sub={`${value}/${MEDIDOR_MAX}`}
+              enabled={enabled}
+              active={openPopover === nombre}
+              onClick={() => setOpenPopover(openPopover === nombre ? null : nombre)}
+            />
+          </PopoverAnchor>
+        );
+      })}
+
+      <ActionButton
+        id="pista"
+        icon={Target}
+        label="Pista"
+        enabled={enabled}
+        onClick={() => {
+          setOpenPopover(null);
+          onPista();
+        }}
+      />
+
+      <ActionButton
+        id="evento"
+        icon={Zap}
+        label="Evento"
+        enabled={false}
+        disabledTitle={EVENTO_TITLE}
+        onClick={() => undefined}
+      />
+
+      {/* Nota: inline expanding input (Enter registra, Escape pliega). */}
+      {notaOpen && enabled ? (
+        <div className="flex min-h-12 min-w-48 flex-[2] items-center gap-1.5 rounded-md border px-2">
+          <StickyNote className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+          <Input
+            ref={notaInputRef}
+            data-quicklog-nota-input
+            autoFocus
+            value={notaText}
+            onChange={(event) => setNotaText(event.target.value)}
+            onKeyDown={handleNotaKeyDown}
+            placeholder="Nota rápida… (Enter registra)"
+            className="h-8 border-none bg-transparent px-1 shadow-none focus-visible:ring-0 dark:bg-transparent"
+            aria-label="Nota rápida"
+          />
+        </div>
+      ) : (
+        <ActionButton
+          id="nota"
+          icon={StickyNote}
+          label="Nota"
+          sub={enabled ? 'n' : undefined}
+          enabled={enabled}
+          onClick={() => {
+            setOpenPopover(null);
+            setNotaOpen(true);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function clampPip(value: number): number {
+  return Math.max(0, Math.min(Math.round(value), MEDIDOR_MAX));
+}
+
+// ── Building blocks ──────────────────────────────────────────────────────────
+
+interface ActionButtonProps {
+  id: string;
+  icon: LucideIcon;
+  label: string;
+  /** Small secondary line (current value / shortcut hint). */
+  sub?: string;
+  enabled: boolean;
+  active?: boolean;
+  disabledTitle?: string;
+  onClick: () => void;
+}
+
+/** Large (min-h-12) vertical icon+label button; disabled state keeps its tooltip. */
+function ActionButton({
+  id,
+  icon: Icon,
+  label,
+  sub,
+  enabled,
+  active = false,
+  disabledTitle = DISABLED_TITLE,
+  onClick,
+}: ActionButtonProps) {
+  const button = (
+    <Button
+      type="button"
+      variant="outline"
+      data-quicklog={id}
+      disabled={!enabled}
+      aria-expanded={active || undefined}
+      onClick={onClick}
+      className={`h-auto min-h-12 w-full flex-col gap-0.5 px-2 py-1.5 ${
+        active ? 'bg-accent text-accent-foreground' : ''
+      }`}
+    >
+      <Icon aria-hidden />
+      <span className="text-xs leading-none">{label}</span>
+      {sub !== undefined && (
+        <span className="text-[10px] leading-none text-muted-foreground">{sub}</span>
+      )}
+    </Button>
+  );
+
+  if (enabled) return <div className="min-w-0 flex-1 basis-20">{button}</div>;
+  // Button's disabled style sets pointer-events-none; the wrapper keeps the hint.
+  return (
+    <div className="min-w-0 flex-1 basis-20" title={disabledTitle}>
+      {button}
+    </div>
+  );
+}
+
+interface PopoverAnchorProps {
+  open: boolean;
+  onClose: () => void;
+  panel: ReactNode;
+  children: ReactNode;
+}
+
+/** Relative anchor whose panel opens upward; closes on outside click or Escape. */
+function PopoverAnchor({ open, onClose, panel, children }: PopoverAnchorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div ref={containerRef} className="relative flex min-w-0 flex-1 basis-20">
+      {children}
+      {open && (
+        <div className="absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+          {panel}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const CREDIT_DELTAS = [10, 50, 100, -10, -50, -100];
+
+function CreditosPanel({ onDelta }: { onDelta: (delta: number) => void }) {
+  const [custom, setCustom] = useState('');
+
+  const submitCustom = () => {
+    const amount = Number.parseInt(custom, 10);
+    if (!Number.isFinite(amount) || amount === 0) return;
+    onDelta(amount);
+    setCustom('');
+  };
+
+  return (
+    <div className="w-44 space-y-2" data-quicklog-creditos-menu>
+      <div className="grid grid-cols-3 gap-1">
+        {CREDIT_DELTAS.map((delta) => (
+          <Button
+            key={delta}
+            type="button"
+            variant={delta > 0 ? 'secondary' : 'outline'}
+            size="sm"
+            data-quicklog-delta={delta}
+            onClick={() => onDelta(delta)}
+            className={`tabular-nums ${delta < 0 ? 'text-destructive' : ''}`}
+          >
+            {delta > 0 ? `+${delta}` : delta}
+          </Button>
+        ))}
+      </div>
+      <Input
+        data-quicklog-creditos-custom
+        value={custom}
+        onChange={(event) => setCustom(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            submitCustom();
+          }
+        }}
+        placeholder="Cantidad… (−400)"
+        inputMode="numeric"
+        className="h-8"
+        aria-label="Cantidad de créditos"
+      />
+    </div>
+  );
+}
+
+interface PipRowProps {
+  nombre: string;
+  current: number;
+  onPick: (to: number) => void;
+}
+
+/** Six pips 0..5; tapping one commits the new gauge value immediately. */
+function PipRow({ nombre, current, onPick }: PipRowProps) {
+  return (
+    <div className="flex items-center gap-1" data-quicklog-pips={nombre}>
+      {Array.from({ length: MEDIDOR_MAX + 1 }, (_, value) => (
+        <button
+          key={value}
+          type="button"
+          data-quicklog-pip={value}
+          aria-pressed={value === current}
+          onClick={() => onPick(value)}
+          className={`flex size-9 items-center justify-center rounded-full border text-sm tabular-nums transition-colors hover:bg-accent hover:text-accent-foreground ${
+            value === current
+              ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground'
+              : value < current
+                ? 'border-primary/50'
+                : 'border-muted-foreground/40 text-muted-foreground'
+          }`}
+          title={`${medidorLabel(nombre)}: ${value}`}
+        >
+          {value}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/world/QuickLogBar.tsx
+++ b/components/world/QuickLogBar.tsx
@@ -30,7 +30,6 @@ import {
 } from 'lucide-react';
 
 const DISABLED_TITLE = 'Inicia sesión para registrar';
-const EVENTO_TITLE = 'Disponible en M4';
 const MEDIDOR_MAX = 5;
 
 const MEDIDOR_ICONS: Record<string, LucideIcon> = {
@@ -65,6 +64,12 @@ interface QuickLogBarProps {
   onMedidor: (nombre: string, to: number) => void;
   /** Opens the leads tab/dialog (page-owned). */
   onPista: () => void;
+  /**
+   * Opens the estancia EventDrawer (page-owned). Enabled whenever the session
+   * runs — with no applicable tables the drawer shows its empty state instead
+   * of disabling the button (the GM discovers why there).
+   */
+  onEvento: () => void;
   /** Freeform note text (non-empty, trimmed). */
   onNota: (text: string) => void;
 }
@@ -78,6 +83,7 @@ export function QuickLogBar({
   onCreditos,
   onMedidor,
   onPista,
+  onEvento,
   onNota,
 }: QuickLogBarProps) {
   /** Which popover is open: 'creditos' | medidor name | null. */
@@ -220,9 +226,11 @@ export function QuickLogBar({
         id="evento"
         icon={Zap}
         label="Evento"
-        enabled={false}
-        disabledTitle={EVENTO_TITLE}
-        onClick={() => undefined}
+        enabled={enabled}
+        onClick={() => {
+          setOpenPopover(null);
+          onEvento();
+        }}
       />
 
       {/* Nota: inline expanding input (Enter registra, Escape pliega). */}

--- a/components/world/RoutePreview.tsx
+++ b/components/world/RoutePreview.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+/**
+ * RoutePreview — dashed animated route line + midpoint label pill for the
+ * sector tier (M4). Pure SVG: the page renders it into SectorView's
+ * `<g data-layer="routes">` slot with endpoints already in map pixels
+ * (world coords × WORLD_SCALE) and the current zoom `k`, so the pill
+ * counter-scales to constant screen size (same convention as EntityNode
+ * labels). Either endpoint null = nothing to draw yet.
+ */
+
+interface RoutePreviewProps {
+  /** Route endpoints in map pixels; null hides the preview. */
+  fromXY: { x: number; y: number } | null;
+  toXY: { x: number; y: number } | null;
+  /** Pill text, e.g. "3 días · −1 combustible". */
+  label: string;
+  /** Current map zoom; the pill renders at 1/k (constant screen size). */
+  k: number;
+}
+
+const PILL_HEIGHT = 22;
+
+/** Width estimate for the 11px label: ~6.2px per glyph + padding. */
+function pillWidth(label: string): number {
+  return Math.max(48, Math.round(label.length * 6.2) + 20);
+}
+
+export function RoutePreview({ fromXY, toXY, label, k }: RoutePreviewProps) {
+  if (!fromXY || !toXY) return null;
+
+  const midX = (fromXY.x + toXY.x) / 2;
+  const midY = (fromXY.y + toXY.y) / 2;
+  const width = pillWidth(label);
+
+  return (
+    <g data-route-preview className="pointer-events-none">
+      {/* Dash cycle is 8+6=14, so offsetting to -14 loops seamlessly. */}
+      <style>{'@keyframes route-preview-dash { to { stroke-dashoffset: -14; } }'}</style>
+      <line
+        x1={fromXY.x}
+        y1={fromXY.y}
+        x2={toXY.x}
+        y2={toXY.y}
+        className="stroke-primary"
+        strokeWidth={2}
+        strokeDasharray="8 6"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        opacity={0.85}
+        style={{ animation: 'route-preview-dash 0.8s linear infinite' }}
+      />
+      {/* Counter-scaled midpoint pill (constant screen size). */}
+      <g transform={`translate(${midX} ${midY}) scale(${1 / k})`} className="select-none">
+        <rect
+          x={-width / 2}
+          y={-PILL_HEIGHT / 2}
+          width={width}
+          height={PILL_HEIGHT}
+          rx={PILL_HEIGHT / 2}
+          className="fill-background stroke-primary"
+          strokeWidth={1.5}
+        />
+        <text
+          y={3.5}
+          textAnchor="middle"
+          className="fill-foreground text-[11px] font-medium"
+        >
+          {label}
+        </text>
+      </g>
+    </g>
+  );
+}

--- a/components/world/ScrollableTabsRow.tsx
+++ b/components/world/ScrollableTabsRow.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * ScrollableTabsRow — a horizontally scrollable strip for the ActRunner tab
+ * row. When the row overflows it shows a left/right scroll-arrow button on the
+ * overflowing side (and a subtle edge fade) so the GM always knows there are
+ * more tabs off-screen; the arrows disappear at each extreme. Overflow is
+ * measured from the scroll container (scrollLeft / scrollWidth / clientWidth)
+ * and re-measured on scroll and on resize (ResizeObserver on both the viewport
+ * and its content), so it reacts to a narrowing act panel and to tabs mounting
+ * or unmounting when the part changes.
+ *
+ * Purely presentational: the children (the real <TabsList> + triggers) keep
+ * their radix wiring untouched.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+/** How far one arrow click nudges the row, as a fraction of the viewport. */
+const SCROLL_STEP_FRACTION = 0.8;
+/** Sub-pixel slack so the extremes read as "at the edge", not "1px more". */
+const EDGE_EPSILON = 2;
+
+export function ScrollableTabsRow({ children }: { children: React.ReactNode }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [canLeft, setCanLeft] = useState(false);
+  const [canRight, setCanRight] = useState(false);
+
+  const measure = useCallback(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    setCanLeft(el.scrollLeft > EDGE_EPSILON);
+    setCanRight(el.scrollLeft < maxScroll - EDGE_EPSILON);
+  }, []);
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    measure();
+    el.addEventListener('scroll', measure, { passive: true });
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    // Observe the content too: tabs appearing/disappearing changes scrollWidth
+    // without a viewport resize.
+    if (el.firstElementChild) ro.observe(el.firstElementChild);
+    return () => {
+      el.removeEventListener('scroll', measure);
+      ro.disconnect();
+    };
+  }, [measure]);
+
+  const scrollByStep = useCallback((direction: -1 | 1) => {
+    const el = viewportRef.current;
+    if (!el) return;
+    el.scrollBy({ left: direction * el.clientWidth * SCROLL_STEP_FRACTION, behavior: 'smooth' });
+  }, []);
+
+  return (
+    <div className="relative flex min-w-0 items-center">
+      {canLeft && (
+        <>
+          <button
+            type="button"
+            data-tabs-scroll-left
+            aria-label="Desplazar pestañas a la izquierda"
+            onClick={() => scrollByStep(-1)}
+            className="bg-background/90 hover:bg-muted absolute left-0 z-20 flex h-8 w-7 items-center justify-center rounded-md border shadow-sm"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          {/* Edge fade hinting there is more to the left. */}
+          <div className="from-background pointer-events-none absolute left-7 z-10 h-full w-6 bg-gradient-to-r to-transparent" />
+        </>
+      )}
+
+      <div
+        ref={viewportRef}
+        data-tabs-scroll
+        className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {children}
+      </div>
+
+      {canRight && (
+        <>
+          <div className="from-background pointer-events-none absolute right-7 z-10 h-full w-6 bg-gradient-to-l to-transparent" />
+          <button
+            type="button"
+            data-tabs-scroll-right
+            aria-label="Desplazar pestañas a la derecha"
+            onClick={() => scrollByStep(1)}
+            className="bg-background/90 hover:bg-muted absolute right-0 z-20 flex h-8 w-7 items-center justify-center rounded-md border shadow-sm"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/world/SectorView.tsx
+++ b/components/world/SectorView.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Conocimiento, PlaceEntity, SystemEntity } from '@/types/world';
+import { EntityNode } from './EntityNode';
+import { PartyMarker } from './PartyMarker';
+
+/** Pixels per world coordinate unit (1 unit = 1 travel day, per manifest). */
+export const WORLD_SCALE = 60;
+
+interface SectorNode {
+  id: string;
+  nombre: string;
+  tipo: string;
+  conocimiento: Conocimiento;
+  x: number;
+  y: number;
+}
+
+interface SectorViewProps {
+  sistemas: SystemEntity[];
+  /** Deep-space places with own `coordenadas` (nodos, bolsillos, puntos...). */
+  deepSpace: PlaceEntity[];
+  selectedId: string | null;
+  /** Entity id where the party is; the marker renders if that entity is on this tier. */
+  partyLocationId: string | null;
+  /** Actionable-leads count per entity id (amber badge when > 0). */
+  leadsBadgeCounts: Map<string, number>;
+  /** Dominant-faction ring color per entity id; undefined = no ring. */
+  factionColor: (id: string) => string | undefined;
+  /** When false, `conocimiento: desconocido` entities are hidden (screen-share mode). */
+  showUnknown: boolean;
+  onSelect: (id: string) => void;
+  onDrillIn: (id: string) => void;
+}
+
+export function SectorView({
+  sistemas,
+  deepSpace,
+  selectedId,
+  partyLocationId,
+  leadsBadgeCounts,
+  factionColor,
+  showUnknown,
+  onSelect,
+  onDrillIn,
+}: SectorViewProps) {
+  const nodes: SectorNode[] = [
+    ...sistemas.map((sistema) => ({
+      id: sistema.id,
+      nombre: sistema.nombre,
+      tipo: sistema.tipo,
+      conocimiento: sistema.conocimiento,
+      x: sistema.coordenadas.x * WORLD_SCALE,
+      y: sistema.coordenadas.y * WORLD_SCALE,
+    })),
+    ...deepSpace.flatMap((lugar) =>
+      lugar.coordenadas
+        ? [
+            {
+              id: lugar.id,
+              nombre: lugar.nombre,
+              tipo: lugar.tipo,
+              conocimiento: lugar.conocimiento,
+              x: lugar.coordenadas.x * WORLD_SCALE,
+              y: lugar.coordenadas.y * WORLD_SCALE,
+            },
+          ]
+        : []
+    ),
+  ];
+
+  const visible = showUnknown
+    ? nodes
+    : nodes.filter((node) => node.conocimiento !== 'desconocido');
+
+  const partyNode = partyLocationId
+    ? nodes.find((node) => node.id === partyLocationId)
+    : undefined;
+
+  return (
+    <>
+      {/* M4 slot: RoutePreview renders travel lines into this layer. */}
+      <g data-layer="routes" />
+      {partyNode && <PartyMarker x={partyNode.x} y={partyNode.y} />}
+      {visible.map((node) => (
+        <EntityNode
+          key={node.id}
+          id={node.id}
+          nombre={node.nombre}
+          tipo={node.tipo}
+          conocimiento={node.conocimiento}
+          selected={node.id === selectedId}
+          faccionColor={factionColor(node.id)}
+          leadsCount={leadsBadgeCounts.get(node.id)}
+          onSelect={onSelect}
+          onDrillIn={onDrillIn}
+          x={node.x}
+          y={node.y}
+        />
+      ))}
+    </>
+  );
+}

--- a/components/world/SectorView.tsx
+++ b/components/world/SectorView.tsx
@@ -14,6 +14,8 @@ interface SectorNode {
   conocimiento: Conocimiento;
   x: number;
   y: number;
+  /** `acceso: portal` (deep-space lugares only) renders the bracket glyph. */
+  portal?: boolean;
 }
 
 interface SectorViewProps {
@@ -63,6 +65,7 @@ export function SectorView({
               conocimiento: lugar.conocimiento,
               x: lugar.coordenadas.x * WORLD_SCALE,
               y: lugar.coordenadas.y * WORLD_SCALE,
+              portal: lugar.acceso === 'portal',
             },
           ]
         : []
@@ -96,6 +99,8 @@ export function SectorView({
           onDrillIn={onDrillIn}
           x={node.x}
           y={node.y}
+          shape={node.portal ? 'diamond' : undefined}
+          portal={node.portal}
         />
       ))}
     </>

--- a/components/world/SectorView.tsx
+++ b/components/world/SectorView.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { Conocimiento, PlaceEntity, SystemEntity } from '@/types/world';
+import type { NodeAffordances } from '@/lib/world/shops';
 import { EntityNode } from './EntityNode';
 import { PartyMarker } from './PartyMarker';
 
@@ -30,6 +31,8 @@ interface SectorViewProps {
   leadsBadgeCounts: Map<string, number>;
   /** Dominant-faction ring color per entity id; undefined = no ring. */
   factionColor: (id: string) => string | undefined;
+  /** Semantic affordance badges (shop/info) per entity id; undefined = none. */
+  nodeIconsFor: (id: string) => NodeAffordances | undefined;
   /** When false, `conocimiento: desconocido` entities are hidden (screen-share mode). */
   showUnknown: boolean;
   onSelect: (id: string) => void;
@@ -45,6 +48,7 @@ export function SectorView({
   partyLocationId,
   leadsBadgeCounts,
   factionColor,
+  nodeIconsFor,
   showUnknown,
   onSelect,
   onDrillIn,
@@ -99,6 +103,7 @@ export function SectorView({
           selected={node.id === selectedId}
           faccionColor={factionColor(node.id)}
           leadsCount={leadsBadgeCounts.get(node.id)}
+          affordances={nodeIconsFor(node.id)}
           onSelect={onSelect}
           onDrillIn={onDrillIn}
           x={node.x}

--- a/components/world/SectorView.tsx
+++ b/components/world/SectorView.tsx
@@ -3,11 +3,17 @@
 import type { ReactNode } from 'react';
 import { Conocimiento, PlaceEntity, SystemEntity } from '@/types/world';
 import type { NodeAffordances } from '@/lib/world/shops';
+import { WORLD_SCALE } from '@/lib/world/constants';
 import { EntityNode } from './EntityNode';
 import { PartyMarker } from './PartyMarker';
 
-/** Pixels per world coordinate unit (1 unit = 1 travel day, per manifest). */
-export const WORLD_SCALE = 60;
+/**
+ * Pixels per world coordinate unit (1 unit = 1 travel day, per manifest).
+ * Canonical value lives in lib/world/constants.ts (so pure geometry helpers
+ * can use it without pulling in this React component); re-exported here for
+ * the existing SectorView consumers.
+ */
+export { WORLD_SCALE };
 
 interface SectorNode {
   id: string;
@@ -39,6 +45,12 @@ interface SectorViewProps {
   onDrillIn: (id: string) => void;
   /** M4 slot: RoutePreview content rendered into the routes layer. */
   routes?: ReactNode;
+  /**
+   * Story-threads slot ("Hilos" feature): a ThreadLayer overlay painting the
+   * focused trama's narrative web. Rendered BEHIND the EntityNodes so the node
+   * glyphs stay clickable and the halos sit under them.
+   */
+  threads?: ReactNode;
 }
 
 export function SectorView({
@@ -53,6 +65,7 @@ export function SectorView({
   onSelect,
   onDrillIn,
   routes,
+  threads,
 }: SectorViewProps) {
   const nodes: SectorNode[] = [
     ...sistemas.map((sistema) => ({
@@ -90,6 +103,9 @@ export function SectorView({
 
   return (
     <>
+      {/* Hilos slot: the focused trama's thread web sits UNDER the nodes so
+          halos back the glyphs and never steal their clicks. */}
+      <g data-layer="threads">{threads}</g>
       {/* M4 slot: RoutePreview renders travel lines into this layer. */}
       <g data-layer="routes">{routes}</g>
       {partyNode && <PartyMarker x={partyNode.x} y={partyNode.y} />}

--- a/components/world/SectorView.tsx
+++ b/components/world/SectorView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { Conocimiento, PlaceEntity, SystemEntity } from '@/types/world';
 import { EntityNode } from './EntityNode';
 import { PartyMarker } from './PartyMarker';
@@ -33,6 +34,8 @@ interface SectorViewProps {
   showUnknown: boolean;
   onSelect: (id: string) => void;
   onDrillIn: (id: string) => void;
+  /** M4 slot: RoutePreview content rendered into the routes layer. */
+  routes?: ReactNode;
 }
 
 export function SectorView({
@@ -45,6 +48,7 @@ export function SectorView({
   showUnknown,
   onSelect,
   onDrillIn,
+  routes,
 }: SectorViewProps) {
   const nodes: SectorNode[] = [
     ...sistemas.map((sistema) => ({
@@ -83,7 +87,7 @@ export function SectorView({
   return (
     <>
       {/* M4 slot: RoutePreview renders travel lines into this layer. */}
-      <g data-layer="routes" />
+      <g data-layer="routes">{routes}</g>
       {partyNode && <PartyMarker x={partyNode.x} y={partyNode.y} />}
       {visible.map((node) => (
         <EntityNode

--- a/components/world/SessionRecoveryBanner.tsx
+++ b/components/world/SessionRecoveryBanner.tsx
@@ -40,10 +40,23 @@ export function SessionRecoveryBanner({
         <span className="font-mono text-xs text-muted-foreground">({journalName})</span>
       </p>
       <div className="flex shrink-0 items-center gap-2">
-        <Button type="button" size="sm" data-session-recover onClick={onRecover}>
+        <Button
+          type="button"
+          size="sm"
+          data-session-recover
+          onClick={onRecover}
+          className="min-h-11"
+        >
           Recuperar
         </Button>
-        <Button type="button" size="sm" variant="outline" data-session-discard onClick={onDiscard}>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          data-session-discard
+          onClick={onDiscard}
+          className="min-h-11"
+        >
           Descartar
         </Button>
       </div>

--- a/components/world/SessionRecoveryBanner.tsx
+++ b/components/world/SessionRecoveryBanner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * SessionRecoveryBanner — amber strip shown when a sessionStorage mirror (or
+ * a journal with `sesion_activa: true`) survives a crash/reload (M3, plan
+ * Part B write path). Pure: the page decides visibility and owns both
+ * recovery paths.
+ */
+
+import { Button } from '@/components/ui/button';
+import { TriangleAlert } from 'lucide-react';
+
+interface SessionRecoveryBannerProps {
+  visible: boolean;
+  /** Journal file name of the interrupted session, e.g. "2026-07-12_s08.md". */
+  journalName: string;
+  /** Re-arm the session over the mirrored entries. */
+  onRecover: () => void;
+  /** Drop the mirror and stay idle (the file on disk is untouched). */
+  onDiscard: () => void;
+}
+
+export function SessionRecoveryBanner({
+  visible,
+  journalName,
+  onRecover,
+  onDiscard,
+}: SessionRecoveryBannerProps) {
+  if (!visible) return null;
+
+  return (
+    <div
+      data-session-recovery
+      role="alert"
+      className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-amber-500/40 bg-amber-500/15 px-3 py-2"
+    >
+      <TriangleAlert className="size-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />
+      <p className="min-w-0 flex-1 text-sm">
+        Sesión interrumpida detectada{' '}
+        <span className="font-mono text-xs text-muted-foreground">({journalName})</span>
+      </p>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button type="button" size="sm" data-session-recover onClick={onRecover}>
+          Recuperar
+        </Button>
+        <Button type="button" size="sm" variant="outline" data-session-discard onClick={onDiscard}>
+          Descartar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/world/ShopPanel.tsx
+++ b/components/world/ShopPanel.tsx
@@ -133,25 +133,27 @@ export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanel
                 return (
                   <li
                     key={`${item.articulo}-${index}`}
-                    className="flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+                    // Stacked layout: the article/stock line, an optional nota,
+                    // then the price + Comprar row. Keeps price and button fully
+                    // visible in the cockpit's NARROW right-column panel (no
+                    // horizontal clip); the ScrollArea handles vertical overflow.
+                    className="flex flex-col gap-1.5 rounded-md border px-2 py-1.5 text-sm"
                   >
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="min-w-0 truncate font-medium">{item.articulo}</span>
-                        <span
-                          className="shrink-0 text-xs text-muted-foreground tabular-nums"
-                          data-shop-stock
-                        >
-                          x{stockLabel(item.stock)}
-                        </span>
-                      </div>
-                      {item.nota && (
-                        <p className="truncate text-xs text-muted-foreground">{item.nota}</p>
-                      )}
+                    <div className="flex items-center gap-2">
+                      <span className="min-w-0 flex-1 truncate font-medium">{item.articulo}</span>
+                      <span
+                        className="shrink-0 text-xs text-muted-foreground tabular-nums"
+                        data-shop-stock
+                      >
+                        x{stockLabel(item.stock)}
+                      </span>
                     </div>
-                    {/* Editable / negotiable price: the input holds the current
-                        per-row amount; the base hint shows the deviation. */}
-                    <div className="flex shrink-0 flex-col items-end gap-0.5">
+                    {item.nota && (
+                      <p className="text-xs text-muted-foreground">{item.nota}</p>
+                    )}
+                    <div className="flex items-center justify-between gap-2">
+                      {/* Editable / negotiable price: the input holds the current
+                          per-row amount; the base hint shows the deviation. */}
                       <span className="flex items-center gap-1" data-shop-price>
                         <Input
                           data-shop-price-input={item.articulo}
@@ -162,44 +164,44 @@ export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanel
                           }
                           aria-label={`Precio de ${item.articulo}`}
                           aria-invalid={precioInvalido || undefined}
-                          className="h-8 w-[6ch] px-1.5 text-right tabular-nums"
+                          className="h-8 w-[7ch] px-1.5 text-right tabular-nums"
                         />
                         <span className="text-xs text-muted-foreground">cr</span>
+                        {negociado && (
+                          <span
+                            className="text-[10px] leading-none text-muted-foreground tabular-nums"
+                            data-shop-price-base
+                          >
+                            base {item.precio.toLocaleString('es-ES')}
+                          </span>
+                        )}
                       </span>
-                      {negociado && (
-                        <span
-                          className="text-[10px] leading-none text-muted-foreground tabular-nums"
-                          data-shop-price-base
+                      {/* The disabled wrapper keeps the tooltip (Button sets
+                          pointer-events-none when disabled). */}
+                      <span title={title} className="shrink-0">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          data-shop-buy={item.articulo}
+                          disabled={buyDisabled}
+                          onClick={() => {
+                            if (precio === null) return;
+                            onBuy(item, precio);
+                            // Reset the row back to its base price after a buy.
+                            setEdited((prev) => {
+                              const next = { ...prev };
+                              delete next[index];
+                              return next;
+                            });
+                          }}
+                          className="min-h-11"
                         >
-                          base {item.precio.toLocaleString('es-ES')}
-                        </span>
-                      )}
+                          <ShoppingCart aria-hidden />
+                          Comprar
+                        </Button>
+                      </span>
                     </div>
-                    {/* The disabled wrapper keeps the tooltip (Button sets
-                        pointer-events-none when disabled). */}
-                    <span title={title} className="shrink-0">
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="secondary"
-                        data-shop-buy={item.articulo}
-                        disabled={buyDisabled}
-                        onClick={() => {
-                          if (precio === null) return;
-                          onBuy(item, precio);
-                          // Reset the row back to its base price after a buy.
-                          setEdited((prev) => {
-                            const next = { ...prev };
-                            delete next[index];
-                            return next;
-                          });
-                        }}
-                        className="min-h-11"
-                      >
-                        <ShoppingCart aria-hidden />
-                        Comprar
-                      </Button>
-                    </span>
                   </li>
                 );
               })}

--- a/components/world/ShopPanel.tsx
+++ b/components/world/ShopPanel.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+/**
+ * ShopPanel — right-panel storefront view for a selected shop (feature — shop
+ * system). Pure and props-driven, mirroring PnjCard/EntityPanel styling.
+ *
+ * Rendered by /world in place of the EntityPanel when the GM opens a shop from
+ * the place panel's "Tiendas" section (page state `selectedShopId`, swapped the
+ * same way selectedPnj swaps in PnjCard). The back button returns to the place.
+ *
+ * Each item row carries a "Comprar" button (data-shop-buy). Buying is
+ * session-gated: `enabled=false` disables every button with the hint tooltip;
+ * an item at stock 0 is also disabled (agotado). Unlimited stock (null) renders
+ * as an infinity mark and never sells out.
+ */
+
+import type { Shop, ShopItem } from '@/types/world';
+import { MarkdownViewer } from '@/components/play/MarkdownViewer';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ArrowLeft, ShoppingCart, User } from 'lucide-react';
+
+interface ShopPanelProps {
+  shop: Shop;
+  /** Display name of the shopkeeper pnj, pre-resolved (raw id as fallback). */
+  pnjNombre?: string;
+  /** Back to the place that owns the shop. */
+  onBack: () => void;
+  /** Buy one unit of `item` (page journals the gasto + decrements stock). */
+  onBuy: (item: ShopItem) => void;
+  /** False without an active session: every Comprar disabled with a hint. */
+  enabled: boolean;
+}
+
+const DISABLED_TITLE = 'Inicia sesión para comprar';
+
+function stockLabel(stock: number | null): string {
+  return stock === null ? '∞' : String(stock);
+}
+
+export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanelProps) {
+  const hasBody = shop.body.trim().length > 0;
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-shop-panel={shop.id}>
+      <CardHeader className="border-b py-4">
+        <CardTitle className="text-base">{shop.nombre}</CardTitle>
+        <div className="flex flex-wrap items-center gap-1">
+          {pnjNombre && (
+            <Badge variant="secondary" className="gap-1" data-shop-keeper>
+              <User className="size-3" aria-hidden />
+              {pnjNombre}
+            </Badge>
+          )}
+          {shop.etiquetas.map((etiqueta) => (
+            <Badge key={etiqueta} variant="outline" className="text-muted-foreground">
+              {etiqueta}
+            </Badge>
+          ))}
+        </div>
+        <CardAction>
+          {/* min-h-11 = 44px tap target (M5 sweep). */}
+          <Button
+            variant="ghost"
+            size="sm"
+            data-shop-back
+            onClick={onBack}
+            aria-label="Volver al lugar"
+            className="min-h-11"
+          >
+            <ArrowLeft />
+            Volver
+          </Button>
+        </CardAction>
+      </CardHeader>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <CardContent className="flex flex-col gap-4 py-4">
+          {hasBody && <MarkdownViewer content={shop.body} className="prose-sm" />}
+
+          {shop.items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Sin artículos a la venta.</p>
+          ) : (
+            <ul className="flex flex-col gap-1.5">
+              {shop.items.map((item, index) => {
+                const agotado = item.stock === 0;
+                const buyDisabled = !enabled || agotado;
+                const title = !enabled
+                  ? DISABLED_TITLE
+                  : agotado
+                    ? 'Sin existencias'
+                    : undefined;
+                return (
+                  <li
+                    key={`${item.articulo}-${index}`}
+                    className="flex items-center gap-2 rounded-md border px-2 py-1.5 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="min-w-0 truncate font-medium">{item.articulo}</span>
+                        <span
+                          className="shrink-0 text-xs text-muted-foreground tabular-nums"
+                          data-shop-stock
+                        >
+                          x{stockLabel(item.stock)}
+                        </span>
+                      </div>
+                      {item.nota && (
+                        <p className="truncate text-xs text-muted-foreground">{item.nota}</p>
+                      )}
+                    </div>
+                    <span className="shrink-0 tabular-nums" data-shop-price>
+                      {item.precio.toLocaleString('es-ES')} cr
+                    </span>
+                    {/* The disabled wrapper keeps the tooltip (Button sets
+                        pointer-events-none when disabled). */}
+                    <span title={title} className="shrink-0">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        data-shop-buy={item.articulo}
+                        disabled={buyDisabled}
+                        onClick={() => onBuy(item)}
+                        className="min-h-11"
+                      >
+                        <ShoppingCart aria-hidden />
+                        Comprar
+                      </Button>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </ScrollArea>
+    </Card>
+  );
+}

--- a/components/world/ShopPanel.tsx
+++ b/components/world/ShopPanel.tsx
@@ -12,13 +12,23 @@
  * session-gated: `enabled=false` disables every button with the hint tooltip;
  * an item at stock 0 is also disabled (agotado). Unlimited stock (null) renders
  * as an infinity mark and never sells out.
+ *
+ * The price is NEGOTIABLE: each row shows an editable numeric input
+ * (data-shop-price-input) defaulting to item.precio; the GM can adjust it and
+ * Comprar charges the edited amount. A blank/NaN/negative input disables
+ * Comprar (never journals NaN); zero is allowed (a freebie). Edits reset when
+ * the shop changes or after a successful buy (keyed by the shop id + a bump
+ * counter). When the edited price deviates from the base a subtle "base <n>"
+ * hint appears.
  */
 
+import { useEffect, useState } from 'react';
 import type { Shop, ShopItem } from '@/types/world';
 import { MarkdownViewer } from '@/components/play/MarkdownViewer';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ArrowLeft, ShoppingCart, User } from 'lucide-react';
 
@@ -28,8 +38,11 @@ interface ShopPanelProps {
   pnjNombre?: string;
   /** Back to the place that owns the shop. */
   onBack: () => void;
-  /** Buy one unit of `item` (page journals the gasto + decrements stock). */
-  onBuy: (item: ShopItem) => void;
+  /**
+   * Buy one unit of `item` at `precio` (the negotiated amount, which may differ
+   * from item.precio). The page journals the gasto + decrements stock.
+   */
+  onBuy: (item: ShopItem, precio: number) => void;
   /** False without an active session: every Comprar disabled with a hint. */
   enabled: boolean;
 }
@@ -40,8 +53,27 @@ function stockLabel(stock: number | null): string {
   return stock === null ? '∞' : String(stock);
 }
 
+/** Parse an edited price field: a non-negative finite integer, else null. */
+function parsePrice(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value < 0) return null;
+  return Math.trunc(value);
+}
+
 export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanelProps) {
   const hasBody = shop.body.trim().length > 0;
+
+  /**
+   * Per-row edited price strings, keyed by item index. Reset whenever the shop
+   * changes (a new id remounts the map values). Cleared for a row after a
+   * successful buy so the field falls back to the item's base price.
+   */
+  const [edited, setEdited] = useState<Record<number, string>>({});
+  useEffect(() => {
+    setEdited({});
+  }, [shop.id]);
 
   return (
     <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-shop-panel={shop.id}>
@@ -86,12 +118,18 @@ export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanel
             <ul className="flex flex-col gap-1.5">
               {shop.items.map((item, index) => {
                 const agotado = item.stock === 0;
-                const buyDisabled = !enabled || agotado;
+                const raw = edited[index] ?? String(item.precio);
+                const precio = parsePrice(raw);
+                const precioInvalido = precio === null;
+                const negociado = precio !== null && precio !== item.precio;
+                const buyDisabled = !enabled || agotado || precioInvalido;
                 const title = !enabled
                   ? DISABLED_TITLE
                   : agotado
                     ? 'Sin existencias'
-                    : undefined;
+                    : precioInvalido
+                      ? 'Introduce un precio válido'
+                      : undefined;
                 return (
                   <li
                     key={`${item.articulo}-${index}`}
@@ -111,9 +149,32 @@ export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanel
                         <p className="truncate text-xs text-muted-foreground">{item.nota}</p>
                       )}
                     </div>
-                    <span className="shrink-0 tabular-nums" data-shop-price>
-                      {item.precio.toLocaleString('es-ES')} cr
-                    </span>
+                    {/* Editable / negotiable price: the input holds the current
+                        per-row amount; the base hint shows the deviation. */}
+                    <div className="flex shrink-0 flex-col items-end gap-0.5">
+                      <span className="flex items-center gap-1" data-shop-price>
+                        <Input
+                          data-shop-price-input={item.articulo}
+                          inputMode="numeric"
+                          value={raw}
+                          onChange={(event) =>
+                            setEdited((prev) => ({ ...prev, [index]: event.target.value }))
+                          }
+                          aria-label={`Precio de ${item.articulo}`}
+                          aria-invalid={precioInvalido || undefined}
+                          className="h-8 w-[6ch] px-1.5 text-right tabular-nums"
+                        />
+                        <span className="text-xs text-muted-foreground">cr</span>
+                      </span>
+                      {negociado && (
+                        <span
+                          className="text-[10px] leading-none text-muted-foreground tabular-nums"
+                          data-shop-price-base
+                        >
+                          base {item.precio.toLocaleString('es-ES')}
+                        </span>
+                      )}
+                    </div>
                     {/* The disabled wrapper keeps the tooltip (Button sets
                         pointer-events-none when disabled). */}
                     <span title={title} className="shrink-0">
@@ -123,7 +184,16 @@ export function ShopPanel({ shop, pnjNombre, onBack, onBuy, enabled }: ShopPanel
                         variant="secondary"
                         data-shop-buy={item.articulo}
                         disabled={buyDisabled}
-                        onClick={() => onBuy(item)}
+                        onClick={() => {
+                          if (precio === null) return;
+                          onBuy(item, precio);
+                          // Reset the row back to its base price after a buy.
+                          setEdited((prev) => {
+                            const next = { ...prev };
+                            delete next[index];
+                            return next;
+                          });
+                        }}
                         className="min-h-11"
                       >
                         <ShoppingCart aria-hidden />

--- a/components/world/SiteList.tsx
+++ b/components/world/SiteList.tsx
@@ -24,6 +24,7 @@ import {
   Info,
   LucideIcon,
   Music,
+  Play,
   ShoppingCart,
   Star,
   Wrench,
@@ -60,9 +61,19 @@ interface SiteListProps {
   partyLocationId: string | null;
   onSelect: (id: string) => void;
   onBack: () => void;
+  /** Opens the ActRunner for a playable row (M5); rows without `playable` never offer it. */
+  onPlay?: (id: string) => void;
 }
 
-export function SiteList({ lugar, sites, leads, partyLocationId, onSelect, onBack }: SiteListProps) {
+export function SiteList({
+  lugar,
+  sites,
+  leads,
+  partyLocationId,
+  onSelect,
+  onBack,
+  onPlay,
+}: SiteListProps) {
   const actionableAt = new Set(
     leads.filter((lead) => lead.accionable === true && lead.donde).map((lead) => lead.donde as string)
   );
@@ -78,7 +89,8 @@ export function SiteList({ lugar, sites, leads, partyLocationId, onSelect, onBac
     <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-site-list={lugar.id}>
       <CardHeader className="border-b py-4">
         <CardTitle className="flex min-w-0 items-center gap-2 text-base">
-          <Button variant="ghost" size="icon-sm" onClick={onBack} aria-label="Volver">
+          {/* size-11 = 44px tap target (M5 sweep). */}
+          <Button variant="ghost" size="icon" onClick={onBack} aria-label="Volver" className="size-11">
             <ArrowLeft />
           </Button>
           <span className="min-w-0 truncate">{lugar.nombre}</span>
@@ -108,6 +120,7 @@ export function SiteList({ lugar, sites, leads, partyLocationId, onSelect, onBac
                     actionable={actionableAt.has(site.id)}
                     partyHere={site.id === partyLocationId}
                     onSelect={onSelect}
+                    onPlay={onPlay}
                   />
                 </li>
               ))}
@@ -124,52 +137,73 @@ interface SiteRowProps {
   actionable: boolean;
   partyHere: boolean;
   onSelect: (id: string) => void;
+  onPlay?: (id: string) => void;
 }
 
-function SiteRow({ site, actionable, partyHere, onSelect }: SiteRowProps) {
+// The select surface and the Jugar affordance are SIBLING buttons inside a
+// styled row container (a button cannot nest another button).
+function SiteRow({ site, actionable, partyHere, onSelect, onPlay }: SiteRowProps) {
   return (
-    <button
-      type="button"
-      data-site-id={site.id}
-      data-knowledge={site.conocimiento}
-      onClick={() => onSelect(site.id)}
-      className={`flex w-full items-center gap-2 rounded-md border p-2 text-left transition-colors hover:bg-accent ${
+    <div
+      className={`flex w-full items-center rounded-md border transition-colors hover:bg-accent ${
         site.conocimiento === 'desconocido' ? 'opacity-50' : ''
       }`}
     >
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <div className="flex items-center gap-2">
-          <span className="min-w-0 truncate text-sm font-medium">{site.nombre}</span>
-          {actionable && (
-            <Star
-              className="size-3.5 shrink-0 fill-amber-400 text-amber-500"
-              aria-label="Pista accionable"
-            />
-          )}
-          {partyHere && <Badge className="shrink-0">Estáis aquí</Badge>}
+      <button
+        type="button"
+        data-site-id={site.id}
+        data-knowledge={site.conocimiento}
+        onClick={() => onSelect(site.id)}
+        className="flex min-w-0 flex-1 items-center gap-2 p-2 text-left"
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="min-w-0 truncate text-sm font-medium">{site.nombre}</span>
+            {actionable && (
+              <Star
+                className="size-3.5 shrink-0 fill-amber-400 text-amber-500"
+                aria-label="Pista accionable"
+              />
+            )}
+            {partyHere && <Badge className="shrink-0">Estáis aquí</Badge>}
+          </div>
+          <div className="flex flex-wrap items-center gap-1">
+            <Badge variant="secondary">{site.tipo}</Badge>
+            <Badge variant="outline">{CONOCIMIENTO_LABEL[site.conocimiento]}</Badge>
+            {site.servicios.length > 0 && (
+              <span className="ml-1 flex items-center gap-1.5 text-muted-foreground">
+                {site.servicios.map((servicio) => {
+                  const Icon = SERVICIO_ICONS[servicio];
+                  return Icon ? (
+                    <span key={servicio} title={servicio} className="inline-flex">
+                      <Icon className="size-3.5" aria-label={servicio} />
+                    </span>
+                  ) : (
+                    <Badge key={servicio} variant="outline" className="text-muted-foreground">
+                      {servicio}
+                    </Badge>
+                  );
+                })}
+              </span>
+            )}
+          </div>
         </div>
-        <div className="flex flex-wrap items-center gap-1">
-          <Badge variant="secondary">{site.tipo}</Badge>
-          <Badge variant="outline">{CONOCIMIENTO_LABEL[site.conocimiento]}</Badge>
-          {site.servicios.length > 0 && (
-            <span className="ml-1 flex items-center gap-1.5 text-muted-foreground">
-              {site.servicios.map((servicio) => {
-                const Icon = SERVICIO_ICONS[servicio];
-                return Icon ? (
-                  <span key={servicio} title={servicio} className="inline-flex">
-                    <Icon className="size-3.5" aria-label={servicio} />
-                  </span>
-                ) : (
-                  <Badge key={servicio} variant="outline" className="text-muted-foreground">
-                    {servicio}
-                  </Badge>
-                );
-              })}
-            </span>
-          )}
-        </div>
-      </div>
-      <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-    </button>
+        <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+      </button>
+      {onPlay && site.playable && (
+        <Button
+          variant="ghost"
+          size="icon"
+          // size-11 = 44px tap target (M5 sweep).
+          className="mr-1 size-11 shrink-0"
+          data-play-site={site.id}
+          aria-label={`Jugar ${site.nombre}`}
+          title="Jugar"
+          onClick={() => onPlay(site.id)}
+        >
+          <Play />
+        </Button>
+      )}
+    </div>
   );
 }

--- a/components/world/SiteList.tsx
+++ b/components/world/SiteList.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+/**
+ * SiteList — non-spatial third map tier (plan Part B): the sites inside a
+ * lugar rendered as a list panel instead of coordinates. Each row shows
+ * knowledge, services and actionable-lead signals; selecting a row opens it
+ * in the EntityPanel (wiring belongs to the page, not this component).
+ */
+
+import { Conocimiento, Lead, PlaceEntity } from '@/types/world';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Anchor,
+  ArrowLeft,
+  Briefcase,
+  ChevronRight,
+  EyeOff,
+  Fuel,
+  HeartPulse,
+  Home,
+  Info,
+  LucideIcon,
+  Music,
+  ShoppingCart,
+  Star,
+  Wrench,
+} from 'lucide-react';
+
+const CONOCIMIENTO_LABEL: Record<Conocimiento, string> = {
+  desconocido: 'Desconocido',
+  rumoreado: 'Rumoreado',
+  conocido: 'Conocido',
+  visitado: 'Visitado',
+};
+
+/** Closed `servicios:` vocabulary -> icon; out-of-vocab values render as text. */
+const SERVICIO_ICONS: Record<string, LucideIcon> = {
+  repostaje: Fuel,
+  mercado: ShoppingCart,
+  medico: HeartPulse,
+  taller: Wrench,
+  astillero: Anchor,
+  trabajo: Briefcase,
+  informacion: Info,
+  ocio: Music,
+  refugio: Home,
+  contrabando: EyeOff,
+};
+
+interface SiteListProps {
+  /** The lugar whose interior is being listed. */
+  lugar: PlaceEntity;
+  /** Child sites of `lugar` (`en:` inverse), pre-resolved by the page. */
+  sites: PlaceEntity[];
+  /** Pistas whose `donde` is this lugar or one of its sites. */
+  leads: Lead[];
+  partyLocationId: string | null;
+  onSelect: (id: string) => void;
+  onBack: () => void;
+}
+
+export function SiteList({ lugar, sites, leads, partyLocationId, onSelect, onBack }: SiteListProps) {
+  const actionableAt = new Set(
+    leads.filter((lead) => lead.accionable === true && lead.donde).map((lead) => lead.donde as string)
+  );
+
+  const sorted = [...sites].sort((a, b) => {
+    const orbitaA = a.orbita ?? Number.POSITIVE_INFINITY;
+    const orbitaB = b.orbita ?? Number.POSITIVE_INFINITY;
+    if (orbitaA !== orbitaB) return orbitaA - orbitaB;
+    return a.nombre.localeCompare(b.nombre, 'es');
+  });
+
+  return (
+    <Card className="flex h-full flex-col gap-0 overflow-hidden py-0" data-site-list={lugar.id}>
+      <CardHeader className="border-b py-4">
+        <CardTitle className="flex min-w-0 items-center gap-2 text-base">
+          <Button variant="ghost" size="icon-sm" onClick={onBack} aria-label="Volver">
+            <ArrowLeft />
+          </Button>
+          <span className="min-w-0 truncate">{lugar.nombre}</span>
+          {actionableAt.has(lugar.id) && (
+            <Star className="size-3.5 shrink-0 fill-amber-400 text-amber-500" aria-label="Pista accionable" />
+          )}
+          {partyLocationId === lugar.id && <Badge className="shrink-0">Estáis aquí</Badge>}
+        </CardTitle>
+        <div className="flex flex-wrap items-center gap-1">
+          <Badge variant="secondary">{lugar.tipo}</Badge>
+          <Badge variant="outline">{CONOCIMIENTO_LABEL[lugar.conocimiento]}</Badge>
+        </div>
+      </CardHeader>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <CardContent className="py-3">
+          {sorted.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              Sin lugares detallados — solo prosa del GM.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1.5">
+              {sorted.map((site) => (
+                <li key={site.id}>
+                  <SiteRow
+                    site={site}
+                    actionable={actionableAt.has(site.id)}
+                    partyHere={site.id === partyLocationId}
+                    onSelect={onSelect}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </ScrollArea>
+    </Card>
+  );
+}
+
+interface SiteRowProps {
+  site: PlaceEntity;
+  actionable: boolean;
+  partyHere: boolean;
+  onSelect: (id: string) => void;
+}
+
+function SiteRow({ site, actionable, partyHere, onSelect }: SiteRowProps) {
+  return (
+    <button
+      type="button"
+      data-site-id={site.id}
+      data-knowledge={site.conocimiento}
+      onClick={() => onSelect(site.id)}
+      className={`flex w-full items-center gap-2 rounded-md border p-2 text-left transition-colors hover:bg-accent ${
+        site.conocimiento === 'desconocido' ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span className="min-w-0 truncate text-sm font-medium">{site.nombre}</span>
+          {actionable && (
+            <Star
+              className="size-3.5 shrink-0 fill-amber-400 text-amber-500"
+              aria-label="Pista accionable"
+            />
+          )}
+          {partyHere && <Badge className="shrink-0">Estáis aquí</Badge>}
+        </div>
+        <div className="flex flex-wrap items-center gap-1">
+          <Badge variant="secondary">{site.tipo}</Badge>
+          <Badge variant="outline">{CONOCIMIENTO_LABEL[site.conocimiento]}</Badge>
+          {site.servicios.length > 0 && (
+            <span className="ml-1 flex items-center gap-1.5 text-muted-foreground">
+              {site.servicios.map((servicio) => {
+                const Icon = SERVICIO_ICONS[servicio];
+                return Icon ? (
+                  <span key={servicio} title={servicio} className="inline-flex">
+                    <Icon className="size-3.5" aria-label={servicio} />
+                  </span>
+                ) : (
+                  <Badge key={servicio} variant="outline" className="text-muted-foreground">
+                    {servicio}
+                  </Badge>
+                );
+              })}
+            </span>
+          )}
+        </div>
+      </div>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+    </button>
+  );
+}

--- a/components/world/StarMap.tsx
+++ b/components/world/StarMap.tsx
@@ -234,10 +234,12 @@ export function StarMap({
         <div className="ml-auto">
           <Button
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             onClick={onToggleCollapsed}
             title="Expandir mapa"
             aria-label="Expandir mapa"
+            // size-11 = 44px tap target (M5 sweep).
+            className="size-11"
           >
             <Maximize2 />
           </Button>
@@ -271,25 +273,28 @@ export function StarMap({
           <Breadcrumbs items={breadcrumb} />
         </div>
         {header && <div className="pointer-events-auto">{header}</div>}
+        {/* size-11 = 44px tap targets on the overlay controls (M5 sweep). */}
         <div className="pointer-events-auto flex items-center gap-1 rounded-md border bg-background/80 p-1 backdrop-blur-sm">
           <Button
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             onClick={onToggleUnknown}
             title={showUnknown ? 'Ocultar entidades desconocidas' : 'Mostrar entidades desconocidas'}
             aria-label={
               showUnknown ? 'Ocultar entidades desconocidas' : 'Mostrar entidades desconocidas'
             }
             aria-pressed={showUnknown}
+            className="size-11"
           >
             {showUnknown ? <Eye /> : <EyeOff />}
           </Button>
           <Button
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             onClick={onToggleCollapsed}
             title="Plegar mapa"
             aria-label="Plegar mapa"
+            className="size-11"
           >
             <Minimize2 />
           </Button>
@@ -311,7 +316,9 @@ function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
               <button
                 type="button"
                 onClick={item.onClick}
-                className="rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                // before: pseudo extends the tap area to ~44px without growing
+                // the breadcrumb pill (M5 tap-target sweep).
+                className="relative rounded px-1 py-0.5 text-muted-foreground transition-colors before:absolute before:-inset-x-0.5 before:-inset-y-2 before:content-[''] hover:bg-accent hover:text-accent-foreground"
               >
                 {item.label}
               </button>

--- a/components/world/StarMap.tsx
+++ b/components/world/StarMap.tsx
@@ -10,7 +10,15 @@ import {
 } from 'react';
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
-import { ChevronRight, Eye, EyeOff, Maximize2, Minimize2 } from 'lucide-react';
+import {
+  ChevronRight,
+  Eye,
+  EyeOff,
+  Maximize2,
+  MessageCircle,
+  Minimize2,
+  ShoppingCart,
+} from 'lucide-react';
 
 /** Viewport applied to the map content: `translate(x, y) scale(k)`. */
 export interface MapViewport {
@@ -295,6 +303,27 @@ export function StarMap({
             <Minimize2 />
           </Button>
         </div>
+      </div>
+
+      {/* Affordance legend: a subtle key so the node icons are self-explanatory.
+          Bottom-left corner, muted + small, so it never blocks the map body or
+          the top controls row. */}
+      <div
+        data-map-legend
+        className="pointer-events-none absolute bottom-2 left-2 flex flex-col gap-0.5 rounded-md border bg-background/80 px-2 py-1 text-[11px] text-muted-foreground backdrop-blur-sm"
+      >
+        <span className="flex items-center gap-1.5">
+          <ShoppingCart className="size-3 text-emerald-500" aria-hidden />
+          Tienda
+        </span>
+        <span className="flex items-center gap-1.5">
+          <MessageCircle className="size-3 text-sky-500" aria-hidden />
+          Información
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block size-2 rounded-full bg-amber-500" aria-hidden />
+          Misión / rumor
+        </span>
       </div>
     </div>
   );

--- a/components/world/StarMap.tsx
+++ b/components/world/StarMap.tsx
@@ -61,8 +61,6 @@ interface StarMapProps {
   onToggleUnknown: () => void;
   collapsed: boolean;
   onToggleCollapsed: () => void;
-  /** Optional extra overlay content (top-center), e.g. a tier hint. */
-  header?: ReactNode;
 }
 
 /** Subtle repeating star field — pure CSS, theme-aware, no images. */
@@ -99,7 +97,6 @@ export function StarMap({
   onToggleUnknown,
   collapsed,
   onToggleCollapsed,
-  header,
 }: StarMapProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const gRef = useRef<SVGGElement>(null);
@@ -272,7 +269,6 @@ export function StarMap({
         <div className="pointer-events-auto flex items-center rounded-md border bg-background/80 px-2 py-1 backdrop-blur-sm">
           <Breadcrumbs items={breadcrumb} />
         </div>
-        {header && <div className="pointer-events-auto">{header}</div>}
         {/* size-11 = 44px tap targets on the overlay controls (M5 sweep). */}
         <div className="pointer-events-auto flex items-center gap-1 rounded-md border bg-background/80 p-1 backdrop-blur-sm">
           <Button

--- a/components/world/StarMap.tsx
+++ b/components/world/StarMap.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { ChevronRight, Eye, EyeOff, Maximize2, Minimize2 } from 'lucide-react';
+
+/** Viewport applied to the map content: `translate(x, y) scale(k)`. */
+export interface MapViewport {
+  x: number;
+  y: number;
+  k: number;
+}
+
+export interface BreadcrumbItem {
+  label: string;
+  onClick?: () => void;
+}
+
+const MIN_ZOOM = 0.3;
+const MAX_ZOOM = 8;
+/** Pixels the pointer must travel before a press becomes a pan (protects node clicks). */
+const DRAG_THRESHOLD_PX = 4;
+/** Quiet period after the last wheel tick before the zoom gesture counts as finished. */
+const WHEEL_SETTLE_MS = 250;
+/** Wheel delta → zoom factor sensitivity. */
+const WHEEL_ZOOM_SPEED = 0.002;
+
+const MapScaleContext = createContext(1);
+
+/**
+ * Current zoom factor `k` of the enclosing StarMap. Map children (EntityNode)
+ * counter-scale labels/badges by `1/k` so text stays a constant screen size.
+ *
+ * Tradeoff: the `<g>` transform is applied imperatively via `setAttribute`
+ * during gestures (60fps pan/zoom with zero React re-renders), but the
+ * counter-scale needs React, so `k` is mirrored into state at most once per
+ * animation frame while zooming. Labels may trail the geometry by one frame
+ * mid-zoom; panning never triggers a re-render at all.
+ */
+export function useMapScale(): number {
+  return useContext(MapScaleContext);
+}
+
+interface StarMapProps {
+  /** The tier view (SVG content), e.g. `<SectorView />`. */
+  children: ReactNode;
+  viewport?: MapViewport;
+  /** Called once per finished gesture (pointer released / wheel settled). */
+  onViewportChange?: (viewport: MapViewport) => void;
+  breadcrumb: BreadcrumbItem[];
+  /** Whether `conocimiento: desconocido` entities render (ghosted) or hide. */
+  showUnknown: boolean;
+  onToggleUnknown: () => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  /** Optional extra overlay content (top-center), e.g. a tier hint. */
+  header?: ReactNode;
+}
+
+/** Subtle repeating star field — pure CSS, theme-aware, no images. */
+const STARFIELD_STYLE: CSSProperties = {
+  backgroundImage: [
+    'radial-gradient(1px 1px at 22% 31%, color-mix(in oklab, var(--foreground) 55%, transparent), transparent)',
+    'radial-gradient(1px 1px at 64% 78%, color-mix(in oklab, var(--foreground) 40%, transparent), transparent)',
+    'radial-gradient(1.5px 1.5px at 83% 12%, color-mix(in oklab, var(--foreground) 30%, transparent), transparent)',
+    'radial-gradient(1px 1px at 41% 57%, color-mix(in oklab, var(--foreground) 22%, transparent), transparent)',
+  ].join(', '),
+  backgroundSize: '210px 210px, 290px 290px, 370px 370px, 450px 450px',
+};
+
+function toTransform(viewport: MapViewport): string {
+  return `translate(${viewport.x} ${viewport.y}) scale(${viewport.k})`;
+}
+
+interface DragState {
+  pointerId: number;
+  lastX: number;
+  lastY: number;
+  startX: number;
+  startY: number;
+  /** True once the drag threshold was crossed and the pointer is captured. */
+  active: boolean;
+}
+
+export function StarMap({
+  children,
+  viewport,
+  onViewportChange,
+  breadcrumb,
+  showUnknown,
+  onToggleUnknown,
+  collapsed,
+  onToggleCollapsed,
+  header,
+}: StarMapProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const gRef = useRef<SVGGElement>(null);
+  const viewRef = useRef<MapViewport>(viewport ? { ...viewport } : { x: 0, y: 0, k: 1 });
+  const dragRef = useRef<DragState | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const wheelEndRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const viewportChangeRef = useRef(onViewportChange);
+
+  // React only tracks k, for the label counter-scale (see useMapScale docs).
+  const [k, setK] = useState(viewRef.current.k);
+
+  useEffect(() => {
+    viewportChangeRef.current = onViewportChange;
+  }, [onViewportChange]);
+
+  const applyTransform = useCallback(() => {
+    gRef.current?.setAttribute('transform', toTransform(viewRef.current));
+  }, []);
+
+  /** Mirror k into React state at most once per animation frame. */
+  const scheduleScaleSync = useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      setK(viewRef.current.k);
+    });
+  }, []);
+
+  const emitViewportChange = useCallback(() => {
+    viewportChangeRef.current?.({ ...viewRef.current });
+  }, []);
+
+  // Adopt an externally-provided viewport (e.g. restored persistence, tier change).
+  useEffect(() => {
+    if (!viewport) return;
+    const current = viewRef.current;
+    if (viewport.x === current.x && viewport.y === current.y && viewport.k === current.k) return;
+    viewRef.current = { ...viewport };
+    applyTransform();
+    setK(viewport.k);
+  }, [viewport, applyTransform]);
+
+  // Wheel zoom-to-cursor. Native listener: React delegates wheel as passive,
+  // so preventDefault() (needed to stop page scroll) only works here.
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const rect = svg.getBoundingClientRect();
+      const cursorX = event.clientX - rect.left;
+      const cursorY = event.clientY - rect.top;
+      const view = viewRef.current;
+      const nextK = Math.min(
+        MAX_ZOOM,
+        Math.max(MIN_ZOOM, view.k * Math.exp(-event.deltaY * WHEEL_ZOOM_SPEED))
+      );
+      // Keep the world point under the cursor fixed while k changes.
+      view.x = cursorX - ((cursorX - view.x) / view.k) * nextK;
+      view.y = cursorY - ((cursorY - view.y) / view.k) * nextK;
+      view.k = nextK;
+      applyTransform();
+      scheduleScaleSync();
+      if (wheelEndRef.current !== null) clearTimeout(wheelEndRef.current);
+      wheelEndRef.current = setTimeout(() => {
+        wheelEndRef.current = null;
+        viewportChangeRef.current?.({ ...viewRef.current });
+      }, WHEEL_SETTLE_MS);
+    };
+    svg.addEventListener('wheel', handleWheel, { passive: false });
+    return () => svg.removeEventListener('wheel', handleWheel);
+  }, [collapsed, applyTransform, scheduleScaleSync]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (wheelEndRef.current !== null) clearTimeout(wheelEndRef.current);
+    };
+  }, []);
+
+  const handlePointerDown = (event: ReactPointerEvent<SVGSVGElement>) => {
+    if (event.button !== 0) return;
+    dragRef.current = {
+      pointerId: event.pointerId,
+      lastX: event.clientX,
+      lastY: event.clientY,
+      startX: event.clientX,
+      startY: event.clientY,
+      active: false,
+    };
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<SVGSVGElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (event.buttons === 0) {
+      // Button released outside the map — abandon the press.
+      dragRef.current = null;
+      return;
+    }
+    if (!drag.active) {
+      const travelled = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
+      if (travelled < DRAG_THRESHOLD_PX) return;
+      // Capture only once panning starts, so plain clicks keep targeting nodes.
+      event.currentTarget.setPointerCapture(event.pointerId);
+      drag.active = true;
+    }
+    viewRef.current.x += event.clientX - drag.lastX;
+    viewRef.current.y += event.clientY - drag.lastY;
+    drag.lastX = event.clientX;
+    drag.lastY = event.clientY;
+    applyTransform();
+  };
+
+  const handlePointerEnd = (event: ReactPointerEvent<SVGSVGElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+    if (drag.active) emitViewportChange();
+  };
+
+  if (collapsed) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border bg-background px-3 py-1.5">
+        <Breadcrumbs items={breadcrumb} />
+        <div className="ml-auto">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleCollapsed}
+            title="Expandir mapa"
+            aria-label="Expandir mapa"
+          >
+            <Maximize2 />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative h-full w-full overflow-hidden rounded-lg border bg-background"
+      style={STARFIELD_STYLE}
+    >
+      <svg
+        ref={svgRef}
+        className="h-full w-full touch-none select-none"
+        role="application"
+        aria-label="Mapa del sector"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+      >
+        <g ref={gRef} transform={toTransform(viewRef.current)}>
+          <MapScaleContext.Provider value={k}>{children}</MapScaleContext.Provider>
+        </g>
+      </svg>
+
+      <div className="pointer-events-none absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-2">
+        <div className="pointer-events-auto flex items-center rounded-md border bg-background/80 px-2 py-1 backdrop-blur-sm">
+          <Breadcrumbs items={breadcrumb} />
+        </div>
+        {header && <div className="pointer-events-auto">{header}</div>}
+        <div className="pointer-events-auto flex items-center gap-1 rounded-md border bg-background/80 p-1 backdrop-blur-sm">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleUnknown}
+            title={showUnknown ? 'Ocultar entidades desconocidas' : 'Mostrar entidades desconocidas'}
+            aria-label={
+              showUnknown ? 'Ocultar entidades desconocidas' : 'Mostrar entidades desconocidas'
+            }
+            aria-pressed={showUnknown}
+          >
+            {showUnknown ? <Eye /> : <EyeOff />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleCollapsed}
+            title="Plegar mapa"
+            aria-label="Plegar mapa"
+          >
+            <Minimize2 />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
+  return (
+    <nav aria-label="Ruta del mapa" className="flex items-center gap-0.5 text-sm">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <span key={`${item.label}-${index}`} className="flex items-center gap-0.5">
+            {index > 0 && <ChevronRight className="size-3.5 text-muted-foreground" aria-hidden />}
+            {item.onClick ? (
+              <button
+                type="button"
+                onClick={item.onClick}
+                className="rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                {item.label}
+              </button>
+            ) : (
+              <span className={`px-1 py-0.5 ${isLast ? 'font-medium text-foreground' : 'text-muted-foreground'}`}>
+                {item.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/world/StarMap.tsx
+++ b/components/world/StarMap.tsx
@@ -205,7 +205,12 @@ export function StarMap({
       const travelled = Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY);
       if (travelled < DRAG_THRESHOLD_PX) return;
       // Capture only once panning starts, so plain clicks keep targeting nodes.
-      event.currentTarget.setPointerCapture(event.pointerId);
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // The pointer may already be gone (released mid-frame / synthetic
+        // event) — the pan continues for this gesture, only capture is lost.
+      }
       drag.active = true;
     }
     viewRef.current.x += event.clientX - drag.lastX;

--- a/components/world/SystemView.tsx
+++ b/components/world/SystemView.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { PlaceEntity, SystemEntity } from '@/types/world';
+import { EntityNode } from './EntityNode';
+import { PartyMarker } from './PartyMarker';
+import { useMapScale } from './StarMap';
+
+/** Central star glyph radius (map units, scales with zoom like EntityNode glyphs). */
+const STAR_RADIUS = 36;
+/** Radius of the innermost orbital ring. */
+const FIRST_RING_RADIUS = 110;
+/** Radial distance between consecutive orbital rings. */
+const RING_STEP = 70;
+
+/**
+ * Stable angular position for a place on its ring, derived from an FNV-1a
+ * 32-bit hash of the entity id mapped onto [0, 2π). Hashing the id (rather
+ * than using array order) keeps every node at the same angle across scans,
+ * renames of siblings, and added/removed files — the map never "shuffles".
+ */
+function angleForId(id: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // >>> 0 coerces to uint32; divide by 2^32 for a stable fraction of the circle.
+  return ((hash >>> 0) / 0x100000000) * 2 * Math.PI;
+}
+
+/** Extra radius past the outermost ring for labels + the party-marker pulse. */
+const FIT_MARGIN = 50;
+
+/**
+ * Outermost content radius of a system view, for the page's fit-to-view math.
+ * Mirrors the ring layout below: one ring per distinct `orbita` plus the
+ * dashed outer ring when any place lacks one; an empty system is just the
+ * star, padded to the first ring.
+ */
+export function systemFitRadius(children: PlaceEntity[]): number {
+  const orbitas = new Set(
+    children
+      .map((lugar) => lugar.orbita)
+      .filter((orbita): orbita is number => orbita !== undefined)
+  );
+  const hasUnranked = children.some((lugar) => lugar.orbita === undefined);
+  const ringCount = orbitas.size + (hasUnranked ? 1 : 0);
+  const outermost =
+    ringCount === 0 ? FIRST_RING_RADIUS : FIRST_RING_RADIUS + (ringCount - 1) * RING_STEP;
+  return outermost + FIT_MARGIN;
+}
+
+interface PlacedNode {
+  lugar: PlaceEntity;
+  x: number;
+  y: number;
+}
+
+interface SystemViewProps {
+  sistema: SystemEntity;
+  /** The lugares whose `en === sistema.id` (direct children only). */
+  children: PlaceEntity[];
+  selectedId: string | null;
+  /** Entity id where the party is; marker renders if it is the sistema or a child. */
+  partyLocationId: string | null;
+  /** Actionable-leads count per entity id (amber badge when > 0). */
+  leadsBadgeCounts: Map<string, number>;
+  /** Dominant-faction ring color per entity id; undefined = no ring. */
+  factionColor: (id: string) => string | undefined;
+  /** When false, `conocimiento: desconocido` entities are hidden (screen-share mode). */
+  showUnknown: boolean;
+  onSelect: (id: string) => void;
+  /** Drill into a place whose children form a site list (tier 3). */
+  onDrillIn: (id: string) => void;
+  /** Back out to the sector tier (double-click on the central star). */
+  onBack: () => void;
+}
+
+export function SystemView({
+  sistema,
+  children,
+  selectedId,
+  partyLocationId,
+  leadsBadgeCounts,
+  factionColor,
+  showUnknown,
+  onSelect,
+  onDrillIn,
+  onBack,
+}: SystemViewProps) {
+  const k = useMapScale();
+
+  const visible = showUnknown
+    ? children
+    : children.filter((lugar) => lugar.conocimiento !== 'desconocido');
+
+  // One ring per distinct orbita value, sorted ascending: orbita N is an
+  // ORDERING, not a distance — ring index sets the radius.
+  const orbitas = [...new Set(
+    visible
+      .map((lugar) => lugar.orbita)
+      .filter((orbita): orbita is number => orbita !== undefined)
+  )].sort((a, b) => a - b);
+  const ringRadius = new Map(
+    orbitas.map((orbita, index) => [orbita, FIRST_RING_RADIUS + index * RING_STEP])
+  );
+
+  // Places without orbita share an extra outermost ring, drawn dashed.
+  const unranked = visible.filter((lugar) => lugar.orbita === undefined);
+  const outerRadius = FIRST_RING_RADIUS + orbitas.length * RING_STEP;
+
+  const nodes: PlacedNode[] = visible.map((lugar) => {
+    const radius = lugar.orbita !== undefined ? ringRadius.get(lugar.orbita)! : outerRadius;
+    const angle = angleForId(lugar.id);
+    return {
+      lugar,
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+    };
+  });
+
+  const partyNode =
+    partyLocationId === null ? undefined : nodes.find((node) => node.lugar.id === partyLocationId);
+  const partyAtStar = partyLocationId === sistema.id;
+
+  const starGradientId = `star-glow-${sistema.id}`;
+  const starLabelY = Math.max(STAR_RADIUS * k, 12) + 16;
+
+  const handleStarClick = (event: ReactMouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    onSelect(sistema.id);
+  };
+
+  const handleStarDoubleClick = (event: ReactMouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    onBack();
+  };
+
+  return (
+    <g data-tier="system">
+      <defs>
+        <radialGradient id={starGradientId}>
+          <stop offset="0%" stopColor="var(--foreground)" stopOpacity={0.95} />
+          <stop offset="45%" stopColor="var(--primary)" stopOpacity={0.75} />
+          <stop offset="100%" stopColor="var(--primary)" stopOpacity={0} />
+        </radialGradient>
+      </defs>
+
+      {/* Orbital rings (drawn first, under everything). */}
+      {orbitas.map((orbita) => (
+        <circle
+          key={orbita}
+          data-orbit-ring={orbita}
+          r={ringRadius.get(orbita)}
+          className="fill-none stroke-border"
+          strokeWidth={1}
+          vectorEffect="non-scaling-stroke"
+        />
+      ))}
+      {unranked.length > 0 && (
+        <circle
+          data-orbit-ring="sin-orbita"
+          r={outerRadius}
+          className="fill-none stroke-border"
+          strokeWidth={1}
+          strokeDasharray="6 6"
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+
+      {/* M4 slot: RoutePreview renders intra-system travel into this layer. */}
+      <g data-layer="routes" />
+
+      {/* Central star: click selects the sistema, double-click backs out to the sector. */}
+      <g
+        data-entity-id={sistema.id}
+        data-knowledge={sistema.conocimiento}
+        className="cursor-pointer"
+        onClick={handleStarClick}
+        onDoubleClick={handleStarDoubleClick}
+      >
+        {selectedId === sistema.id && (
+          <circle
+            r={STAR_RADIUS + 8}
+            className="fill-none stroke-ring"
+            strokeWidth={2}
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+        <circle r={STAR_RADIUS} fill={`url(#${starGradientId})`} />
+        <g transform={`scale(${1 / k})`} className="pointer-events-none select-none">
+          <text
+            y={starLabelY}
+            textAnchor="middle"
+            paintOrder="stroke"
+            strokeLinejoin="round"
+            strokeWidth={3}
+            className="fill-foreground stroke-background text-[12px] font-medium"
+          >
+            {sistema.nombre}
+          </text>
+        </g>
+      </g>
+
+      {(partyAtStar || partyNode) && (
+        <PartyMarker x={partyAtStar ? 0 : partyNode!.x} y={partyAtStar ? 0 : partyNode!.y} />
+      )}
+
+      {nodes.map(({ lugar, x, y }) => (
+        <EntityNode
+          key={lugar.id}
+          id={lugar.id}
+          nombre={lugar.nombre}
+          tipo={lugar.tipo}
+          conocimiento={lugar.conocimiento}
+          selected={lugar.id === selectedId}
+          faccionColor={factionColor(lugar.id)}
+          leadsCount={leadsBadgeCounts.get(lugar.id)}
+          onSelect={onSelect}
+          onDrillIn={onDrillIn}
+          x={x}
+          y={y}
+          shape={lugar.acceso === 'portal' ? 'diamond' : undefined}
+          portal={lugar.acceso === 'portal'}
+        />
+      ))}
+    </g>
+  );
+}

--- a/components/world/SystemView.tsx
+++ b/components/world/SystemView.tsx
@@ -169,9 +169,6 @@ export function SystemView({
         />
       )}
 
-      {/* M4 slot: RoutePreview renders intra-system travel into this layer. */}
-      <g data-layer="routes" />
-
       {/* Central star: click selects the sistema, double-click backs out to the sector. */}
       <g
         data-entity-id={sistema.id}

--- a/components/world/SystemView.tsx
+++ b/components/world/SystemView.tsx
@@ -2,6 +2,7 @@
 
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import { PlaceEntity, SystemEntity } from '@/types/world';
+import type { NodeAffordances } from '@/lib/world/shops';
 import { EntityNode } from './EntityNode';
 import { PartyMarker } from './PartyMarker';
 import { useMapScale } from './StarMap';
@@ -68,6 +69,8 @@ interface SystemViewProps {
   leadsBadgeCounts: Map<string, number>;
   /** Dominant-faction ring color per entity id; undefined = no ring. */
   factionColor: (id: string) => string | undefined;
+  /** Semantic affordance badges (shop/info) per entity id; undefined = none. */
+  nodeIconsFor: (id: string) => NodeAffordances | undefined;
   /** When false, `conocimiento: desconocido` entities are hidden (screen-share mode). */
   showUnknown: boolean;
   onSelect: (id: string) => void;
@@ -84,6 +87,7 @@ export function SystemView({
   partyLocationId,
   leadsBadgeCounts,
   factionColor,
+  nodeIconsFor,
   showUnknown,
   onSelect,
   onDrillIn,
@@ -214,6 +218,7 @@ export function SystemView({
           selected={lugar.id === selectedId}
           faccionColor={factionColor(lugar.id)}
           leadsCount={leadsBadgeCounts.get(lugar.id)}
+          affordances={nodeIconsFor(lugar.id)}
           onSelect={onSelect}
           onDrillIn={onDrillIn}
           x={x}

--- a/components/world/ThreadLayer.tsx
+++ b/components/world/ThreadLayer.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * ThreadLayer — the focused trama's narrative web painted on the sector map
+ * (feature — Hilos de historia). Given the trama's sector-root nodes (already
+ * in map pixels, from lib/world/threads.tramaThreadNodes), it draws:
+ *   - a hub-and-spoke of soft colored lines from each node to the centroid
+ *     (reads cleanly for any N; a single node draws no spokes, just its halo),
+ *   - a colored halo ring at each node, and
+ *   - a small trama-name label near the centroid.
+ *
+ * Pure SVG, rendered into SectorView's `threads` slot BEHIND the EntityNodes
+ * (so halos back the glyphs and nothing here steals node clicks). The whole
+ * group is pointer-events-none; strokes are non-scaling and the label
+ * counter-scales to constant screen size (same convention as EntityNode /
+ * RoutePreview labels).
+ */
+
+import { useMapScale } from './StarMap';
+
+interface ThreadLayerProps {
+  /** Sector-root nodes in map pixels; empty renders nothing. */
+  nodes: { id: string; x: number; y: number }[];
+  /** Rol accent color (shared TRAMA_ROL_COLOR map). */
+  color: string;
+  /** Trama name for the centroid label. */
+  label?: string;
+}
+
+const HALO_RADIUS = 26;
+const LABEL_HEIGHT = 20;
+
+/** Width estimate for the 11px label: ~6.2px per glyph + padding. */
+function pillWidth(label: string): number {
+  return Math.max(40, Math.round(label.length * 6.2) + 18);
+}
+
+export function ThreadLayer({ nodes, color, label }: ThreadLayerProps) {
+  const k = useMapScale();
+  if (nodes.length === 0) return null;
+
+  const cx = nodes.reduce((sum, n) => sum + n.x, 0) / nodes.length;
+  const cy = nodes.reduce((sum, n) => sum + n.y, 0) / nodes.length;
+  const width = label ? pillWidth(label) : 0;
+
+  return (
+    <g data-thread-layer className="pointer-events-none select-none">
+      {/* Hub-and-spoke: a spoke from each node to the centroid. With a single
+          node the centroid IS the node, so no visible line is drawn. */}
+      {nodes.length > 1 &&
+        nodes.map((node) => (
+          <line
+            key={`spoke-${node.id}`}
+            x1={node.x}
+            y1={node.y}
+            x2={cx}
+            y2={cy}
+            stroke={color}
+            strokeWidth={2}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            opacity={0.55}
+          />
+        ))}
+
+      {/* Halo ring per node (backs the glyph). */}
+      {nodes.map((node) => (
+        <g key={`node-${node.id}`} data-thread-node={node.id}>
+          <circle
+            cx={node.x}
+            cy={node.y}
+            r={HALO_RADIUS}
+            fill={color}
+            opacity={0.14}
+          />
+          <circle
+            cx={node.x}
+            cy={node.y}
+            r={HALO_RADIUS}
+            fill="none"
+            stroke={color}
+            strokeWidth={2}
+            vectorEffect="non-scaling-stroke"
+            opacity={0.85}
+          />
+        </g>
+      ))}
+
+      {/* Counter-scaled centroid label (constant screen size). */}
+      {label && (
+        <g transform={`translate(${cx} ${cy}) scale(${1 / k})`}>
+          <rect
+            x={-width / 2}
+            y={-LABEL_HEIGHT / 2}
+            width={width}
+            height={LABEL_HEIGHT}
+            rx={LABEL_HEIGHT / 2}
+            className="fill-background"
+            stroke={color}
+            strokeWidth={1.5}
+          />
+          <text
+            y={3.5}
+            textAnchor="middle"
+            className="fill-foreground text-[11px] font-medium"
+          >
+            {label}
+          </text>
+        </g>
+      )}
+    </g>
+  );
+}

--- a/components/world/TravelDialog.tsx
+++ b/components/world/TravelDialog.tsx
@@ -2,20 +2,26 @@
 
 /**
  * TravelDialog — route confirmation before travel mode starts (M4). Pure and
- * props-driven: the page computes the plan (lib/world/travel.ts) and handles
- * the confirm (journal `rumbo`, arm the TravelStepper); this dialog only
- * presents it:
+ * props-driven: the page computes the plan + per-day schedule
+ * (lib/world/travel.ts) and handles the confirm (journal `rumbo`, arm the
+ * TravelStepper); this dialog only presents it:
  *   - legs list (endpoint names + días per leg) and totals,
  *   - consumption preview as current→after pip rows (same pip language as
  *     the PartyStatusBar gauges; the "after" value clamps at 0),
  *   - red banners for plan.warnings — the confirm button stays enabled as a
- *     GM override ("Viajar igualmente", gauges clamp at 0),
+ *     GM override ("Viajar igualmente", gauges clamp at 0) — each carrying
+ *     the exact depletion day derived from the schedule ("Se agota el día X
+ *     de Y", data-travel-agotamiento-<gauge>),
  *   - portal variant: no route calculable, confirm becomes "Registrar
- *     llegada manualmente".
+ *     llegada manualmente",
+ *   - no active session: the plan stays previewable (routes without a
+ *     session are legit) but the confirm disables with a hint row.
  * plan === null (no computable route) renders a hint with confirm disabled.
  */
 
 import { TravelPlan } from '@/types/world';
+import { WARN_COMBUSTIBLE, WARN_VIVERES } from '@/lib/world/travel';
+import type { TravelDayConsumption } from '@/lib/world/travel';
 import {
   Dialog,
   DialogContent,
@@ -25,7 +31,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Clock, MoveRight, Sparkles, TriangleAlert } from 'lucide-react';
+import { Clock, MoveRight, Play, Sparkles, TriangleAlert } from 'lucide-react';
 
 const MEDIDOR_LABELS: Record<string, string> = {
   combustible: 'Combustible',
@@ -41,6 +47,10 @@ interface TravelDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Plan from computeTravelPlan; null = no computable route (confirm disabled). */
   plan: TravelPlan | null;
+  /** Per-day consumption (travelDaySchedule) — backs the depletion-day hints. */
+  schedule?: TravelDayConsumption[];
+  /** False = viewer mode: plan previewable, confirm disabled with a hint. */
+  sessionActive?: boolean;
   fromName: string;
   toName: string;
   /** Current gauges (0-5) backing the current→after preview rows. */
@@ -54,10 +64,26 @@ interface TravelDialogProps {
   nameFor?: (id: string) => string;
 }
 
+/** First 1-based trip day whose cumulative consumption exceeds `current`, or null. */
+function depletionDay(
+  schedule: TravelDayConsumption[],
+  gauge: keyof TravelDayConsumption,
+  current: number
+): number | null {
+  let acc = 0;
+  for (let day = 1; day <= schedule.length; day++) {
+    acc += schedule[day - 1][gauge];
+    if (acc > current) return day;
+  }
+  return null;
+}
+
 export function TravelDialog({
   open,
   onOpenChange,
   plan,
+  schedule = [],
+  sessionActive = true,
   fromName,
   toName,
   medidores,
@@ -161,17 +187,51 @@ export function TravelDialog({
               />
             </div>
 
-            {/* Insufficiency warnings — confirm stays enabled (GM override). */}
-            {plan.warnings.map((warning) => (
-              <div
-                key={warning}
-                data-travel-warning
-                className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-              >
-                <TriangleAlert className="size-4 shrink-0" aria-hidden />
-                {warning}
-              </div>
-            ))}
+            {/* Insufficiency warnings — confirm stays enabled (GM override),
+                each with the exact schedule-derived depletion day. */}
+            {plan.warnings.map((warning) => {
+              const gauge =
+                warning === WARN_COMBUSTIBLE
+                  ? ('combustible' as const)
+                  : warning === WARN_VIVERES
+                    ? ('viveres' as const)
+                    : null;
+              const agotamiento =
+                gauge !== null ? depletionDay(schedule, gauge, medidores[gauge] ?? 0) : null;
+              return (
+                <div
+                  key={warning}
+                  data-travel-warning
+                  className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                >
+                  <div className="flex items-center gap-2">
+                    <TriangleAlert className="size-4 shrink-0" aria-hidden />
+                    {warning}
+                  </div>
+                  {gauge !== null && agotamiento !== null && (
+                    <p
+                      className="mt-0.5 pl-6 text-xs text-destructive/90"
+                      {...{ [`data-travel-agotamiento-${gauge}`]: agotamiento }}
+                    >
+                      {gauge === 'viveres' ? 'Se agotan' : 'Se agota'} el día {agotamiento} de{' '}
+                      {plan.totalDias} del viaje.
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Viewer mode: previewing routes is legit, travelling records — hint
+            instead of the old confirm-then-reject dance. */}
+        {plan !== null && !sessionActive && (
+          <div
+            data-travel-session-hint
+            className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+          >
+            <Play className="size-4 shrink-0" aria-hidden />
+            Inicia la sesión para poder viajar.
           </div>
         )}
 
@@ -187,7 +247,7 @@ export function TravelDialog({
           <Button
             type="button"
             data-travel-confirm
-            disabled={plan === null}
+            disabled={plan === null || !sessionActive}
             variant={plan && plan.warnings.length > 0 ? 'destructive' : 'default'}
             onClick={handleConfirm}
             className="min-h-11"

--- a/components/world/TravelDialog.tsx
+++ b/components/world/TravelDialog.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+/**
+ * TravelDialog — route confirmation before travel mode starts (M4). Pure and
+ * props-driven: the page computes the plan (lib/world/travel.ts) and handles
+ * the confirm (journal `rumbo`, arm the TravelStepper); this dialog only
+ * presents it:
+ *   - legs list (endpoint names + días per leg) and totals,
+ *   - consumption preview as current→after pip rows (same pip language as
+ *     the PartyStatusBar gauges; the "after" value clamps at 0),
+ *   - red banners for plan.warnings — the confirm button stays enabled as a
+ *     GM override ("Viajar igualmente", gauges clamp at 0),
+ *   - portal variant: no route calculable, confirm becomes "Registrar
+ *     llegada manualmente".
+ * plan === null (no computable route) renders a hint with confirm disabled.
+ */
+
+import { TravelPlan } from '@/types/world';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Clock, MoveRight, Sparkles, TriangleAlert } from 'lucide-react';
+
+const MEDIDOR_LABELS: Record<string, string> = {
+  combustible: 'Combustible',
+  viveres: 'Víveres',
+};
+
+function diasLabel(dias: number): string {
+  return dias === 1 ? '1 día' : `${dias} días`;
+}
+
+interface TravelDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Plan from computeTravelPlan; null = no computable route (confirm disabled). */
+  plan: TravelPlan | null;
+  fromName: string;
+  toName: string;
+  /** Current gauges (0-5) backing the current→after preview rows. */
+  medidores: Record<string, number>;
+  onConfirm: () => void;
+  /**
+   * Optional display-name resolver for intermediate leg endpoints (sector
+   * roots). Defaults to fromName/toName for the trip endpoints and the raw
+   * id for anything in between.
+   */
+  nameFor?: (id: string) => string;
+}
+
+export function TravelDialog({
+  open,
+  onOpenChange,
+  plan,
+  fromName,
+  toName,
+  medidores,
+  onConfirm,
+  nameFor,
+}: TravelDialogProps) {
+  const resolveName = (id: string): string => {
+    if (nameFor) return nameFor(id);
+    if (plan && plan.legs.length > 0) {
+      if (id === plan.legs[0].fromId) return fromName;
+      if (id === plan.legs[plan.legs.length - 1].toId) return toName;
+    }
+    return id;
+  };
+
+  const confirmLabel = plan?.portal
+    ? 'Registrar llegada manualmente'
+    : plan && plan.warnings.length > 0
+      ? 'Viajar igualmente'
+      : 'Viajar';
+
+  const handleConfirm = () => {
+    onConfirm();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" data-travel-dialog>
+        <DialogHeader>
+          <DialogTitle>
+            Viajar: {fromName} <MoveRight className="inline size-4" aria-hidden /> {toName}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Ruta propuesta con días y consumo estimado. Confirmar inicia el viaje por etapas.
+          </DialogDescription>
+        </DialogHeader>
+
+        {plan === null ? (
+          <p className="py-4 text-sm text-muted-foreground">
+            No se puede calcular una ruta hasta este destino.
+          </p>
+        ) : plan.portal ? (
+          <div
+            data-travel-portal
+            className="flex items-start gap-2 rounded-md border border-primary/40 bg-primary/5 p-3 text-sm"
+          >
+            <Sparkles className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+            <div>
+              <p className="font-medium">
+                Este destino se alcanza por portal — sin ruta calculable.
+              </p>
+              <p className="mt-1 text-muted-foreground">
+                Sin días de viaje ni consumo estimado: el GM registra la llegada manualmente.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* Legs */}
+            <ol className="space-y-1" data-travel-legs>
+              {plan.legs.map((leg, index) => (
+                <li
+                  key={`${leg.fromId}-${leg.toId}`}
+                  data-travel-leg={index}
+                  className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                >
+                  <span className="min-w-0 flex-1 truncate">
+                    {resolveName(leg.fromId)}{' '}
+                    <MoveRight className="inline size-3.5 text-muted-foreground" aria-hidden />{' '}
+                    {resolveName(leg.toId)}
+                  </span>
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {diasLabel(leg.dias)}
+                  </span>
+                </li>
+              ))}
+            </ol>
+
+            {/* Totals */}
+            <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Clock className="size-4" aria-hidden />
+              <span data-travel-total-dias={plan.totalDias}>
+                Total: {diasLabel(plan.totalDias)}
+                {plan.totalCombustible > 0 && ` · −${plan.totalCombustible} combustible`}
+                {plan.totalViveres > 0 && ` · −${plan.totalViveres} víveres`}
+              </span>
+            </p>
+
+            {/* Consumption preview (current -> after; clamps at 0) */}
+            <div className="space-y-1.5">
+              <PipRow
+                name="combustible"
+                current={medidores['combustible'] ?? 0}
+                delta={plan.totalCombustible}
+              />
+              <PipRow
+                name="viveres"
+                current={medidores['viveres'] ?? 0}
+                delta={plan.totalViveres}
+              />
+            </div>
+
+            {/* Insufficiency warnings — confirm stays enabled (GM override). */}
+            {plan.warnings.map((warning) => (
+              <div
+                key={warning}
+                data-travel-warning
+                className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                <TriangleAlert className="size-4 shrink-0" aria-hidden />
+                {warning}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            data-travel-confirm
+            disabled={plan === null}
+            variant={plan && plan.warnings.length > 0 ? 'destructive' : 'default'}
+            onClick={handleConfirm}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PipRowProps {
+  name: string;
+  /** Current gauge value (0-5). */
+  current: number;
+  /** Proposed consumption; "after" clamps at 0. */
+  delta: number;
+  max?: number;
+}
+
+/**
+ * Current→after gauge preview: kept pips filled, consumed pips destructive,
+ * the rest hollow — same visual language as the PartyStatusBar gauge rows.
+ */
+function PipRow({ name, current, delta, max = 5 }: PipRowProps) {
+  const clamped = Math.max(0, Math.min(Math.round(current), max));
+  const after = Math.max(0, clamped - delta);
+  const label = MEDIDOR_LABELS[name] ?? name.charAt(0).toUpperCase() + name.slice(1);
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      data-travel-medidor={name}
+      data-antes={clamped}
+      data-despues={after}
+    >
+      <span className="w-24 text-xs font-medium text-muted-foreground">{label}</span>
+      <div className="flex items-center gap-0.5" aria-hidden>
+        {Array.from({ length: max }, (_, index) => (
+          <span
+            key={index}
+            className={`size-2 rounded-full ${
+              index < after
+                ? 'bg-primary'
+                : index < clamped
+                  ? 'bg-destructive/70'
+                  : 'border border-muted-foreground/40'
+            }`}
+          />
+        ))}
+      </div>
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {clamped} → {after}
+      </span>
+    </div>
+  );
+}

--- a/components/world/TravelDialog.tsx
+++ b/components/world/TravelDialog.tsx
@@ -176,7 +176,12 @@ export function TravelDialog({
         )}
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="min-h-11"
+          >
             Cancelar
           </Button>
           <Button
@@ -185,6 +190,7 @@ export function TravelDialog({
             disabled={plan === null}
             variant={plan && plan.warnings.length > 0 ? 'destructive' : 'default'}
             onClick={handleConfirm}
+            className="min-h-11"
           >
             {confirmLabel}
           </Button>

--- a/components/world/TravelStepper.tsx
+++ b/components/world/TravelStepper.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * TravelStepper — in-travel banner (M4): the cockpit's top strip while the
+ * party is en route ("Día 2 de 3 — rumbo a X"). Pure and props-driven; the
+ * page owns the day loop (per-day date + consumption entries), the event
+ * draw (EventDrawer) and the arrival. Cancel aborts the remaining days —
+ * nothing further is logged.
+ */
+
+import { Button } from '@/components/ui/button';
+import { Dices, FastForward, MoveRight, Rocket, X } from 'lucide-react';
+
+interface TravelStepperProps {
+  /** Current travel day, 1-based. */
+  dia: number;
+  totalDias: number;
+  destinoName: string;
+  /** Open the EventDrawer with the travel-context tables. */
+  onDrawEvent: () => void;
+  /** Advance one day (page journals date + consumption; last day = arrival). */
+  onNextDay: () => void;
+  /** Fast-forward the remaining days without event draws. */
+  onResolveRest: () => void;
+  /** Abort the remaining days; nothing further is logged. */
+  onCancel: () => void;
+  /** True when no event table applies to the current context. */
+  eventDisabled: boolean;
+}
+
+export function TravelStepper({
+  dia,
+  totalDias,
+  destinoName,
+  onDrawEvent,
+  onNextDay,
+  onResolveRest,
+  onCancel,
+  eventDisabled,
+}: TravelStepperProps) {
+  const progress = totalDias > 0 ? Math.min(Math.max(dia / totalDias, 0), 1) : 0;
+
+  return (
+    <div
+      data-travel-stepper
+      data-dia={dia}
+      data-total-dias={totalDias}
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-primary/30 bg-primary/5 px-3 py-2"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Rocket className="size-4 shrink-0 text-primary" aria-hidden />
+        <span className="truncate text-sm">
+          <span className="font-medium tabular-nums">
+            Día {dia} de {totalDias}
+          </span>
+          <span className="text-muted-foreground"> — rumbo a {destinoName}</span>
+        </span>
+      </div>
+
+      <div
+        className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full bg-primary/15"
+        role="progressbar"
+        aria-label="Progreso del viaje"
+        aria-valuenow={dia}
+        aria-valuemin={0}
+        aria-valuemax={totalDias}
+      >
+        <div
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+
+      <div className="ml-auto flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          data-travel-event
+          disabled={eventDisabled}
+          title={eventDisabled ? 'No hay tablas de eventos aplicables' : undefined}
+          onClick={onDrawEvent}
+        >
+          <Dices />
+          Tirar evento de viaje
+        </Button>
+        <Button type="button" size="sm" data-travel-next onClick={onNextDay}>
+          <MoveRight />
+          Continuar
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          data-travel-rest
+          onClick={onResolveRest}
+        >
+          <FastForward />
+          Resolver resto sin eventos
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          data-travel-cancel
+          onClick={onCancel}
+          className="text-muted-foreground"
+        >
+          <X />
+          Cancelar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/world/TravelStepper.tsx
+++ b/components/world/TravelStepper.tsx
@@ -5,9 +5,11 @@
  * party is en route ("Día 2 de 3 — rumbo a X"). Pure and props-driven; the
  * page owns the day loop (per-day date + consumption entries), the event
  * draw (EventDrawer) and the arrival. Cancel aborts the remaining days —
- * nothing further is logged.
+ * nothing further is logged — behind a small confirm popover: it sits next
+ * to "Resolver resto" and a misclick would silently abort the trip.
  */
 
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Dices, FastForward, MoveRight, Rocket, X } from 'lucide-react';
 
@@ -38,7 +40,8 @@ export function TravelStepper({
   onCancel,
   eventDisabled,
 }: TravelStepperProps) {
-  const progress = totalDias > 0 ? Math.min(Math.max(dia / totalDias, 0), 1) : 0;
+  // Day `dia` is ABOUT to be traveled: the bar fills with completed days.
+  const progress = totalDias > 0 ? Math.min(Math.max((dia - 1) / totalDias, 0), 1) : 0;
 
   return (
     <div
@@ -61,7 +64,7 @@ export function TravelStepper({
         className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full bg-primary/15"
         role="progressbar"
         aria-label="Progreso del viaje"
-        aria-valuenow={dia}
+        aria-valuenow={dia - 1}
         aria-valuemin={0}
         aria-valuemax={totalDias}
       >
@@ -101,18 +104,90 @@ export function TravelStepper({
           <FastForward />
           Resolver resto sin eventos
         </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          data-travel-cancel
-          onClick={onCancel}
-          className="min-h-11 text-muted-foreground"
-        >
-          <X />
-          Cancelar
-        </Button>
+        <CancelTravelButton destinoName={destinoName} onCancel={onCancel} />
       </div>
+    </div>
+  );
+}
+
+/** "Cancelar" behind a confirm popover (same pattern as Terminar sesión). */
+function CancelTravelButton({
+  destinoName,
+  onCancel,
+}: {
+  destinoName: string;
+  onCancel: () => void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!confirmOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setConfirmOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setConfirmOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [confirmOpen]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        data-travel-cancel
+        aria-expanded={confirmOpen}
+        onClick={() => setConfirmOpen((open) => !open)}
+        className="min-h-11 text-muted-foreground"
+      >
+        <X />
+        Cancelar
+      </Button>
+      {confirmOpen && (
+        <div
+          data-travel-cancel-confirm-popover
+          className="absolute right-0 top-full z-50 mt-2 w-72 rounded-md border bg-popover p-3 text-popover-foreground shadow-md"
+        >
+          <p className="text-sm font-medium">¿Cancelar el viaje a {destinoName}?</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            El grupo mantiene su posición; los días ya avanzados no se devuelven.
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmOpen(false)}
+              className="min-h-11"
+            >
+              Seguir viajando
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              data-travel-cancel-confirm
+              onClick={() => {
+                setConfirmOpen(false);
+                onCancel();
+              }}
+              className="min-h-11"
+            >
+              Cancelar viaje
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/world/TravelStepper.tsx
+++ b/components/world/TravelStepper.tsx
@@ -71,6 +71,7 @@ export function TravelStepper({
         />
       </div>
 
+      {/* min-h-11 = 44px tap targets on the per-day loop (M5 sweep). */}
       <div className="ml-auto flex flex-wrap items-center gap-2">
         <Button
           type="button"
@@ -80,11 +81,12 @@ export function TravelStepper({
           disabled={eventDisabled}
           title={eventDisabled ? 'No hay tablas de eventos aplicables' : undefined}
           onClick={onDrawEvent}
+          className="min-h-11"
         >
           <Dices />
           Tirar evento de viaje
         </Button>
-        <Button type="button" size="sm" data-travel-next onClick={onNextDay}>
+        <Button type="button" size="sm" data-travel-next onClick={onNextDay} className="min-h-11">
           <MoveRight />
           Continuar
         </Button>
@@ -94,6 +96,7 @@ export function TravelStepper({
           variant="ghost"
           data-travel-rest
           onClick={onResolveRest}
+          className="min-h-11"
         >
           <FastForward />
           Resolver resto sin eventos
@@ -104,7 +107,7 @@ export function TravelStepper({
           variant="ghost"
           data-travel-cancel
           onClick={onCancel}
-          className="text-muted-foreground"
+          className="min-h-11 text-muted-foreground"
         >
           <X />
           Cancelar

--- a/components/world/WorldAudioDock.tsx
+++ b/components/world/WorldAudioDock.tsx
@@ -3,10 +3,14 @@
 /**
  * WorldAudioDock — bottom-left cockpit dock for the world-level music
  * (`mundo/musica/`: generic ambient/travel BGM rotation + named event
- * playlists). Mounted by app/world/page.tsx only when the scanned
- * model.musica carries at least one track; the page owns the AudioManager
- * lifecycle (created on ready, disposed on model change/unmount) — the dock
- * is presentation only.
+ * playlists). ALWAYS mounted by app/world/page.tsx in the world-ready state,
+ * whether or not the scanned model.musica carries tracks — an empty
+ * mundo/musica/ (or no folder) must read as "no music yet", not as a broken
+ * cockpit. The page owns the AudioManager lifecycle (created on ready ONLY
+ * when there is at least one track, disposed on model change/unmount); when
+ * there are zero tracks `audioManager` is null and the dock opens to a small
+ * empty-state panel instead of the AudioControls — no manager exists to
+ * render.
  *
  * REUSES the play AudioControls unmodified. That component positions itself
  * `fixed top-4 right-0` with a hover-pill collapse — a layout owned by /play
@@ -37,8 +41,12 @@ import { Button } from '@/components/ui/button';
 import { Music2 } from 'lucide-react';
 
 interface WorldAudioDockProps {
-  /** Page-owned world-level manager, already loaded with bgm + playlists. */
-  audioManager: AudioManager;
+  /**
+   * Page-owned world-level manager, already loaded with bgm + playlists —
+   * null when mundo/musica/ carries zero tracks (the dock shows an empty
+   * state instead; no manager is ever created for an empty folder).
+   */
+  audioManager: AudioManager | null;
   bgm: AudioFile[];
   eventPlaylists: EventPlaylist[];
   /** True while the ActRunner overlay owns the room — hidden, state kept. */
@@ -55,28 +63,41 @@ export function WorldAudioDock({
 
   return (
     <div data-world-audio="dock" className={concealed ? 'hidden' : undefined}>
-      {open && (
-        <div
-          data-world-audio="panel"
-          className="fixed bottom-40 left-3 z-40 max-h-[calc(100vh-20rem)] w-[21rem] overflow-y-auto rounded-xl border bg-background shadow-lg"
-        >
-          <div className="flex items-center justify-between gap-2 border-b px-3 py-2 text-sm">
-            <span className="font-medium">Música del mundo</span>
-            <span
-              className="text-xs text-muted-foreground"
-              data-world-audio-bgm-count={bgm.length}
-              data-world-audio-playlist-count={eventPlaylists.length}
-            >
-              {bgm.length} {bgm.length === 1 ? 'pista' : 'pistas'} · {eventPlaylists.length}{' '}
-              {eventPlaylists.length === 1 ? 'lista' : 'listas'}
-            </span>
+      {open &&
+        (audioManager ? (
+          <div
+            data-world-audio="panel"
+            className="fixed bottom-40 left-3 z-40 max-h-[calc(100vh-20rem)] w-[21rem] overflow-y-auto rounded-xl border bg-background shadow-lg"
+          >
+            <div className="flex items-center justify-between gap-2 border-b px-3 py-2 text-sm">
+              <span className="font-medium">Música del mundo</span>
+              <span
+                className="text-xs text-muted-foreground"
+                data-world-audio-bgm-count={bgm.length}
+                data-world-audio-playlist-count={eventPlaylists.length}
+              >
+                {bgm.length} {bgm.length === 1 ? 'pista' : 'pistas'} · {eventPlaylists.length}{' '}
+                {eventPlaylists.length === 1 ? 'lista' : 'listas'}
+              </span>
+            </div>
+            {/* Scoped CSS adapter for the reused AudioControls (see module doc). */}
+            <div className="[&>div.cursor-pointer]:hidden [&>div]:static! [&>div]:transform-none!">
+              <AudioControls audioManager={audioManager} eventPlaylists={eventPlaylists} />
+            </div>
           </div>
-          {/* Scoped CSS adapter for the reused AudioControls (see module doc). */}
-          <div className="[&>div.cursor-pointer]:hidden [&>div]:static! [&>div]:transform-none!">
-            <AudioControls audioManager={audioManager} eventPlaylists={eventPlaylists} />
+        ) : (
+          <div
+            data-world-audio="panel"
+            data-world-audio-empty
+            className="fixed bottom-40 left-3 z-40 w-[21rem] rounded-xl border bg-background p-3 text-sm shadow-lg"
+          >
+            <p className="font-medium">Sin música cargada</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Añade pistas .mp3 en <code className="rounded bg-muted px-1">mundo/musica/</code> (raíz
+              = rotación; subcarpetas = listas).
+            </p>
           </div>
-        </div>
-      )}
+        ))}
       {/* min-h-11 = 44px tap target (M5 sweep). Above the QuickLogBar; the
           bottom-center strip stays free for the Toaster (offset 96px). */}
       <Button

--- a/components/world/WorldAudioDock.tsx
+++ b/components/world/WorldAudioDock.tsx
@@ -12,6 +12,12 @@
  * empty-state panel instead of the AudioControls — no manager exists to
  * render.
  *
+ * CONTROLLED (feature 3): the dock no longer owns a toggle button. Open state
+ * lives in the page (`open` + `onOpenChange`) so the QuickLogBar «Música»
+ * button drives it — the standalone floating toggle "flew over" the map, so it
+ * moved into the action band. The dock renders ONLY the panel (or empty state)
+ * when `open`; closed = nothing but the mount point.
+ *
  * REUSES the play AudioControls unmodified. That component positions itself
  * `fixed top-4 right-0` with a hover-pill collapse — a layout owned by /play
  * and the ActRunner overlay, where the top-right edge is free. Here it is
@@ -19,8 +25,8 @@
  * reserves bottom-center for timer/toasts and the right column for actions,
  * so the dock parks bottom-LEFT and adapts the panel with scoped CSS instead
  * of forking the component:
- *   - the hover pill (`div.cursor-pointer`) is display:none — the dock's own
- *     music button is the expand/collapse affordance;
+ *   - the hover pill (`div.cursor-pointer`) is display:none — the QuickLogBar
+ *     «Música» button is the expand/collapse affordance now;
  *   - AudioControls' two fixed divs are forced into normal flow (`static!`)
  *     and the inline collapse transform is neutralized (`transform-none!`,
  *     !important beats the inline style), so the full panel simply IS the
@@ -28,17 +34,13 @@
  * If AudioControls ever changes its root markup, revisit those selectors.
  *
  * `concealed` (ActRunner open) hides the dock with CSS but keeps it MOUNTED,
- * so the open/closed state survives the audio handoff — e2e asserts
- * aria-pressed across an open/close round-trip. The audio ducking itself
- * lives in the page (see the actRunnerPlace wiring), not here.
+ * so the open/closed state (page-owned) survives the audio handoff. The audio
+ * ducking itself lives in the page (see the actRunnerPlace wiring), not here.
  */
 
-import { useState } from 'react';
 import type { AudioFile, EventPlaylist } from '@/types';
 import { AudioManager } from '@/lib/audioManager';
 import { AudioControls } from '@/components/play/AudioControls';
-import { Button } from '@/components/ui/button';
-import { Music2 } from 'lucide-react';
 
 interface WorldAudioDockProps {
   /**
@@ -49,6 +51,8 @@ interface WorldAudioDockProps {
   audioManager: AudioManager | null;
   bgm: AudioFile[];
   eventPlaylists: EventPlaylist[];
+  /** Page-owned open state (driven by the QuickLogBar «Música» button). */
+  open: boolean;
   /** True while the ActRunner overlay owns the room — hidden, state kept. */
   concealed: boolean;
 }
@@ -57,17 +61,16 @@ export function WorldAudioDock({
   audioManager,
   bgm,
   eventPlaylists,
+  open,
   concealed,
 }: WorldAudioDockProps) {
-  const [open, setOpen] = useState(false);
-
   return (
     <div data-world-audio="dock" className={concealed ? 'hidden' : undefined}>
       {open &&
         (audioManager ? (
           <div
             data-world-audio="panel"
-            className="fixed bottom-40 left-3 z-40 max-h-[calc(100vh-20rem)] w-[21rem] overflow-y-auto rounded-xl border bg-background shadow-lg"
+            className="fixed bottom-24 left-3 z-40 max-h-[calc(100vh-14rem)] w-[21rem] overflow-y-auto rounded-xl border bg-background shadow-lg"
           >
             <div className="flex items-center justify-between gap-2 border-b px-3 py-2 text-sm">
               <span className="font-medium">Música del mundo</span>
@@ -89,7 +92,7 @@ export function WorldAudioDock({
           <div
             data-world-audio="panel"
             data-world-audio-empty
-            className="fixed bottom-40 left-3 z-40 w-[21rem] rounded-xl border bg-background p-3 text-sm shadow-lg"
+            className="fixed bottom-24 left-3 z-40 w-[21rem] rounded-xl border bg-background p-3 text-sm shadow-lg"
           >
             <p className="font-medium">Sin música cargada</p>
             <p className="mt-1 text-xs text-muted-foreground">
@@ -98,21 +101,6 @@ export function WorldAudioDock({
             </p>
           </div>
         ))}
-      {/* min-h-11 = 44px tap target (M5 sweep). Above the QuickLogBar; the
-          bottom-center strip stays free for the Toaster (offset 96px). */}
-      <Button
-        type="button"
-        variant={open ? 'default' : 'outline'}
-        size="sm"
-        data-world-audio="toggle"
-        aria-pressed={open}
-        aria-label="Música del mundo"
-        onClick={() => setOpen((current) => !current)}
-        className="fixed bottom-24 left-3 z-40 min-h-11 shadow-md"
-      >
-        <Music2 />
-        Música
-      </Button>
     </div>
   );
 }

--- a/components/world/WorldAudioDock.tsx
+++ b/components/world/WorldAudioDock.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+/**
+ * WorldAudioDock — bottom-left cockpit dock for the world-level music
+ * (`mundo/musica/`: generic ambient/travel BGM rotation + named event
+ * playlists). Mounted by app/world/page.tsx only when the scanned
+ * model.musica carries at least one track; the page owns the AudioManager
+ * lifecycle (created on ready, disposed on model change/unmount) — the dock
+ * is presentation only.
+ *
+ * REUSES the play AudioControls unmodified. That component positions itself
+ * `fixed top-4 right-0` with a hover-pill collapse — a layout owned by /play
+ * and the ActRunner overlay, where the top-right edge is free. Here it is
+ * not (header buttons + the Diagnóstico overlay live there), and the plan
+ * reserves bottom-center for timer/toasts and the right column for actions,
+ * so the dock parks bottom-LEFT and adapts the panel with scoped CSS instead
+ * of forking the component:
+ *   - the hover pill (`div.cursor-pointer`) is display:none — the dock's own
+ *     music button is the expand/collapse affordance;
+ *   - AudioControls' two fixed divs are forced into normal flow (`static!`)
+ *     and the inline collapse transform is neutralized (`transform-none!`,
+ *     !important beats the inline style), so the full panel simply IS the
+ *     dock's content and sizes it.
+ * If AudioControls ever changes its root markup, revisit those selectors.
+ *
+ * `concealed` (ActRunner open) hides the dock with CSS but keeps it MOUNTED,
+ * so the open/closed state survives the audio handoff — e2e asserts
+ * aria-pressed across an open/close round-trip. The audio ducking itself
+ * lives in the page (see the actRunnerPlace wiring), not here.
+ */
+
+import { useState } from 'react';
+import type { AudioFile, EventPlaylist } from '@/types';
+import { AudioManager } from '@/lib/audioManager';
+import { AudioControls } from '@/components/play/AudioControls';
+import { Button } from '@/components/ui/button';
+import { Music2 } from 'lucide-react';
+
+interface WorldAudioDockProps {
+  /** Page-owned world-level manager, already loaded with bgm + playlists. */
+  audioManager: AudioManager;
+  bgm: AudioFile[];
+  eventPlaylists: EventPlaylist[];
+  /** True while the ActRunner overlay owns the room — hidden, state kept. */
+  concealed: boolean;
+}
+
+export function WorldAudioDock({
+  audioManager,
+  bgm,
+  eventPlaylists,
+  concealed,
+}: WorldAudioDockProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div data-world-audio="dock" className={concealed ? 'hidden' : undefined}>
+      {open && (
+        <div
+          data-world-audio="panel"
+          className="fixed bottom-40 left-3 z-40 max-h-[calc(100vh-20rem)] w-[21rem] overflow-y-auto rounded-xl border bg-background shadow-lg"
+        >
+          <div className="flex items-center justify-between gap-2 border-b px-3 py-2 text-sm">
+            <span className="font-medium">Música del mundo</span>
+            <span
+              className="text-xs text-muted-foreground"
+              data-world-audio-bgm-count={bgm.length}
+              data-world-audio-playlist-count={eventPlaylists.length}
+            >
+              {bgm.length} {bgm.length === 1 ? 'pista' : 'pistas'} · {eventPlaylists.length}{' '}
+              {eventPlaylists.length === 1 ? 'lista' : 'listas'}
+            </span>
+          </div>
+          {/* Scoped CSS adapter for the reused AudioControls (see module doc). */}
+          <div className="[&>div.cursor-pointer]:hidden [&>div]:static! [&>div]:transform-none!">
+            <AudioControls audioManager={audioManager} eventPlaylists={eventPlaylists} />
+          </div>
+        </div>
+      )}
+      {/* min-h-11 = 44px tap target (M5 sweep). Above the QuickLogBar; the
+          bottom-center strip stays free for the Toaster (offset 96px). */}
+      <Button
+        type="button"
+        variant={open ? 'default' : 'outline'}
+        size="sm"
+        data-world-audio="toggle"
+        aria-pressed={open}
+        aria-label="Música del mundo"
+        onClick={() => setOpen((current) => !current)}
+        className="fixed bottom-24 left-3 z-40 min-h-11 shadow-md"
+      >
+        <Music2 />
+        Música
+      </Button>
+    </div>
+  );
+}

--- a/components/world/WorldSearchDialog.tsx
+++ b/components/world/WorldSearchDialog.tsx
@@ -8,6 +8,11 @@
  * it, because its props are SearchManager/partId-shaped while this one
  * consumes WorldSearchResult ids. Selecting a result (click or Enter for the
  * top hit) hands the entity id to the page, which navigates the map.
+ *
+ * Enter searches the CURRENT input text synchronously (the debounced results
+ * can lag what was just typed), so the top hit always matches the query on
+ * screen. The sr-only DialogDescription satisfies Radix's aria-describedby
+ * expectation (play's SearchDialog predates the warning and never added one).
  */
 
 import { useEffect, useState } from 'react';
@@ -16,6 +21,7 @@ import { WorldSearchIndex, WorldSearchResult } from '@/lib/world/worldSearch';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -72,11 +78,15 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
     setQuery('');
   };
 
+  // Enter must act on what the input says NOW, not on the last debounced
+  // results (typing fast + Enter within DEBOUNCE_MS used to open a stale hit).
   const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter' && results.length > 0) {
-      event.preventDefault();
-      handleSelect(results[0]);
-    }
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    const fresh = index && query.trim() ? index.search(query, 10) : [];
+    setResults(fresh);
+    setIsSearching(false);
+    if (fresh.length > 0) handleSelect(fresh[0]);
   };
 
   return (
@@ -93,6 +103,10 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
       <DialogContent className="max-w-2xl" data-world-search>
         <DialogHeader>
           <DialogTitle>Buscar en el mundo</DialogTitle>
+          <DialogDescription className="sr-only">
+            Busca sistemas, lugares, facciones, PNJs, pistas y tramas. Enter abre el primer
+            resultado.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
           <Input

--- a/components/world/WorldSearchDialog.tsx
+++ b/components/world/WorldSearchDialog.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+/**
+ * WorldSearchDialog — Cmd/Ctrl+K entity search over a WorldSearchIndex.
+ *
+ * A thin world-mode sibling of components/play/SearchDialog (same shell:
+ * trigger button + dialog + debounced input + result list) — NOT a reuse of
+ * it, because its props are SearchManager/partId-shaped while this one
+ * consumes WorldSearchResult ids. Selecting a result (click or Enter for the
+ * top hit) hands the entity id to the page, which navigates the map.
+ */
+
+import { useEffect, useState } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { WorldSearchIndex, WorldSearchResult } from '@/lib/world/worldSearch';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Search } from 'lucide-react';
+
+const DEBOUNCE_MS = 300;
+
+interface WorldSearchDialogProps {
+  /** Rebuilt once per scan by the page (null while no world is loaded). */
+  index: WorldSearchIndex | null;
+  /** Receives the selected entity id; the page selects + navigates the map. */
+  onResultSelect: (id: string) => void;
+}
+
+export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<WorldSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  useEffect(() => {
+    if (!query.trim() || !index) {
+      setResults([]);
+      return;
+    }
+    setIsSearching(true);
+    const timeoutId = setTimeout(() => {
+      setResults(index.search(query, 10));
+      setIsSearching(false);
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timeoutId);
+  }, [query, index]);
+
+  // Keyboard shortcut: Cmd/Ctrl + K (same binding as the play-mode search).
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        setIsOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const handleSelect = (result: WorldSearchResult) => {
+    onResultSelect(result.id);
+    setIsOpen(false);
+    setQuery('');
+  };
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && results.length > 0) {
+      event.preventDefault();
+      handleSelect(results[0]);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2" aria-label="Buscar en el mundo">
+          <Search className="h-4 w-4" />
+          Buscar
+          <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+            <span className="text-xs">⌘</span>K
+          </kbd>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl" data-world-search>
+        <DialogHeader>
+          <DialogTitle>Buscar en el mundo</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input
+            placeholder="Buscar en el mundo…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleInputKeyDown}
+            autoFocus
+          />
+
+          {isSearching && (
+            <p className="py-4 text-center text-sm text-muted-foreground">Buscando…</p>
+          )}
+
+          {!isSearching && query && results.length === 0 && (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              Sin resultados para &quot;{query}&quot;
+            </p>
+          )}
+
+          {!isSearching && results.length > 0 && (
+            <ScrollArea className="max-h-[400px]">
+              <div className="space-y-2 pr-4">
+                {results.map((result) => (
+                  <button
+                    key={result.id}
+                    type="button"
+                    data-search-result-id={result.id}
+                    onClick={() => handleSelect(result)}
+                    className="w-full rounded-lg border p-3 text-left transition-colors hover:bg-accent"
+                  >
+                    <div className="flex items-center gap-2">
+                      <p className="min-w-0 truncate font-medium">{result.nombre}</p>
+                      <Badge variant="secondary" className="shrink-0">
+                        {result.tipo}
+                      </Badge>
+                    </div>
+                    {result.snippet && (
+                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                        {result.snippet}
+                      </p>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+
+          {!query && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Escribe para buscar sistemas, lugares, facciones, PNJs, pistas y tramas
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/world/WorldSearchDialog.tsx
+++ b/components/world/WorldSearchDialog.tsx
@@ -138,7 +138,8 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
           )}
 
           {!isSearching && results.length > 0 && (
-            <ScrollArea className="max-h-[400px]">
+            // eslint-disable-next-line -- native scroll: ScrollArea root lacks overflow-hidden
+            <div className="max-h-[400px] overflow-y-auto">
               <div className="space-y-2 pr-4">
                 {results.map((result) => (
                   <button
@@ -162,7 +163,7 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
                   </button>
                 ))}
               </div>
-            </ScrollArea>
+            </div>
           )}
 
           {!query && (

--- a/components/world/WorldSearchDialog.tsx
+++ b/components/world/WorldSearchDialog.tsx
@@ -72,10 +72,20 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  // Closing by ANY path clears the query, so reopening never shows stale
+  // results (Escape-close used to keep them).
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setQuery('');
+      setResults([]);
+      setIsSearching(false);
+    }
+  };
+
   const handleSelect = (result: WorldSearchResult) => {
     onResultSelect(result.id);
-    setIsOpen(false);
-    setQuery('');
+    handleOpenChange(false);
   };
 
   // Enter must act on what the input says NOW, not on the last debounced
@@ -90,7 +100,7 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="min-h-11 gap-2" aria-label="Buscar en el mundo">
           <Search className="h-4 w-4" />

--- a/components/world/WorldSearchDialog.tsx
+++ b/components/world/WorldSearchDialog.tsx
@@ -92,7 +92,7 @@ export function WorldSearchDialog({ index, onResultSelect }: WorldSearchDialogPr
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2" aria-label="Buscar en el mundo">
+        <Button variant="outline" size="sm" className="min-h-11 gap-2" aria-label="Buscar en el mundo">
           <Search className="h-4 w-4" />
           Buscar
           <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -343,6 +343,7 @@ paga inmediata y sin papeleo.
 
 :::efecto
 - ganancia: 200 | turnos de descarga
+- medidor: oxigeno -1 | fuga en el sello de carga (medidor NO manifestado)
 :::
 `,
         },

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -8,8 +8,13 @@
  *   - 3 systems with the three knowledge extremes (visitado/rumoreado/desconocido)
  *     plus 1 deep-space node with own coords  -> 4 sector-tier map nodes.
  *   - porto_verne/ is a PLAYABLE place folder (lugar.md + plan/characters/music).
- *   - torre_korinth is a CHILD of porto_verne (en: porto_verne) so the
- *     non-spatial SiteList tier (tier 3) is reachable from the fixture.
+ *   - torre_korinth is a CHILD of porto_verne (en: porto_verne) with NO poi
+ *     coords, so porto_verne stays the non-spatial SiteList tier (tier 3) —
+ *     the Plano fallback + regression case.
+ *   - mercado_de_brasa (in sistema_kessler) has TWO poi-coord children
+ *     (rampa_carga {30,70}, sala_franca {72,40}) so it renders the SPATIAL
+ *     Plano tier (data-tier="place"); an EXTRA child (trastienda) carries NO
+ *     poi to exercise the "sin ubicar" dashed ring.
  *   - PLANTILLAS/pista.md and lugares/_borrador.md must be IGNORED by the scanner.
  *   - lugares/roto.md has invalid YAML -> degraded load + Diagnostico entry.
  *   - estado/ exists but is EMPTY -> the party bar renders the absent-estado hint.
@@ -112,6 +117,39 @@ resumen: Estacion franca entre los asteroides de Kessler, segun los mineros.
 servicios: [repostaje, mercado]
 ---
 Dicen que alli se compra de todo y no se pregunta nada.
+`,
+            'rampa_carga.md': `---
+tipo: estructura
+nombre: Rampa de Carga
+en: mercado_de_brasa
+conocimiento: visitado
+poi: {x: 30, y: 70}
+etiquetas: [muelles]
+resumen: Rampa principal de descarga de la estacion franca.
+---
+Un pasillo de grúas y contenedores donde nadie hace preguntas.
+`,
+            'sala_franca.md': `---
+tipo: estructura
+nombre: Sala Franca
+en: mercado_de_brasa
+conocimiento: conocido
+poi: {x: 72, y: 40}
+etiquetas: [mercado]
+servicios: [mercado, contrabando]
+resumen: Salón de trueque de la estacion; se compra de todo.
+---
+Mesas plegables y una barra larga; el corazon comercial de Brasa.
+`,
+            'trastienda.md': `---
+tipo: estructura
+nombre: Trastienda
+en: mercado_de_brasa
+conocimiento: rumoreado
+etiquetas: [oculto]
+resumen: Se rumorea una trastienda sin ubicacion fija en los planos.
+---
+Nadie coincide en donde esta; por eso queda en el anillo "sin ubicar".
 `,
             'nodo_central.md': `---
 tipo: nodo

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -16,6 +16,10 @@
  *
  * MUNDO_CAMPAIGN_CON_ESTADO adds estado/grupo.md (party at porto_verne) for the
  * M2 party-readout tests: PartyStatusBar values + marker roll-up across tiers.
+ * It also adds (M6) mundo/imagenes/ profile images (SVG on purpose: text-based
+ * bytes survive the OPFS utf-8 write) for kovar_iii and the kael_voss pnj, and
+ * an images/ file inside the porto_verne playable folder so the ActRunner
+ * grows an image tab (player-safe fullscreen regression test).
  *
  * MUNDO_CAMPAIGN_CON_MUSICA adds mundo/musica/ (world-level music): 2 root
  * mp3s = BGM rotation + eventos_generales/ = 1 named event playlist + a
@@ -430,13 +434,31 @@ Kael necesita que alguien entregue un paquete sin que el consorcio se
 entere. Si sale bien, Zara Hollis le perdona parte de la deuda.
 `;
 
-/** Same campaign, plus estado/grupo.md — the party is docked at porto_verne. */
+/** Tiny valid SVG (text bytes — OPFS writes utf-8, binary formats would corrupt). */
+function fixtureSvg(fill: string): string {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="40"><rect width="80" height="40" fill="${fill}"/></svg>`;
+}
+
+/**
+ * Same campaign, plus estado/grupo.md — the party is docked at porto_verne —
+ * plus entity profile images and an ActRunner image (M6, see header doc).
+ */
 export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     // FileTree is JSON-safe (plain strings/objects), so a JSON round-trip clones it.
     const clone = JSON.parse(JSON.stringify(MUNDO_CAMPAIGN)) as FileTree;
     const mundo = clone.mundo as FileTree;
     (mundo.estado as FileTree)['grupo.md'] = GRUPO_MD;
     (mundo.pistas as FileTree)['deuda_kael_zara.md'] = DEUDA_KAEL_ZARA_CON_REQUISITOS;
+    // M6: profile images by convention (basename = entity id) — a lugar and
+    // the pnj located at porto_verne (pnjs/kael_voss.md, ubicacion already set).
+    mundo.imagenes = {
+        'kovar_iii.svg': fixtureSvg('#3aa675'),
+        'kael_voss.svg': fixtureSvg('#7a5cc7'),
+    };
+    // M6: an image inside the playable place folder -> ActRunner image tab.
+    ((mundo.lugares as FileTree).porto_verne as FileTree).images = {
+        'muelle_7.svg': fixtureSvg('#c7823a'),
+    };
     return clone;
 })();
 

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -602,8 +602,28 @@ export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
         'zara_hollis.md': '# Zara Hollis\n\nPrestamista a la que Kael debe dinero.\n',
         'capataz_vortex.md': '# Capataz de Vortex\n\nSupervisa el muelle 7 con mano dura.\n',
     };
+    // dron_aduanas carries a real CA/PV statblock (fenced, Spanish labels) so
+    // the ActRunner's "Añadir al combate" control appears; cobrador_tetrad is
+    // prose-only (no statblock) to prove the button is threat-AND-statblock
+    // gated. The Depredador-style format is mirrored from the real fichas.
     ((mundo.lugares as FileTree).porto_verne as FileTree).threats = {
-        'dron_aduanas.md': '# Dron de aduanas\n\nEscanea el casco al acoplar. Nivel 1.\n',
+        'dron_aduanas.md': `# Dron de aduanas
+
+Escanea el casco al acoplar. Nivel 1.
+
+\`\`\`
+DRON DE ADUANAS                                  CRIATURA 1
+PEQUEÑO CONSTRUCTO
+Perception +7
+
+CA 16; Fort +5, Ref +8, Will +4
+PV 22
+Debilidad: electricidad 3
+
+ATAQUES
+Cuerpo a cuerpo [1 acción] pinza +8, Daño 1d6+2 contundente
+\`\`\`
+`,
         'cobrador_tetrad.md': '# Cobrador del Tetrad\n\nBusca al mensajero del paquete.\n',
     };
     // Shop system: a tiendas/ subfolder inside the porto_verne place folder.

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -16,6 +16,11 @@
  *
  * MUNDO_CAMPAIGN_CON_ESTADO adds estado/grupo.md (party at porto_verne) for the
  * M2 party-readout tests: PartyStatusBar values + marker roll-up across tiers.
+ *
+ * MUNDO_CAMPAIGN_CON_MUSICA adds mundo/musica/ (world-level music): 2 root
+ * mp3s = BGM rotation + eventos_generales/ = 1 named event playlist + a
+ * markdown prompt doc the scanner must ignore. The base fixture deliberately
+ * has NO musica/ folder — the no-dock test depends on that.
  */
 
 export type FileTree = { [name: string]: string | FileTree };
@@ -432,5 +437,23 @@ export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     const mundo = clone.mundo as FileTree;
     (mundo.estado as FileTree)['grupo.md'] = GRUPO_MD;
     (mundo.pistas as FileTree)['deuda_kael_zara.md'] = DEUDA_KAEL_ZARA_CON_REQUISITOS;
+    return clone;
+})();
+
+/**
+ * Same campaign, plus mundo/musica/ — world-level music for the cockpit dock.
+ * The "mp3" bytes are fake: the app only LISTS the files until one is played,
+ * and the audio-dock tests never press play (Playwright cannot verify sound).
+ */
+export const MUNDO_CAMPAIGN_CON_MUSICA: FileTree = (() => {
+    const clone = JSON.parse(JSON.stringify(MUNDO_CAMPAIGN)) as FileTree;
+    (clone.mundo as FileTree).musica = {
+        'viaje_nucleo.mp3': 'fake-mp3-bytes-nucleo',
+        'viaje_frontera.mp3': 'fake-mp3-bytes-frontera',
+        '_instrucciones.md': '# Prompts — el scanner debe ignorar este markdown',
+        eventos_generales: {
+            'evento_averia.mp3': 'fake-mp3-bytes-averia',
+        },
+    };
     return clone;
 })();

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -274,6 +274,56 @@ chaqueta de tres temporadas atras, sonrisa de vendedor cansado.
                 },
                 music: {},
             },
+            // A NODE-style playable place: its plan/ has NO act1 folder — content
+            // starts at act2 (acto2). Proves the ActRunner auto-selects the first
+            // act that actually exists and never renders a phantom acto1 slot.
+            jardin_que_exhala: {
+                'lugar.md': `---
+tipo: estructura
+nombre: Jardin que Exhala
+en: sistema_verne
+conocimiento: rumoreado
+etiquetas: [anomalia, predecesor]
+resumen: Camara viva que respira; el arco no la abre hasta el segundo acto.
+---
+Nadie describe igual lo que hay dentro. La entrada solo se abre a mitad del arco.
+`,
+                plan: {
+                    act2: {
+                        'acto2_umbral.md': `# ACTO 2 — EL UMBRAL SE ABRE
+
+## La camara respira por primera vez
+
+:::leer
+El aire sale tibio de las paredes y todo el jardin parece inhalar a la vez.
+Las luces palpitan al ritmo de algo que no veis.
+:::
+
+:::gm
+Este es el punto de entrada real del arco. No hay acto anterior que jugar.
+:::
+
+:::accion
+**Leer el pulso de la camara**
+- habilidad: Naturaleza
+- cd: 16
+- exito: entienden el ciclo de respiracion y cuando cruzar
+:::
+`,
+                    },
+                    act3: {
+                        'acto3_corazon.md': `# ACTO 3 — EL CORAZON
+
+## Descenso al nucleo latente
+
+:::leer
+Al fondo late una masa suspendida, atada por filamentos de luz.
+:::
+`,
+                    },
+                },
+                music: {},
+            },
         },
         facciones: {
             'vortex_logistics.md': `---

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -125,6 +125,7 @@ en: mercado_de_brasa
 conocimiento: visitado
 poi: {x: 30, y: 70}
 etiquetas: [muelles]
+servicios: [informacion]
 resumen: Rampa principal de descarga de la estacion franca.
 ---
 Un pasillo de grúas y contenedores donde nadie hace preguntas.

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -404,6 +404,7 @@ medidores:
   viveres: 3
   combustible: 2
   nave: 2
+personajes: [Xiao, Chesco]
 ---
 ## Inventario
 

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -10,6 +10,10 @@
  *   - porto_verne/ is a PLAYABLE place folder (lugar.md + plan/characters/music).
  *   - PLANTILLAS/pista.md and lugares/_borrador.md must be IGNORED by the scanner.
  *   - lugares/roto.md has invalid YAML -> degraded load + Diagnostico entry.
+ *   - estado/ exists but is EMPTY -> the party bar renders the absent-estado hint.
+ *
+ * MUNDO_CAMPAIGN_CON_ESTADO adds estado/grupo.md (party at porto_verne) for the
+ * M2 party-readout tests: PartyStatusBar values + marker roll-up across tiers.
  */
 
 export type FileTree = { [name: string]: string | FileTree };
@@ -316,3 +320,35 @@ Plantilla: el escaner debe ignorar este archivo (carpeta en MAYUSCULAS).
         },
     },
 };
+
+/**
+ * estado/grupo.md for the party-readout variant (plan Part A frontmatter:
+ * app-owned header, agent-owned body). dia_mundo 4127 renders as
+ * "17 de Cenit, 356 dG" under the fixture calendar (4 meses x 30 dias).
+ */
+const GRUPO_MD = `---
+tipo: estado_grupo
+sesion_activa: false
+dia_mundo: 4127
+ubicacion: porto_verne
+rumbo: null
+creditos: 1240
+medidores:
+  viveres: 3
+  combustible: 2
+  nave: 2
+---
+## Inventario
+
+- Paquete sellado de Kael (entregar en el punto de intercambio).
+- 2 cargas de repuestos para la nave.
+`;
+
+/** Same campaign, plus estado/grupo.md — the party is docked at porto_verne. */
+export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
+    // FileTree is JSON-safe (plain strings/objects), so a JSON round-trip clones it.
+    const clone = JSON.parse(JSON.stringify(MUNDO_CAMPAIGN)) as FileTree;
+    const mundo = clone.mundo as FileTree;
+    (mundo.estado as FileTree)['grupo.md'] = GRUPO_MD;
+    return clone;
+})();

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -538,6 +538,24 @@ Un tenderete entre las grúas; Kael conoce al dueño.
 | Raciones de campo | 40 | - | siempre en stock |
 `;
 
+/**
+ * GM play-aid sheets for the in-app Guías menu (feature — Guías dialog). These
+ * live at the mundo/ root under the GUIA_FILES allowlist. RUN_OF_SHOW carries a
+ * leading `# heading` (first-heading title wins over the fallback); MAPA_DE_HILOS
+ * has no heading, so its label falls back to the mapping titulo.
+ */
+const RUN_OF_SHOW_MD = `# Guion de la sesión
+
+1. Reentrada en Porto Verne.
+2. El favor de Kael Voss en el muelle 7.
+3. La ruta franca de Vortex.
+`;
+
+const MAPA_DE_HILOS_MD = `Contrabando -> Brasa -> Consorcio Tetrad.
+
+Deudas -> Kael Voss -> Zara Hollis.
+`;
+
 /** Session recap for the in-app Resumen dialog (feature — in-app resumen). */
 const RESUMEN_MD = `# Anteriormente
 
@@ -594,6 +612,12 @@ export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     };
     // In-app resumen: mundo/resumen.md (the base fixture has none on purpose).
     mundo['resumen.md'] = RESUMEN_MD;
+    // GM guías: curated play-aid sheets at mundo/ root (GUIA_FILES allowlist).
+    // _RUN_OF_SHOW.md carries a leading heading (first-heading title wins);
+    // _MAPA_DE_HILOS.md has none, so its dropdown label falls back to the
+    // mapping titulo "Mapa de Hilos".
+    mundo['_RUN_OF_SHOW.md'] = RUN_OF_SHOW_MD;
+    mundo['_MAPA_DE_HILOS.md'] = MAPA_DE_HILOS_MD;
     return clone;
 })();
 

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -259,6 +259,11 @@ El paquete conecta con la pista deuda_kael_zara. Si los PJ negocian bien
 - efecto: activa la pista deuda_kael_zara
 - recompensa: 400 creditos al entregar
 :::
+
+:::efecto
+- pista: rumor_lejano activa | el eco del nodo se enciende
+- ganancia: 150 | pago inicial de Kael
+:::
 `,
                 },
                 characters: {

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -237,6 +237,7 @@ capataz de Vortex. El capataz se marcha si los PJ se acercan.
 **Localizar a Kael Voss**
 - habilidad: Percepcion o Sociedad
 - cd: 15
+- reto: 4 exitos / 3 fallos
 - exito: encuentran a Kael antes de que el capataz lo eche del muelle
 - fallo: pierden una hora; Kael los encuentra a ellos, molesto
 :::

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -567,6 +567,14 @@ export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     ((mundo.lugares as FileTree).porto_verne as FileTree).images = {
         'muelle_7.svg': fixtureSvg('#c7823a'),
     };
+    // Battlemaps: maps/ carries a markdown ASCII map (-> supportDocs) AND an
+    // image battlemap (-> part.battlemaps -> BattlemapViewer). The .png holds
+    // SVG bytes (OPFS is utf-8; the viewer only needs a blob URL, the scanner
+    // keys off the extension).
+    ((mundo.lugares as FileTree).porto_verne as FileTree).maps = {
+        'muelle_7_battlemap.png': fixtureSvg('#4a6b8a'),
+        'plano_ascii.md': '```\n#####\n#...#\n#####\n```\n',
+    };
     // Shop system: a tiendas/ subfolder inside the porto_verne place folder.
     ((mundo.lugares as FileTree).porto_verne as FileTree).tiendas = {
         'muelles.md': TIENDA_MUELLES,

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -15,6 +15,10 @@
  *     (rampa_carga {30,70}, sala_franca {72,40}) so it renders the SPATIAL
  *     Plano tier (data-tier="place"); an EXTRA child (trastienda) carries NO
  *     poi to exercise the "sin ubicar" dashed ring.
+ *   - tramas/: `deudas` (secundaria, 1 pista at porto_verne) plus `contrabando`
+ *     (principal, lugares_clave porto_verne + mercado_de_brasa, 2 pistas whose
+ *     donde resolve to DIFFERENT sector roots — sistema_verne + sistema_kessler)
+ *     so the Hilos thread web has >=2 map points to connect.
  *   - PLANTILLAS/pista.md and lugares/_borrador.md must be IGNORED by the scanner.
  *   - lugares/roto.md has invalid YAML -> degraded load + Diagnostico entry.
  *   - estado/ exists but is EMPTY -> the party bar renders the absent-estado hint.
@@ -343,6 +347,26 @@ origen: mercado_de_brasa
 Se habla de una senal que se enciende cada 47 dias en el Nodo Central.
 Nadie ha vuelto para contarlo dos veces.
 `,
+            'ruta_franca.md': `---
+tipo: pista
+nombre: La ruta franca de Vortex
+estado: activa
+trama: contrabando
+donde: porto_verne
+origen: kael_voss
+---
+Vortex mueve carga sin declarar entre Porto Verne y la estacion franca.
+`,
+            'contacto_brasa.md': `---
+tipo: pista
+nombre: El contacto en Brasa
+estado: rumor
+trama: contrabando
+donde: mercado_de_brasa
+origen: kael_voss
+---
+Alguien en la Sala Franca compra los manifiestos robados sin preguntar.
+`,
         },
         tramas: {
             'deudas.md': `---
@@ -360,6 +384,21 @@ facciones: [vortex_logistics]
 2. Kael desaparece de los muelles.
 3. El Consorcio usa el expediente de Kael contra los PJ.
 4. Cierre: la deuda se salda o Kael cae.
+`,
+            'contrabando.md': `---
+tipo: trama
+nombre: Contrabando
+rol: principal
+estado: activa
+reloj: {actual: 2, max: 6}
+lugares_clave: [porto_verne, mercado_de_brasa]
+facciones: [consorcio_tetrad]
+---
+## Cuando el reloj avance
+
+1. El Consorcio abre una ruta franca permanente por Brasa.
+2. Vortex descubre la fuga y cierra los muelles.
+3. Los PJ quedan en medio del fuego cruzado.
 `,
         },
         eventos: {

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -8,6 +8,8 @@
  *   - 3 systems with the three knowledge extremes (visitado/rumoreado/desconocido)
  *     plus 1 deep-space node with own coords  -> 4 sector-tier map nodes.
  *   - porto_verne/ is a PLAYABLE place folder (lugar.md + plan/characters/music).
+ *   - torre_korinth is a CHILD of porto_verne (en: porto_verne) so the
+ *     non-spatial SiteList tier (tier 3) is reachable from the fixture.
  *   - PLANTILLAS/pista.md and lugares/_borrador.md must be IGNORED by the scanner.
  *   - lugares/roto.md has invalid YAML -> degraded load + Diagnostico entry.
  *   - estado/ exists but is EMPTY -> the party bar renders the absent-estado hint.
@@ -30,7 +32,7 @@ calendario:
 viaje:
   dias_por_unidad: 1
   intrasistema_dias: 1
-  combustible_por_tramo: 1
+  combustible_cada_dias: 4
   viveres_cada_dias: 4
 medidores: [viveres, combustible, nave]
 regiones: [nucleo, frontera]
@@ -113,6 +115,17 @@ resumen: Estructura predecesora en el espacio profundo; solo accesible por porta
 ---
 Ninguna ruta convencional llega hasta el. Los que hablan de el mencionan
 una puerta que se abre desde dentro.
+`,
+            'torre_korinth.md': `---
+tipo: estructura
+nombre: Torre Korinth
+en: porto_verne
+conocimiento: conocido
+etiquetas: [corporativo]
+resumen: Aguja corporativa que domina el anillo de muelles de Porto Verne.
+servicios: [informacion, trabajo]
+---
+Sede local de Vortex Logistics; medio puerto le debe algo a alguien de la torre.
 `,
             '_borrador.md': `---
 tipo: estacion

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -1,0 +1,318 @@
+/**
+ * In-memory `mundo/` campaign fixture for world-mode e2e tests.
+ *
+ * The tree is materialized into OPFS by e2e/helpers/opfs.ts and opened by the
+ * app through the window.__ttrpgWorldTest seam (contract documented there).
+ *
+ * Deliberate contents (what each entry exercises):
+ *   - 3 systems with the three knowledge extremes (visitado/rumoreado/desconocido)
+ *     plus 1 deep-space node with own coords  -> 4 sector-tier map nodes.
+ *   - porto_verne/ is a PLAYABLE place folder (lugar.md + plan/characters/music).
+ *   - PLANTILLAS/pista.md and lugares/_borrador.md must be IGNORED by the scanner.
+ *   - lugares/roto.md has invalid YAML -> degraded load + Diagnostico entry.
+ */
+
+export type FileTree = { [name: string]: string | FileTree };
+
+export const MUNDO_CAMPAIGN: FileTree = {
+    mundo: {
+        'mundo.md': `---
+nombre: Sector Eloran
+calendario:
+  era: dG
+  ano_epoca: 322
+  dias_por_mes: 30
+  meses: [Albor, Cenit, Ocaso, Umbra]
+viaje:
+  dias_por_unidad: 1
+  intrasistema_dias: 1
+  combustible_por_tramo: 1
+  viveres_cada_dias: 4
+medidores: [viveres, combustible, nave]
+regiones: [nucleo, frontera]
+---
+# Sector Eloran
+
+Franja comercial entre el nucleo colonizado y la frontera sin cartografiar.
+Las rutas mineras acaban de abrirse de nuevo y todo el mundo quiere su parte.
+`,
+        sistemas: {
+            'sistema_verne.md': `---
+tipo: sistema
+nombre: Sistema Verne
+coordenadas: {x: 0, y: 0}
+region: nucleo
+conocimiento: visitado
+etiquetas: [comercio, transitado]
+resumen: Corazon comercial del sector, hogar de Porto Verne.
+estado: >
+  Trafico intenso tras la reapertura de las rutas mineras; los precios
+  del combustible suben cada semana.
+---
+Sistema binario con un gigante gaseoso y tres planetas interiores.
+`,
+            'sistema_kessler.md': `---
+tipo: sistema
+nombre: Sistema Kessler
+coordenadas: {x: 6, y: 3}
+region: frontera
+conocimiento: rumoreado
+etiquetas: [mineria, peligroso]
+resumen: Campo de asteroides denso; se rumorea que hay una estacion franca.
+---
+Nadie del grupo ha estado, pero los mineros de Verne hablan de el sin parar.
+`,
+            'sistema_umbral.md': `---
+tipo: sistema
+nombre: Sistema Umbral
+coordenadas: {x: -5, y: 4}
+region: frontera
+conocimiento: desconocido
+etiquetas: [inexplorado]
+resumen: Solo una firma gravitatoria en los mapas antiguos.
+---
+Sin datos. Ninguna carta estelar moderna lo incluye.
+`,
+        },
+        lugares: {
+            'kovar_iii.md': `---
+tipo: planeta
+nombre: Kovar III
+en: sistema_verne
+orbita: 3
+conocimiento: conocido
+etiquetas: [agricola]
+resumen: Mundo agricola que alimenta a medio sistema.
+servicios: [mercado, refugio]
+---
+Campos hidroponicos hasta el horizonte y una unica ciudad-elevador.
+`,
+            'mercado_de_brasa.md': `---
+tipo: estacion
+nombre: Mercado de Brasa
+en: sistema_kessler
+conocimiento: rumoreado
+etiquetas: [franco, mineria]
+resumen: Estacion franca entre los asteroides de Kessler, segun los mineros.
+servicios: [repostaje, mercado]
+---
+Dicen que alli se compra de todo y no se pregunta nada.
+`,
+            'nodo_central.md': `---
+tipo: nodo
+nombre: Nodo Central
+coordenadas: {x: 14, y: -14}
+acceso: portal
+conocimiento: rumoreado
+etiquetas: [predecesor, anomalia]
+resumen: Estructura predecesora en el espacio profundo; solo accesible por portal.
+---
+Ninguna ruta convencional llega hasta el. Los que hablan de el mencionan
+una puerta que se abre desde dentro.
+`,
+            '_borrador.md': `---
+tipo: estacion
+nombre: Borrador sin terminar
+---
+Notas sueltas del GM. El escaner debe ignorar este archivo por el guion bajo.
+`,
+            'roto.md': `---
+nombre: [sin cerrar
+tipo: estacion
+---
+Cuerpo intacto pese al YAML invalido. Debe aparecer en el Diagnostico,
+no tumbar la carga del mundo.
+`,
+            porto_verne: {
+                'lugar.md': `---
+tipo: estacion
+nombre: Porto Verne
+en: sistema_verne
+orbita: 4
+conocimiento: visitado
+etiquetas: [puerto, comercio]
+resumen: Puerto franco principal del sistema Verne.
+servicios: [repostaje, mercado, taller, informacion, ocio]
+facciones:
+  - {faccion: vortex_logistics, nivel: dominante}
+  - {faccion: consorcio_tetrad, nivel: encubierta}
+peligro: 1
+---
+Anillo de muelles alrededor de un nucleo de habitats apilados. Todo lo que
+entra o sale del sistema pasa por sus gruas.
+`,
+                plan: {
+                    'acto1_regreso.md': `# ACTO 1 — REGRESO A PORTO VERNE
+
+## Vuelta al puerto con la bodega medio vacia
+
+:::gm
+Acto de apertura del arco. La nave vuelve a Porto Verne y Kael Voss espera
+en el muelle 7 con un encargo turbio. Tono: bullicio portuario, deudas.
+:::
+
+## 1. Reentrada
+
+:::leer
+Las luces del muelle se encienden en fila mientras la nave se acopla.
+Olor a metal caliente, vapor y especias. Un dron de aduanas escanea el
+casco con una linea azul y, al fondo, una voz metalica anuncia salidas.
+:::
+
+:::gm
+Si los PJ preguntan por Kael, esta en el muelle 7 discutiendo con un
+capataz de Vortex. El capataz se marcha si los PJ se acercan.
+:::
+
+:::accion
+**Localizar a Kael Voss**
+- habilidad: Percepcion o Sociedad
+- cd: 15
+- exito: encuentran a Kael antes de que el capataz lo eche del muelle
+- fallo: pierden una hora; Kael los encuentra a ellos, molesto
+:::
+
+## 2. El favor de Kael
+
+:::leer
+Kael Voss baja la voz y desliza un chip de datos hacia vosotros.
+"Un paquete pequeno", dice. "Nada peligroso. Solo llevadlo al punto de
+intercambio y el consorcio no tiene por que saberlo".
+:::
+
+:::gm
+El paquete conecta con la pista deuda_kael_zara. Si los PJ negocian bien
+(Diplomacia CD 17), Kael sube la paga a 500 creditos.
+:::
+
+:::accion
+**Aceptar el encargo**
+- efecto: activa la pista deuda_kael_zara
+- recompensa: 400 creditos al entregar
+:::
+`,
+                },
+                characters: {
+                    'kael_voss.md': `# Kael Voss
+
+Intermediario de carga en los muelles de Porto Verne. Cuarenta anos,
+chaqueta de tres temporadas atras, sonrisa de vendedor cansado.
+
+- **Quiere:** saldar su deuda con Zara Hollis antes de fin de mes.
+- **Teme:** que Vortex Logistics lo vete de los muelles.
+- **Voz:** habla deprisa, se toca la oreja cuando miente.
+`,
+                },
+                music: {},
+            },
+        },
+        facciones: {
+            'vortex_logistics.md': `---
+tipo: faccion
+nombre: Vortex Logistics
+actitud: neutral
+poder: 4
+objetivos:
+  - controlar todo el transito de carga del sistema Verne
+  - absorber a los transportistas independientes
+etiquetas: [corporacion, logistica]
+resumen: La corporacion que mueve (y cobra) casi toda la carga del nucleo.
+estado: >
+  Ha subido las tasas de muelle un 12% y los independientes protestan.
+---
+Uniformes grises, contratos largos y letra pequena.
+`,
+            'consorcio_tetrad.md': `---
+tipo: faccion
+nombre: Consorcio Tetrad
+actitud: rival
+poder: 3
+objetivos:
+  - infiltrar los muelles de Porto Verne
+  - hacerse con el mapa de rutas de Vortex
+etiquetas: [cartel, contrabando]
+resumen: Cartel de contrabando que opera en la sombra de los puertos francos.
+estado: >
+  Su celula en Porto Verne busca mensajeros que no hagan preguntas.
+---
+Nadie ha visto a su directiva; solo a sus cobradores.
+`,
+        },
+        pnjs: {
+            'kael_voss.md': `---
+tipo: pnj
+nombre: Kael Voss
+faccion: vortex_logistics
+rol: contacto
+ubicacion: porto_verne
+etiquetas: [muelles, deudas]
+resumen: Intermediario de carga con demasiadas deudas y buenos contactos.
+estado: >
+  Debe 2000 creditos a Zara Hollis y busca un encargo que lo salve
+  antes de fin de mes.
+---
+Dossier: lleva quince anos en los muelles y conoce cada grua por su nombre.
+`,
+        },
+        pistas: {
+            'deuda_kael_zara.md': `---
+tipo: pista
+nombre: La deuda de Kael con Zara
+estado: activa
+trama: deudas
+donde: porto_verne
+origen: kael_voss
+plazo: 40
+recompensa: 400 creditos y un contacto estable en los muelles
+---
+Kael necesita que alguien entregue un paquete sin que el consorcio se
+entere. Si sale bien, Zara Hollis le perdona parte de la deuda.
+`,
+            'rumor_lejano.md': `---
+tipo: pista
+nombre: Un eco en el nodo
+estado: rumor
+donde: nodo_central
+origen: mercado_de_brasa
+---
+Se habla de una senal que se enciende cada 47 dias en el Nodo Central.
+Nadie ha vuelto para contarlo dos veces.
+`,
+        },
+        tramas: {
+            'deudas.md': `---
+tipo: trama
+nombre: Deudas
+rol: secundaria
+estado: activa
+reloj: {actual: 1, max: 4}
+lugares_clave: [porto_verne]
+facciones: [vortex_logistics]
+---
+## Cuando el reloj avance
+
+1. Zara vende la deuda de Kael al Consorcio Tetrad.
+2. Kael desaparece de los muelles.
+3. El Consorcio usa el expediente de Kael contra los PJ.
+4. Cierre: la deuda se salda o Kael cae.
+`,
+        },
+        eventos: {},
+        estado: {},
+        diario: {},
+        PLANTILLAS: {
+            'pista.md': `---
+tipo: pista
+nombre: <nombre de la pista>
+estado: rumor
+trama: <trama_id o quitar>
+donde: <lugar_id o quitar>
+origen: <entidad_id o texto>
+plazo: <dia_mundo limite, opcional>
+recompensa: <texto, opcional>
+---
+Plantilla: el escaner debe ignorar este archivo (carpeta en MAYUSCULAS).
+`,
+        },
+    },
+};

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -301,7 +301,51 @@ facciones: [vortex_logistics]
 4. Cierre: la deuda se salda o Kael cae.
 `,
         },
-        eventos: {},
+        eventos: {
+            'viajes_nucleo.md': `---
+tipo: eventos
+nombre: Viajes por el nucleo
+contexto: viaje
+regiones: [nucleo]
+---
+## v01 — Control de aduanas {peso=3}
+
+:::leer
+Una patrulla de aduanas os hace detener los motores y acoplarse para una
+inspeccion de carga. El oficial menciona, de pasada, avistamientos en el
+espacio profundo.
+:::
+
+:::efecto
+- gasto: 50 | tasa de inspeccion
+- sabe: nodo_central conocido
+:::
+
+## v02 — Consumo critico {peso=1; si=combustible<=1}
+
+:::gm
+El indicador de combustible entra en zona critica; sin repostar pronto la
+nave quedara a la deriva.
+:::
+`,
+            'estancia_porto.md': `---
+tipo: eventos
+nombre: Estancia en el nucleo
+contexto: estancia
+regiones: [nucleo]
+---
+## e01 — Encargo de descarga {peso=2}
+
+:::leer
+Un capataz del muelle os ofrece unos turnos de descarga bien pagados:
+paga inmediata y sin papeleo.
+:::
+
+:::efecto
+- ganancia: 200 | turnos de descarga
+:::
+`,
+        },
         estado: {},
         diario: {},
         PLANTILLAS: {
@@ -344,11 +388,35 @@ medidores:
 - 2 cargas de repuestos para la nave.
 `;
 
+/**
+ * M4 variant of deuda_kael_zara: `requisitos` evaluated against the LIVE
+ * party numbers — with the estado fixture (creditos 1240 >= 800) it derives
+ * accionable; a session gasto below 800 must drop the star (e2e asserts the
+ * re-derivation). Only the CON_ESTADO variant carries it: without grupo.md
+ * the defaults (creditos 0) would turn the base-fixture pista false and
+ * change what the M1-M3 tests see.
+ */
+const DEUDA_KAEL_ZARA_CON_REQUISITOS = `---
+tipo: pista
+nombre: La deuda de Kael con Zara
+estado: activa
+trama: deudas
+donde: porto_verne
+origen: kael_voss
+plazo: 40
+requisitos: ["creditos>=800"]
+recompensa: 400 creditos y un contacto estable en los muelles
+---
+Kael necesita que alguien entregue un paquete sin que el consorcio se
+entere. Si sale bien, Zara Hollis le perdona parte de la deuda.
+`;
+
 /** Same campaign, plus estado/grupo.md — the party is docked at porto_verne. */
 export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     // FileTree is JSON-safe (plain strings/objects), so a JSON round-trip clones it.
     const clone = JSON.parse(JSON.stringify(MUNDO_CAMPAIGN)) as FileTree;
     const mundo = clone.mundo as FileTree;
     (mundo.estado as FileTree)['grupo.md'] = GRUPO_MD;
+    (mundo.pistas as FileTree)['deuda_kael_zara.md'] = DEUDA_KAEL_ZARA_CON_REQUISITOS;
     return clone;
 })();

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -575,6 +575,19 @@ export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
         'muelle_7_battlemap.png': fixtureSvg('#4a6b8a'),
         'plano_ascii.md': '```\n#####\n#...#\n#####\n```\n',
     };
+    // Many support docs -> the "Fichas" dropdown groups them by folder. The
+    // base fixture already ships characters/kael_voss.md; add more characters
+    // and a threats/ folder so the flat-tabs overflow the tab strip and the
+    // grouped dropdown (Personajes / Amenazas / Mapas ASCII) has each section.
+    ((mundo.lugares as FileTree).porto_verne as FileTree).characters = {
+        'kael_voss.md': '# Kael Voss\n\nIntermediario de carga en los muelles.\n',
+        'zara_hollis.md': '# Zara Hollis\n\nPrestamista a la que Kael debe dinero.\n',
+        'capataz_vortex.md': '# Capataz de Vortex\n\nSupervisa el muelle 7 con mano dura.\n',
+    };
+    ((mundo.lugares as FileTree).porto_verne as FileTree).threats = {
+        'dron_aduanas.md': '# Dron de aduanas\n\nEscanea el casco al acoplar. Nivel 1.\n',
+        'cobrador_tetrad.md': '# Cobrador del Tetrad\n\nBusca al mensajero del paquete.\n',
+    };
     // Shop system: a tiendas/ subfolder inside the porto_verne place folder.
     ((mundo.lugares as FileTree).porto_verne as FileTree).tiendas = {
         'muelles.md': TIENDA_MUELLES,

--- a/e2e/fixtures/mundoCampaign.ts
+++ b/e2e/fixtures/mundoCampaign.ts
@@ -441,8 +441,37 @@ function fixtureSvg(fill: string): string {
 }
 
 /**
+ * A shop under porto_verne (feature — shop system): frontmatter `tipo: tienda`
+ * + a GM-prose blurb + the exact `| articulo | precio | stock | nota |` table.
+ * Two items: one with stock 1 (buy-twice must block on the second), one
+ * unlimited ("-"). pnj resolves to kael_voss (located at porto_verne).
+ */
+const TIENDA_MUELLES = `---
+tipo: tienda
+nombre: Suministros del Muelle 7
+pnj: kael_voss
+etiquetas: [repuestos]
+---
+Un tenderete entre las grúas; Kael conoce al dueño.
+
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Célula de combustible | 120 | 1 | última unidad |
+| Raciones de campo | 40 | - | siempre en stock |
+`;
+
+/** Session recap for the in-app Resumen dialog (feature — in-app resumen). */
+const RESUMEN_MD = `# Anteriormente
+
+El grupo llegó a Porto Verne con la bodega medio vacía y una deuda pendiente
+con Kael Voss.
+`;
+
+/**
  * Same campaign, plus estado/grupo.md — the party is docked at porto_verne —
- * plus entity profile images and an ActRunner image (M6, see header doc).
+ * plus entity profile images and an ActRunner image (M6, see header doc), plus
+ * a porto_verne shop (tiendas/) and a session recap (resumen.md) for the shop
+ * and in-app-resumen features.
  */
 export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     // FileTree is JSON-safe (plain strings/objects), so a JSON round-trip clones it.
@@ -460,6 +489,12 @@ export const MUNDO_CAMPAIGN_CON_ESTADO: FileTree = (() => {
     ((mundo.lugares as FileTree).porto_verne as FileTree).images = {
         'muelle_7.svg': fixtureSvg('#c7823a'),
     };
+    // Shop system: a tiendas/ subfolder inside the porto_verne place folder.
+    ((mundo.lugares as FileTree).porto_verne as FileTree).tiendas = {
+        'muelles.md': TIENDA_MUELLES,
+    };
+    // In-app resumen: mundo/resumen.md (the base fixture has none on purpose).
+    mundo['resumen.md'] = RESUMEN_MD;
     return clone;
 })();
 

--- a/e2e/general.spec.ts
+++ b/e2e/general.spec.ts
@@ -105,8 +105,14 @@ test.describe('Theme and Styling', () => {
 test.describe('Form Interactions', () => {
     test('should focus PC input on tab', async ({ page }) => {
         await page.goto('/');
+        // FLAKE FIX (M5): under parallel headless workers this page's window
+        // may not hold focus when the test runs, and element.focus() on an
+        // unfocused page races Chromium's focus bookkeeping (observed as a
+        // first-run-only failure that passes in isolation). Bring the page to
+        // front and focus through a real click; the assertion is unchanged.
+        await page.bringToFront();
         const input = page.getByPlaceholder(/Enter PC name/i);
-        await input.focus();
+        await input.click();
         await expect(input).toBeFocused();
     });
 

--- a/e2e/helpers/opfs.ts
+++ b/e2e/helpers/opfs.ts
@@ -81,6 +81,55 @@ export async function materializeIntoOPFS(page: Page, tree: FileTree): Promise<v
 }
 
 /**
+ * Reads a file back from OPFS by campaign-relative path — the M3 journal /
+ * estado assertions verify what the app actually wrote to "disk".
+ *
+ * Chromium's createWritable() swaps the file atomically on close(), which can
+ * make the entry vanish for an instant while the app is mid-rewrite — the
+ * read retries briefly on NotFoundError instead of failing the poll.
+ */
+export async function readOPFSFile(page: Page, path: string): Promise<string> {
+    return await page.evaluate(async (relativePath: string) => {
+        const parts = relativePath.split('/').filter(Boolean);
+        const readOnce = async (): Promise<string> => {
+            let dir = await navigator.storage.getDirectory();
+            for (let i = 0; i < parts.length - 1; i++) {
+                dir = await dir.getDirectoryHandle(parts[i]);
+            }
+            const fileHandle = await dir.getFileHandle(parts[parts.length - 1]);
+            const file = await fileHandle.getFile();
+            return await file.text();
+        };
+        let lastError: unknown = null;
+        for (let attempt = 0; attempt < 10; attempt++) {
+            try {
+                return await readOnce();
+            } catch (error) {
+                lastError = error;
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+        }
+        throw lastError;
+    }, path);
+}
+
+/** Lists the entry names of an OPFS directory (sorted). */
+export async function listOPFSDir(page: Page, path: string): Promise<string[]> {
+    return await page.evaluate(async (relativePath: string) => {
+        const parts = relativePath.split('/').filter(Boolean);
+        let dir = await navigator.storage.getDirectory();
+        for (const part of parts) {
+            dir = await dir.getDirectoryHandle(part);
+        }
+        const names: string[] = [];
+        for await (const name of dir.keys()) {
+            names.push(name);
+        }
+        return names.sort();
+    }, path);
+}
+
+/**
  * Opens the world from OPFS via the app's test hook and waits until the
  * world model is loaded and rendered (`[data-world-status="ready"]`).
  */

--- a/e2e/helpers/opfs.ts
+++ b/e2e/helpers/opfs.ts
@@ -1,0 +1,96 @@
+/**
+ * OPFS testing seam — the CONTRACT between world-mode e2e tests and the app.
+ *
+ * Playwright cannot drive `window.showDirectoryPicker()`, but the Origin
+ * Private File System (`navigator.storage.getDirectory()`) returns a real,
+ * writable FileSystemDirectoryHandle in Chromium without any permission
+ * prompt. Tests materialize a fixture FileTree into OPFS and then ask the app
+ * to open it through the exact handle-consuming code path a user would hit.
+ *
+ * App side of the contract (the integrator implements EXACTLY this on the
+ * /world page — tests in e2e/world.spec.ts depend on every point):
+ *
+ *   1. On mount, the /world page registers a test hook on window:
+ *
+ *          window.__ttrpgWorldTest = {
+ *              openFromOPFS: async (): Promise<void> => { ... },
+ *          };
+ *
+ *      `openFromOPFS()` obtains `await navigator.storage.getDirectory()` and
+ *      feeds that handle through the SAME code path as folder selection
+ *      (probe for mundo/mundo.md -> world scan -> populate stores). It only
+ *      needs to kick the scan off; tests wait on the DOM status below.
+ *
+ *   2. The /world page exposes a `data-world-status` attribute on a rendered
+ *      element, reaching the value "ready" once the world model is loaded and
+ *      the map has rendered. Degraded loads (validation issues present) still
+ *      end in "ready" — the world always loads.
+ *
+ *   3. Sector-map nodes carry `data-entity-id="<id>"` and
+ *      `data-knowledge="<conocimiento>"`; the entity side panel root carries
+ *      `data-entity-panel`; the diagnostics affordance is a button whose
+ *      accessible name contains "Diagnóstico"; the ghost toggle is a button
+ *      whose accessible name contains "desconocidos". See e2e/world.spec.ts
+ *      for the full selector contract.
+ */
+
+import type { Page } from '@playwright/test';
+import type { FileTree } from '../fixtures/mundoCampaign';
+
+/** Shape the /world page must register on `window.__ttrpgWorldTest`. */
+export interface TtrpgWorldTestHook {
+    openFromOPFS: () => Promise<void>;
+}
+
+type WorldTestWindow = Window & { __ttrpgWorldTest?: TtrpgWorldTestHook };
+
+/**
+ * Writes `tree` into the page origin's OPFS root, clearing whatever a
+ * previous test left behind. Must run after `page.goto()` (needs an origin).
+ */
+export async function materializeIntoOPFS(page: Page, tree: FileTree): Promise<void> {
+    await page.evaluate(async (fixture: FileTree) => {
+        const root = await navigator.storage.getDirectory();
+
+        // Clear existing entries first (collect names, then remove — do not
+        // remove while iterating the live directory).
+        const existing: string[] = [];
+        for await (const name of root.keys()) {
+            existing.push(name);
+        }
+        for (const name of existing) {
+            await root.removeEntry(name, { recursive: true });
+        }
+
+        const writeTree = async (dir: FileSystemDirectoryHandle, node: FileTree): Promise<void> => {
+            for (const [name, value] of Object.entries(node)) {
+                if (typeof value === 'string') {
+                    const fileHandle = await dir.getFileHandle(name, { create: true });
+                    const writable = await fileHandle.createWritable();
+                    await writable.write(value);
+                    await writable.close();
+                } else {
+                    const subdir = await dir.getDirectoryHandle(name, { create: true });
+                    await writeTree(subdir, value);
+                }
+            }
+        };
+
+        await writeTree(root, fixture);
+    }, tree);
+}
+
+/**
+ * Opens the world from OPFS via the app's test hook and waits until the
+ * world model is loaded and rendered (`[data-world-status="ready"]`).
+ */
+export async function openWorldViaOPFS(page: Page): Promise<void> {
+    // The hook is registered by the /world page on mount.
+    await page.waitForFunction(() => Boolean((window as WorldTestWindow).__ttrpgWorldTest));
+    await page.evaluate(async () => {
+        const hook = (window as WorldTestWindow).__ttrpgWorldTest;
+        if (!hook) throw new Error('window.__ttrpgWorldTest no registrado en /world');
+        await hook.openFromOPFS();
+    });
+    await page.waitForSelector('[data-world-status="ready"]', { state: 'attached' });
+}

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -603,6 +603,31 @@ test.describe('World Mode - Travel & events', () => {
             .toMatch(/- \[\d{2}:\d{2}\] evento: estancia_porto#e01 \| resuelto/);
     });
 
+    // Dedup wiring no-regression: the drawer still opens/draws and the redraw
+    // still returns an event with the new history-model plumbing in place. A
+    // random draw is unit-covered (eventEngine.test.ts); here we only assert
+    // the wiring did not break — the single-event estancia table means the
+    // redraw's exclude-the-shown-event step empties the live pool and falls
+    // back, so an event is always shown (never a dead-end drawer).
+    test('event drawer opens and redraws with the dedup wiring (no regression)', async ({ page }) => {
+        await startSession(page);
+
+        await page.locator('[data-quicklog="evento"]').click();
+        const drawer = page.locator('[data-event-drawer]');
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+        await expect(drawer).toContainText('Encargo de descarga');
+
+        // "Otra tirada" (redraw) still returns a drawn event, never emptiness.
+        await drawer.locator('[data-event-redraw]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+        await expect(drawer).toContainText('Encargo de descarga');
+        // Redraw is one-shot per opening: the button is gone after using it.
+        await expect(drawer.locator('[data-event-redraw]')).toHaveCount(0);
+
+        await drawer.locator('[data-event-outcome="ignorado"]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'closed');
+    });
+
     test('LeadsBoard: accionable star, transition, live re-derivation on gasto', async ({ page }) => {
         const journalPath = await startSession(page);
 
@@ -771,13 +796,33 @@ test.describe('World Mode - Música del mundo', () => {
         await expect(toggle).toHaveAttribute('aria-pressed', 'false');
     });
 
-    test('a world without mundo/musica/ renders no dock at all', async ({ page }) => {
+    test('a world without mundo/musica/ still shows the dock, opening to an empty state', async ({ page }) => {
         await page.goto('/world');
         await materializeIntoOPFS(page, MUNDO_CAMPAIGN); // no musica/ folder
         await openWorldViaOPFS(page);
 
         await expect(page.locator('[data-world-status="ready"]')).toBeAttached();
-        await expect(page.locator('[data-world-audio="toggle"]')).toHaveCount(0);
+
+        // The toggle is ALWAYS present now (an empty folder must not read as a
+        // broken cockpit) — closed by default, no panel yet.
+        const toggle = page.locator('[data-world-audio="toggle"]');
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+        await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
+
+        // Open it: the empty-state panel with the "Sin música cargada" hint.
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        const panel = page.locator('[data-world-audio="panel"]');
+        await expect(panel).toBeVisible();
+        await expect(page.locator('[data-world-audio="panel"][data-world-audio-empty]')).toBeVisible();
+        await expect(panel).toContainText('Sin música cargada');
+        await expect(panel).toContainText('mundo/musica/');
+        // No AudioControls rendered (no manager exists for an empty folder).
+        await expect(panel.locator('[data-world-audio-bgm-count]')).toHaveCount(0);
+
+        // Toggle back off.
+        await toggle.click();
         await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
     });
 

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -132,11 +132,14 @@ test.describe('World Mode - Drill-in & tiers', () => {
         await page.locator('[data-entity-id="sistema_verne"]').dblclick();
         await expect(page.locator('[data-tier="system"]')).toBeAttached();
 
-        // porto_verne contains torre_korinth -> dblclick drills into the list.
+        // porto_verne contains torre_korinth (NO poi) -> dblclick drills into
+        // the non-spatial SiteList (the Plano fallback / regression case).
         await page.locator('[data-entity-id="porto_verne"]').dblclick();
         const list = page.locator('[data-site-list="porto_verne"]');
         await expect(list).toBeVisible();
         await expect(list.locator('[data-site-id="torre_korinth"]')).toBeVisible();
+        // No spatial place tier was entered.
+        await expect(page.locator('[data-tier="place"]')).toHaveCount(0);
         // The duplicate EntityPanel for the SAME lugar is suppressed (the list
         // header already names it); selecting a row brings the panel back.
         await expect(page.locator('[data-entity-panel="porto_verne"]')).toHaveCount(0);
@@ -150,6 +153,45 @@ test.describe('World Mode - Drill-in & tiers', () => {
         await crumbs.getByRole('button', { name: 'Sistema Verne' }).click();
         await expect(page.locator('[data-site-list="porto_verne"]')).toHaveCount(0);
         await expect(page.locator('[data-tier="system"]')).toBeAttached();
+    });
+
+    test('double-clicking a place with POI children opens the spatial Plano (tier 3)', async ({
+        page,
+    }) => {
+        await page.locator('[data-entity-id="sistema_kessler"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await expect(page.locator('[data-entity-id="mercado_de_brasa"]')).toBeAttached();
+
+        // mercado_de_brasa has poi-coord children -> dblclick renders the Plano.
+        await page.locator('[data-entity-id="mercado_de_brasa"]').dblclick();
+        const plano = page.locator('[data-tier="place"]');
+        await expect(plano).toBeAttached();
+        // No non-spatial SiteList this time.
+        await expect(page.locator('[data-site-list="mercado_de_brasa"]')).toHaveCount(0);
+
+        // POIs render spatially as entity nodes (both placed and "sin ubicar").
+        await expect(plano.locator('[data-entity-id="rampa_carga"]')).toBeAttached();
+        await expect(plano.locator('[data-entity-id="sala_franca"]')).toBeAttached();
+        await expect(plano.locator('[data-entity-id="trastienda"]')).toBeAttached();
+        // The hub glyph carries the place's own id.
+        await expect(plano.locator('[data-entity-id="mercado_de_brasa"]')).toBeAttached();
+
+        // Clicking a POI selects it (panel shows it).
+        await plano.locator('[data-entity-id="rampa_carga"]').click();
+        await expect(page.locator('[data-entity-panel="rampa_carga"]')).toBeVisible();
+
+        // Breadcrumb: Sector -> Sistema Kessler -> Mercado de Brasa. The sistema
+        // crumb pops back to the system tier.
+        const crumbs = page.getByRole('navigation', { name: 'Ruta del mapa' });
+        await expect(crumbs).toContainText('Mercado de Brasa');
+        await crumbs.getByRole('button', { name: 'Sistema Kessler' }).click();
+        await expect(page.locator('[data-tier="place"]')).toHaveCount(0);
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+
+        // Back out to the sector tier.
+        await page.getByRole('button', { name: 'Sector Eloran' }).click();
+        await expect(page.locator('[data-tier="system"]')).toHaveCount(0);
+        await expect(page.locator('[data-entity-id]')).toHaveCount(4);
     });
 });
 

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -781,6 +781,28 @@ test.describe('World Mode - Eventos en curso & combate', () => {
         await expect(page.getByText('Chesco', { exact: true }).first()).toBeVisible();
     });
 
+    test('(e) Revelar lights a ghost entity so it becomes conocido + Mover-able', async ({ page }) => {
+        await startSession(page); // sabe: must be journaled
+
+        // sistema_umbral starts desconocido (a ghost at the sector tier).
+        const umbral = page.locator('[data-entity-id="sistema_umbral"]');
+        await expect(umbral).toHaveAttribute('data-knowledge', 'desconocido');
+        await umbral.click();
+        const panel = page.locator('[data-entity-panel="sistema_umbral"]');
+        await expect(panel).toBeVisible();
+
+        // Revelar bumps it to conocido (logs sabe:).
+        await panel.locator('[data-reveal]').click();
+        await expect(page.locator('[data-entity-id="sistema_umbral"]')).toHaveAttribute(
+            'data-knowledge',
+            'conocido'
+        );
+
+        // Now it is a valid Mover destination (Mover excludes desconocido).
+        await page.locator('[data-quicklog="mover"]').click();
+        await expect(page.locator('[data-mover-id="sistema_umbral"]')).toBeVisible();
+    });
+
     test('(d) Terminar -> Descartar wipes the test session (journal gone, estado reverted)', async ({ page }) => {
         await startSession(page);
         await expect

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1457,3 +1457,46 @@ test.describe('World Mode - Perfiles, imagen segura y detalle de pistas', () => 
         await expect(page.locator('[data-lead-detail]')).toHaveCount(0);
     });
 });
+
+test.describe('World Mode - Hilos de historia', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+    });
+
+    test('Hilos tab lists tramas + pistas and paints/clears the focused thread web', async ({
+        page,
+    }) => {
+        // Switch to the Hilos tab: both tramas listed, with a child pista visible.
+        await page.locator('[data-panel-tab="hilos"]').click();
+        const panel = page.locator('[data-hilos-panel]');
+        await expect(panel).toBeVisible();
+        await expect(panel.locator('[data-hilo-id="contrabando"]')).toBeVisible();
+        await expect(panel.locator('[data-hilo-id="deudas"]')).toBeVisible();
+        await expect(panel).toContainText('Contrabando');
+        // A child pista of the trama is listed inside its card.
+        await expect(
+            page.locator('[data-hilo-id="contrabando"] [data-hilo-pista="ruta_franca"]')
+        ).toBeVisible();
+
+        // Nothing painted before focusing.
+        await expect(page.locator('[data-thread-layer]')).toHaveCount(0);
+
+        // Focus contrabando: its 2 lugares_clave resolve to two different sector
+        // roots (sistema_verne + sistema_kessler) -> two thread-node markers.
+        await page.locator('[data-hilo-focus="contrabando"]').click();
+        const layer = page.locator('[data-thread-layer]');
+        await expect(layer).toBeVisible();
+        // Still at the sector tier (focusing drops there).
+        await expect(page.locator('[data-tier="system"]')).toHaveCount(0);
+        await expect(page.locator('[data-tier="place"]')).toHaveCount(0);
+        await expect(layer.locator('[data-thread-node="sistema_verne"]')).toBeAttached();
+        await expect(layer.locator('[data-thread-node="sistema_kessler"]')).toBeAttached();
+        await expect(layer.locator('[data-thread-node]')).toHaveCount(2);
+
+        // Toggle off (re-click the same trama) removes the layer.
+        await page.locator('[data-hilo-focus="contrabando"]').click();
+        await expect(page.locator('[data-thread-layer]')).toHaveCount(0);
+    });
+});

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1447,6 +1447,62 @@ test.describe('World Mode - Perfiles, imagen segura y detalle de pistas', () => 
         await expect(page.locator('[data-act-runner]')).toBeVisible();
     });
 
+    test('ActRunner collapses support docs into a grouped Fichas dropdown', async ({ page }) => {
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        // The many characters/ + threats/ + maps/*.md docs no longer render as
+        // flat tabs: no tab reads as a support-doc name.
+        await expect(page.getByRole('tab', { name: /zara hollis/i })).toHaveCount(0);
+        await expect(page.getByRole('tab', { name: /dron aduanas/i })).toHaveCount(0);
+        await expect(page.getByRole('tab', { name: /plano ascii/i })).toHaveCount(0);
+
+        // Plan / image / battlemap stay as real tabs.
+        await expect(page.getByRole('tab', { name: /^Plan$/ })).toBeVisible();
+        await expect(page.getByRole('tab', { name: 'muelle_7.svg' })).toBeVisible();
+        await expect(page.getByRole('tab', { name: /muelle 7 battlemap/i })).toBeVisible();
+
+        // Instead there is ONE "Fichas" dropdown trigger.
+        const fichas = runner.locator('[data-fichas-menu]');
+        await expect(fichas).toBeVisible();
+        await expect(fichas).toContainText('Fichas');
+        await expect(fichas).not.toHaveAttribute('data-active', 'true');
+
+        // Opening it groups the docs by folder with section labels.
+        await fichas.click();
+        const menu = page.locator('[data-slot="dropdown-menu-content"]');
+        await expect(menu).toBeVisible();
+        await expect(menu).toContainText('Personajes');
+        await expect(menu).toContainText('Amenazas');
+        await expect(menu).toContainText('Mapas (ASCII)');
+        await expect(menu.locator('[data-fichas-item]')).toHaveCount(6);
+
+        // Picking a ficha activates its TabsContent (the RunnerMarkdown body)...
+        await menu.locator('[data-fichas-item]', { hasText: 'zara hollis' }).click();
+        await expect(menu).toHaveCount(0);
+        await expect(runner.getByText('Prestamista a la que Kael debe dinero')).toBeVisible();
+        // ...and the trigger now shows the active state + the doc's label.
+        await expect(fichas).toHaveAttribute('data-active', 'true');
+        await expect(fichas).toContainText('zara hollis');
+
+        // A threats doc from the same dropdown swaps the content.
+        await fichas.click();
+        await page
+            .locator('[data-slot="dropdown-menu-content"] [data-fichas-item]', {
+                hasText: 'dron aduanas',
+            })
+            .click();
+        await expect(runner.getByText('Escanea el casco al acoplar')).toBeVisible();
+
+        // Plan tab still works, and returns the dropdown to its idle state.
+        await page.getByRole('tab', { name: /^Plan$/ }).click();
+        await expect(fichas).not.toHaveAttribute('data-active', 'true');
+        await expect(fichas).toContainText('Fichas');
+
+        // The tab strip is wrapped in the horizontal scroll container.
+        await expect(runner.locator('[data-tabs-scroll]')).toBeVisible();
+    });
+
     test('pista row opens a detail view with body + recompensa; transitions do not', async ({ page }) => {
         // Session active so the transition journals a pista line.
         await page.locator('[data-session-start]').click();

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -176,6 +176,29 @@ test.describe('World Mode - Drill-in & tiers', () => {
         // The hub glyph carries the place's own id.
         await expect(plano.locator('[data-entity-id="mercado_de_brasa"]')).toBeAttached();
 
+        // Affordance badges: sala_franca (servicios mercado/contrabando, conocido)
+        // shows a SHOP icon; rampa_carga (servicios informacion, visitado) shows an
+        // INFO icon. trastienda (rumoreado) must NOT leak any affordance, and the
+        // shop node carries no info icon (nor vice versa).
+        await expect(
+            plano.locator('[data-entity-id="sala_franca"] [data-node-icon="shop"]')
+        ).toBeAttached();
+        await expect(
+            plano.locator('[data-entity-id="sala_franca"] [data-node-icon="info"]')
+        ).toHaveCount(0);
+        await expect(
+            plano.locator('[data-entity-id="rampa_carga"] [data-node-icon="info"]')
+        ).toBeAttached();
+        await expect(
+            plano.locator('[data-entity-id="rampa_carga"] [data-node-icon="shop"]')
+        ).toHaveCount(0);
+        await expect(
+            plano.locator('[data-entity-id="trastienda"] [data-node-icon]')
+        ).toHaveCount(0);
+
+        // The legend key is present so the icons are self-explanatory.
+        await expect(page.locator('[data-map-legend]')).toBeVisible();
+
         // Clicking a POI selects it (panel shows it).
         await plano.locator('[data-entity-id="rampa_carga"]').click();
         await expect(page.locator('[data-entity-panel="rampa_carga"]')).toBeVisible();

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -926,14 +926,48 @@ test.describe('World Mode - Tiendas', () => {
         await expect(shop).toContainText('Suministros del Muelle 7');
         await expect(shop).toContainText('Kael Voss'); // shopkeeper chip
 
-        // Buy the unlimited item: creditos drop by 40 (1240 -> 1200).
+        // The price shows as an editable input defaulting to the base (40).
+        await expect(
+            shop.locator('[data-shop-price-input="Raciones de campo"]')
+        ).toHaveValue('40');
+
+        // Buy the unlimited item at base: creditos drop by 40 (1240 -> 1200).
         await shop.locator('[data-shop-buy="Raciones de campo"]').click();
         await expect(page.locator('[data-party-bar] [data-creditos="1200"]')).toBeVisible();
 
-        // Journal carries the gasto with the compra comentario.
+        // Journal carries the gasto with the compra comentario (no negociado tag
+        // at base price).
         await expect
             .poll(() => readOPFSFile(page, journalPath))
-            .toMatch(/- \[\d{2}:\d{2}\] gasto: 40 \| compra: Raciones de campo/);
+            .toMatch(/- \[\d{2}:\d{2}\] gasto: 40 \| compra: Raciones de campo(?! \(negociado)/);
+    });
+
+    test('negotiate a lower price: Comprar charges the edited amount', async ({ page }) => {
+        const journalPath = await startSession(page);
+        await openPortoVernePanel(page);
+        await page.locator('[data-shop-link="muelles"]').click();
+        const shop = page.locator('[data-shop-panel="muelles"]');
+        await expect(shop).toBeVisible();
+
+        // Negotiate the base 40 down to 25 in the price input.
+        const priceInput = shop.locator('[data-shop-price-input="Raciones de campo"]');
+        await priceInput.fill('25');
+        // The base hint surfaces the deviation.
+        await expect(shop.locator('[data-shop-price-base]').first()).toContainText('base 40');
+
+        // Comprar charges 25: creditos drop by 25 (1240 -> 1215).
+        await shop.locator('[data-shop-buy="Raciones de campo"]').click();
+        await expect(page.locator('[data-party-bar] [data-creditos="1215"]')).toBeVisible();
+
+        // Journal records the negotiated gasto with the base annotation.
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(
+                /- \[\d{2}:\d{2}\] gasto: 25 \| compra: Raciones de campo \(negociado, base 40\)/
+            );
+
+        // After a buy the input resets back to the base price.
+        await expect(priceInput).toHaveValue('40');
     });
 
     test('a stock-1 item blocks the second purchase', async ({ page }) => {

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1106,6 +1106,83 @@ async function openPortoVerneRunner(page: import('@playwright/test').Page): Prom
 }
 
 test.describe('World Mode - ActRunner', () => {
+    test('a threat ficha with a statblock adds prefilled combatants to the initiative tracker', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        // Open the Fichas dropdown and pick the statblock threat (dron aduanas).
+        const fichas = runner.locator('[data-fichas-menu]');
+        await fichas.click();
+        await page
+            .locator('[data-slot="dropdown-menu-content"] [data-fichas-item]', {
+                hasText: 'dron aduanas',
+            })
+            .click();
+
+        // The threat pane shows the one-tap add control (parsed CA 16 / PV 22).
+        const addBtn = runner.locator('[data-threat-add]');
+        await expect(addBtn).toBeVisible();
+        await expect(runner).toContainText('CA 16');
+        await expect(runner).toContainText('PV 22');
+
+        // Bump the count stepper to 2, then add to combat.
+        const count = runner.locator('[data-threat-count]');
+        await expect(count).toHaveText('1');
+        await runner.getByRole('button', { name: 'Más' }).click();
+        await expect(count).toHaveText('2');
+        await addBtn.click();
+
+        // A confirmation toast names the creature and the count.
+        await expect(page.locator('[data-combat-toast]')).toContainText('×2 → combate');
+
+        // Open the initiative tracker (hover its collapsed toggle) and assert two
+        // rows named after the creature, with the parsed HP/AC prefilled (not 0).
+        await page.locator('[data-initiative-toggle]').hover();
+        await expect(page.getByText('Initiative')).toBeVisible();
+        // #1 also appears in the "Current Turn" header; #2 only as a row. Both
+        // prove the two de-duped combatants landed.
+        await expect(page.getByText('Dron de aduanas #1', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('Dron de aduanas #2', { exact: true }).first()).toBeVisible();
+        // Parsed maxHP shows in each HP readout (22/22), proving it is not 0.
+        await expect(page.getByText('22/22').first()).toBeVisible();
+        await expect(page.getByText('22/22')).toHaveCount(2);
+    });
+
+    test('a threat ficha without a statblock shows no add-to-combat control', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        const fichas = runner.locator('[data-fichas-menu]');
+        await fichas.click();
+        // cobrador_tetrad is prose-only -> no CA/PV -> no button.
+        await page
+            .locator('[data-slot="dropdown-menu-content"] [data-fichas-item]', {
+                hasText: 'cobrador tetrad',
+            })
+            .click();
+        await expect(runner.getByText('Busca al mensajero del paquete')).toBeVisible();
+        await expect(runner.locator('[data-threat-add]')).toHaveCount(0);
+
+        // And a non-threat ficha (a character) never shows it either. Wait for the
+        // menu to fully close before reopening (Radix toggles a mid-close click).
+        await expect(page.locator('[data-slot="dropdown-menu-content"]')).toHaveCount(0);
+        await fichas.click();
+        await page
+            .locator('[data-slot="dropdown-menu-content"] [data-fichas-item]', {
+                hasText: 'zara hollis',
+            })
+            .click();
+        await expect(runner.locator('[data-threat-add]')).toHaveCount(0);
+    });
+
     test('Jugar opens the 3-panel act renderer and Cerrar returns to the cockpit', async ({ page }) => {
         // No estado fixture on purpose: viewing prep without a session is legit.
         await page.goto('/world');

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1241,6 +1241,93 @@ test.describe('World Mode - ActRunner', () => {
             .poll(() => readOPFSFile(page, journalPath))
             .toMatch(/- \[\d{2}:\d{2}\] nota: Acto cerrado: Part 1 @ Porto Verne/);
     });
+
+    test('Vista jugador hides the GM answer-key rails, then restores them', async ({ page }) => {
+        // CON_ESTADO adds an image to porto_verne, so we can assert the player-safe
+        // media survives the toggle while the GM rails vanish.
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        const readAloud = runner.getByText('Las luces del muelle se encienden en fila', {
+            exact: false,
+        });
+        const gmAnswerKey = runner.getByText('Acto de apertura del arco', { exact: false });
+        const accionCard = runner.getByText('Localizar a Kael Voss', { exact: false });
+        // A SECTION-scoped :::gm body (bare :::gm under the numbered "## 2. El
+        // favor de Kael" heading) — this renders inline in the CENTER column, not
+        // in the left rail, so it must be guarded separately or it leaks.
+        const gmSectionNote = runner.getByText('Kael sube la paga a 500 creditos', {
+            exact: false,
+        });
+
+        // Default GM view: read-aloud AND the GM-only rails/notes are present.
+        await expect(readAloud).toBeVisible();
+        await expect(runner.getByText('Recordatorios del acto')).toBeVisible();
+        await expect(gmAnswerKey).toBeVisible();
+        await expect(accionCard).toBeVisible();
+        await expect(gmSectionNote).toBeVisible();
+
+        const toggle = runner.locator('[data-player-view]');
+        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+        // Toggle Vista jugador ON: the :::gm answer-key + :::accion cards must be
+        // gone from the DOM entirely, while the :::leer read-aloud remains.
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(readAloud).toBeVisible();
+        await expect(gmAnswerKey).toHaveCount(0);
+        await expect(accionCard).toHaveCount(0);
+        await expect(runner.getByText('Recordatorios del acto')).toHaveCount(0);
+        // The section-scoped :::gm note must be gone from the DOM too.
+        await expect(gmSectionNote).toHaveCount(0);
+
+        // The Plan tab strip (player-safe media viewers) is still mounted.
+        await expect(runner.locator('[role="tab"]').filter({ hasText: 'Plan' })).toBeVisible();
+
+        // Toggle OFF restores the full GM view byte-for-byte.
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+        await expect(gmAnswerKey).toBeVisible();
+        await expect(accionCard).toBeVisible();
+        await expect(runner.getByText('Recordatorios del acto')).toBeVisible();
+        await expect(gmSectionNote).toBeVisible();
+    });
+
+    test('a node place whose first act is acto2 auto-selects it (no phantom acto1)', async ({
+        page,
+    }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        // jardin_que_exhala is a system-tier child of sistema_verne; its plan/
+        // starts at act2 (no act1 folder at all).
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await page.locator('[data-entity-id="jardin_que_exhala"]').click();
+        await expect(page.locator('[data-entity-panel="jardin_que_exhala"]')).toBeVisible();
+
+        await page.locator('[data-play-act]').click();
+        const runner = page.locator('[data-act-runner]');
+        await expect(runner).toBeVisible();
+
+        // No phantom acto1 tab, and the first real act (Acto2) is the selected one.
+        await expect(runner.locator('[data-act-part*="Acto1"]')).toHaveCount(0);
+        const firstTab = runner.locator('[data-act-part="Acto2 Umbral"]');
+        await expect(firstTab).toBeVisible();
+        await expect(firstTab).toHaveAttribute('aria-selected', 'true');
+        // Its ENTRADA badge flags "start here"; act3 has none.
+        await expect(firstTab.locator('[data-act-entry]')).toBeVisible();
+        await expect(
+            runner.locator('[data-act-part="Acto3 Corazon"] [data-act-entry]')
+        ).toHaveCount(0);
+
+        // The auto-selected act's read-aloud renders (proves acto2 is live).
+        await expect(runner.getByText('El aire sale tibio de las paredes', { exact: false })).toBeVisible();
+    });
 });
 
 // ── World-level music (mundo/musica/ -> bottom-left audio dock) ─────────────

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -372,7 +372,7 @@ test.describe('World Mode - Session recorder', () => {
         // (g) Terminar sesión -> fin line + dia_fin + estado frontmatter updated
         // with the agent-owned body preserved byte-for-byte.
         await page.locator('[data-session-end]').click();
-        await page.locator('[data-session-end-confirm-button]').click();
+        await page.locator('[data-session-save]').click();
         await expect(page.locator('[data-session-start]')).toBeVisible();
 
         const journalFinal = await readOPFSFile(page, journalPath);
@@ -771,23 +771,49 @@ test.describe('World Mode - Eventos en curso & combate', () => {
         await expect(page.locator('[data-combat-open]')).toBeVisible();
     });
 
-    test('(c) cockpit initiative shows the PC names from personajes', async ({ page }) => {
+    test('(c) Combate force-opens the initiative panel with the PC roster', async ({ page }) => {
         await startSession(page);
 
-        // No ActRunner open -> revealing combat mounts the COCKPIT tracker.
+        // No ActRunner open -> Combate mounts the COCKPIT tracker AND force-opens
+        // the full panel via openSignal — the PC rows render WITHOUT a hover.
         await page.locator('[data-combat-open]').click();
-
-        // The tracker seeds one PC entry per personajes name. Collapsed it shows
-        // a left-edge semi-circle pull-tab; hovering it expands the full panel
-        // where the PC rows (Xiao / Chesco) render. It is left-edge fixed.
-        const pullTab = page.locator('div.fixed.left-0.cursor-pointer').first();
-        await expect(pullTab).toBeVisible();
-        await pullTab.hover();
-        // The expanded panel lists one row per personajes name (the tracker also
-        // keeps its compact pull-tab mounted, so the name can resolve twice —
-        // .first() suffices to prove the roster reached the tracker).
         await expect(page.getByText('Xiao', { exact: true }).first()).toBeVisible();
         await expect(page.getByText('Chesco', { exact: true }).first()).toBeVisible();
+    });
+
+    test('(d) Terminar -> Descartar wipes the test session (journal gone, estado reverted)', async ({ page }) => {
+        await startSession(page);
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+
+        // Spend credits during the test session (would persist if saved).
+        await page.locator('[data-quicklog="creditos"]').click();
+        await page.locator('[data-quicklog-creditos-custom]').fill('-200');
+        await page.locator('[data-quicklog-creditos-custom]').press('Enter');
+        await expect(page.locator('[data-party-bar] [data-creditos="1040"]')).toBeVisible();
+
+        // Terminar -> Descartar (prueba).
+        await page.locator('[data-session-end]').click();
+        await page.locator('[data-session-discard]').click();
+
+        // Journal deleted; estado rolled back to the pre-session snapshot.
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(0);
+        const estado = await readOPFSFile(page, 'mundo/estado/grupo.md');
+        expect(estado).toContain('sesion_activa: false');
+        expect(estado).toContain('creditos: 1240'); // reverted
+        expect(estado).toMatch(/personajes:\s*\n?\s*(\[Xiao|-\s*Xiao)/); // roster preserved
+        // UI reverted: session over, credits back.
+        await expect(page.locator('[data-session-start]')).toBeVisible();
+        await expect(page.locator('[data-party-bar] [data-creditos="1240"]')).toBeVisible();
+
+        // A fresh session numbers as s01 again — the discarded one left no trace.
+        await page.locator('[data-session-start]').click();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario'))[0] ?? '')
+            .toMatch(/_s01\.md$/);
     });
 });
 
@@ -1067,7 +1093,7 @@ test.describe('World Mode - Console hygiene', () => {
 
         // End session (journal flush + forced estado write).
         await page.locator('[data-session-end]').click();
-        await page.locator('[data-session-end-confirm-button]').click();
+        await page.locator('[data-session-save]').click();
         await expect(page.locator('[data-session-start]')).toBeVisible();
 
         expect(issues).toEqual([]);

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -678,6 +678,119 @@ test.describe('World Mode - Travel & events', () => {
     });
 });
 
+// ── Feature 1 + 2: Ongoing events ("En curso") + cockpit combat ─────────────
+//
+// estancia_porto#e01 "Encargo de descarga" is the single estancia event in
+// region nucleo (drawn from the QuickLogBar "evento" button at porto_verne).
+// The CON_ESTADO fixture carries personajes: [Xiao, Chesco] for the cockpit
+// initiative tracker.
+
+test.describe('World Mode - Eventos en curso & combate', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+    });
+
+    /** Starts a session and returns the diario path (single file, sesion 1). */
+    async function startSession(page: import('@playwright/test').Page): Promise<string> {
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        return `mundo/diario/${journalName}`;
+    }
+
+    test('(a) En curso parks the event; the Eventos tab lists it, reopen + Resuelto closes it', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        // Draw an estancia event and PARK it "En curso".
+        await page.locator('[data-quicklog="evento"]').click();
+        const drawer = page.locator('[data-event-drawer]');
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+        await expect(drawer).toContainText('Encargo de descarga');
+        await drawer.locator('[data-event-outcome="en_curso"]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'closed');
+
+        // Journal carries the "en curso" comentario (exact string).
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] evento: estancia_porto#e01 \| en curso/);
+
+        // Eventos tab badge = 1 and the row is visible.
+        const eventosTab = page.locator('[data-panel-tab="eventos"]');
+        await expect(eventosTab.locator('[data-eventos-badge="1"]')).toBeVisible();
+        await eventosTab.click();
+        const row = page.locator('[data-ongoing-event="estancia_porto#e01"]');
+        await expect(row).toBeVisible();
+        await expect(row).toContainText('Encargo de descarga');
+
+        // Clicking the row (data-ongoing-open is on the row button itself)
+        // reopens the event drawer with that event.
+        await expect(row).toHaveAttribute('data-ongoing-open');
+        await row.click();
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+        await expect(drawer).toContainText('Encargo de descarga');
+
+        // Pick Resuelto: drawer closes, the event drops from ongoing, badge gone.
+        await drawer.locator('[data-event-outcome="resuelto"]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'closed');
+        await expect(page.locator('[data-eventos-badge]')).toHaveCount(0);
+        await expect(page.locator('[data-ongoing-event="estancia_porto#e01"]')).toHaveCount(0);
+        await expect(page.locator('[data-eventos-empty]')).toBeVisible();
+
+        // Journal shows both states for the id: "en curso" then "resuelto".
+        const journal = await readOPFSFile(page, journalPath);
+        expect(journal).toMatch(/- \[\d{2}:\d{2}\] evento: estancia_porto#e01 \| en curso/);
+        expect(journal).toMatch(/- \[\d{2}:\d{2}\] evento: estancia_porto#e01 \| resuelto/);
+    });
+
+    test('(b) Abrir combate parks the event and reveals the initiative affordance', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        await page.locator('[data-quicklog="evento"]').click();
+        const drawer = page.locator('[data-event-drawer]');
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+
+        // "Abrir combate": parks en_curso + reveals initiative + closes drawer.
+        await drawer.locator('[data-event-combat]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'closed');
+
+        // The event is parked (Eventos tab shows it).
+        await expect(page.locator('[data-panel-tab="eventos"] [data-eventos-badge="1"]')).toBeVisible();
+        await page.locator('[data-panel-tab="eventos"]').click();
+        await expect(page.locator('[data-ongoing-event="estancia_porto#e01"]')).toBeVisible();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] evento: estancia_porto#e01 \| en curso/);
+
+        // The initiative affordance is present (the cockpit tracker is mounted;
+        // it renders its own left-edge pull-tab). data-combat-open stays too.
+        await expect(page.locator('[data-combat-open]')).toBeVisible();
+    });
+
+    test('(c) cockpit initiative shows the PC names from personajes', async ({ page }) => {
+        await startSession(page);
+
+        // No ActRunner open -> revealing combat mounts the COCKPIT tracker.
+        await page.locator('[data-combat-open]').click();
+
+        // The tracker seeds one PC entry per personajes name. Collapsed it shows
+        // a left-edge semi-circle pull-tab; hovering it expands the full panel
+        // where the PC rows (Xiao / Chesco) render. It is left-edge fixed.
+        const pullTab = page.locator('div.fixed.left-0.cursor-pointer').first();
+        await expect(pullTab).toBeVisible();
+        await pullTab.hover();
+        // The expanded panel lists one row per personajes name (the tracker also
+        // keeps its compact pull-tab mounted, so the name can resolve twice —
+        // .first() suffices to prove the roster reached the tracker).
+        await expect(page.getByText('Xiao', { exact: true }).first()).toBeVisible();
+        await expect(page.getByText('Chesco', { exact: true }).first()).toBeVisible();
+    });
+});
+
 // ── M5: ActRunner (scripted acts inside /world) ─────────────────────────────
 //
 // porto_verne is the fixture's playable place: lugares/porto_verne/ holds

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1328,6 +1328,107 @@ test.describe('World Mode - ActRunner', () => {
         // The auto-selected act's read-aloud renders (proves acto2 is live).
         await expect(runner.getByText('El aire sale tibio de las paredes', { exact: false })).toBeVisible();
     });
+
+    // ── "Efectos del acto" — one-tap apply of an act's :::efecto transitions ──
+    //
+    // acto1_regreso.md declares a :::efecto block (pista rumor_lejano
+    // rumor->activa + ganancia 150). The panel surfaces those as apply buttons;
+    // applying them journals the transition (so it can't silently revert).
+
+    test('Efectos del acto: apply a :::efecto transition, button checks off, raw text hidden', async ({
+        page,
+    }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        // A session must be active for the apply buttons to journal.
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        const journalPath = `mundo/diario/${journalName}`;
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        // The Efectos del acto panel renders both transitions as apply buttons.
+        const panel = runner.locator('[data-act-efectos]');
+        await expect(panel).toBeVisible();
+        await expect(panel).toContainText('Efectos del acto');
+        const pistaBtn = panel.locator('[data-act-efecto="0"]');
+        const gananciaBtn = panel.locator('[data-act-efecto="1"]');
+        await expect(pistaBtn).toBeEnabled();
+        await expect(gananciaBtn).toContainText('+150 créditos');
+
+        // The raw :::efecto source is NOT in the act view (stripped before ActPanels).
+        await expect(runner).not.toContainText(':::efecto');
+        await expect(runner).not.toContainText('rumor->activa');
+
+        // Apply the ganancia: party bar credits jump 1240 -> 1390 and it journals.
+        await gananciaBtn.click();
+        await expect(page.locator('[data-party-bar] [data-creditos="1390"]')).toBeVisible();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] ganancia: 150/);
+        // The applied button checks off + disables (can't double-apply).
+        await expect(gananciaBtn).toBeDisabled();
+
+        // Apply the pista transition: journals a pista line rumor -> activa.
+        await pistaBtn.click();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] pista: rumor_lejano rumor->activa/);
+        await expect(pistaBtn).toBeDisabled();
+    });
+
+    test('Efectos del acto: hidden under Vista jugador and gated without a session', async ({
+        page,
+    }) => {
+        // No estado fixture -> no active session -> the apply buttons are gated.
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        const panel = runner.locator('[data-act-efectos]');
+        await expect(panel).toBeVisible();
+        // Session-gated: the hint shows and each apply button is disabled.
+        await expect(panel.locator('[data-act-efectos-hint]')).toBeVisible();
+        await expect(panel.locator('[data-act-efecto="0"]')).toBeDisabled();
+        await expect(panel.locator('[data-act-efecto="1"]')).toBeDisabled();
+
+        // Vista jugador is GM-only: the panel must vanish from the DOM entirely.
+        const toggle = runner.locator('[data-player-view]');
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(runner.locator('[data-act-efectos]')).toHaveCount(0);
+
+        // Toggling back off restores it.
+        await toggle.click();
+        await expect(runner.locator('[data-act-efectos]')).toBeVisible();
+    });
+
+    test('an act WITHOUT a :::efecto block shows no Efectos del acto panel', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        // jardin_que_exhala's acto2 plan carries no :::efecto block.
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await page.locator('[data-entity-id="jardin_que_exhala"]').click();
+        await expect(page.locator('[data-entity-panel="jardin_que_exhala"]')).toBeVisible();
+        await page.locator('[data-play-act]').click();
+
+        const runner = page.locator('[data-act-runner]');
+        await expect(runner).toBeVisible();
+        await expect(runner.getByText('El aire sale tibio de las paredes', { exact: false })).toBeVisible();
+        await expect(runner.locator('[data-act-efectos]')).toHaveCount(0);
+    });
 });
 
 // ── World-level music (mundo/musica/ -> bottom-left audio dock) ─────────────

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -123,6 +123,62 @@ test.describe('World Mode - Drill-in & tiers', () => {
         await expect(bar).toBeVisible();
         await expect(bar).toContainText('no hay datos del grupo');
     });
+
+    test('double-clicking a place with children opens the SiteList (tier 3)', async ({ page }) => {
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+
+        // porto_verne contains torre_korinth -> dblclick drills into the list.
+        await page.locator('[data-entity-id="porto_verne"]').dblclick();
+        const list = page.locator('[data-site-list="porto_verne"]');
+        await expect(list).toBeVisible();
+        await expect(list.locator('[data-site-id="torre_korinth"]')).toBeVisible();
+        // The duplicate EntityPanel for the SAME lugar is suppressed (the list
+        // header already names it); selecting a row brings the panel back.
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toHaveCount(0);
+
+        await list.locator('[data-site-id="torre_korinth"]').click();
+        await expect(page.locator('[data-entity-panel="torre_korinth"]')).toBeVisible();
+
+        // Breadcrumb carries all three levels; the middle crumb pops the list.
+        const crumbs = page.getByRole('navigation', { name: 'Ruta del mapa' });
+        await expect(crumbs).toContainText('Porto Verne');
+        await crumbs.getByRole('button', { name: 'Sistema Verne' }).click();
+        await expect(page.locator('[data-site-list="porto_verne"]')).toHaveCount(0);
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+    });
+});
+
+// ── B1 fix: cockpit bootstrap without estado/grupo.md ───────────────────────
+
+test.describe('World Mode - Crear estado/grupo.md', () => {
+    test('the null-estado bar offers creating the file and unblocks the session', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN); // estado/ empty
+        await openWorldViaOPFS(page);
+
+        const bar = page.locator('[data-party-bar]');
+        await expect(bar).toContainText('no hay datos del grupo');
+
+        await page.locator('[data-create-estado]').click();
+
+        // The bar switches to the live readout with the defaults...
+        await expect(bar.locator('[data-creditos="0"]')).toBeVisible();
+        await expect(bar.locator('[data-medidor="viveres"][data-valor="3"]')).toBeAttached();
+        await expect(page.locator('[data-session-start]')).toBeEnabled();
+
+        // ...and the file landed on disk, agent-parseable.
+        const estado = await readOPFSFile(page, 'mundo/estado/grupo.md');
+        expect(estado).toContain('tipo: estado_grupo');
+        expect(estado).toContain('sesion_activa: false');
+
+        // The unblocked cockpit records for real.
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+    });
 });
 
 // ── M2: search + deep link ──────────────────────────────────────────────────
@@ -367,10 +423,15 @@ test.describe('World Mode - Travel & events', () => {
         await page.locator('[data-travel-here]').click();
         const dialog = page.locator('[data-travel-dialog]');
         await expect(dialog).toBeVisible();
-        // Intra-system hop: 1 flat day, no consumption (pips stay 2 -> 2).
+        // Intra-system hop: 1 flat day, no fuel (pips stay 2 -> 2) — but the
+        // calendar crosses dia 4128 (multiple of viveres_cada_dias 4), so the
+        // dialog previews exactly 1 ración: 3 -> 2.
         await expect(dialog.locator('[data-travel-total-dias="1"]')).toBeVisible();
         await expect(
             dialog.locator('[data-travel-medidor="combustible"][data-antes="2"][data-despues="2"]')
+        ).toBeAttached();
+        await expect(
+            dialog.locator('[data-travel-medidor="viveres"][data-antes="3"][data-despues="2"]')
         ).toBeAttached();
 
         await page.locator('[data-travel-confirm]').click();
@@ -395,7 +456,7 @@ test.describe('World Mode - Travel & events', () => {
             page.locator('[data-party-bar]').getByRole('navigation', { name: 'Ubicación' })
         ).toContainText('Kovar III');
 
-        // Full journal trail: rumbo -> dia -> llegada.
+        // Full journal trail: rumbo -> dia -> consumo -> llegada.
         await expect
             .poll(() => readOPFSFile(page, journalPath))
             .toMatch(/- \[\d{2}:\d{2}\] llegada: kovar_iii \| dia 4128/);
@@ -404,6 +465,101 @@ test.describe('World Mode - Travel & events', () => {
             /- \[\d{2}:\d{2}\] rumbo: kovar_iii \| 1 dias, llegada estimada dia 4128/
         );
         expect(journal).toMatch(/- \[\d{2}:\d{2}\] dia: 4127->4128/);
+        // The calendar tick journaled as a medidor entry (replay-safe trail).
+        expect(journal).toMatch(
+            /- \[\d{2}:\d{2}\] medidor: viveres 3->2 \| consumo de víveres/
+        );
+        await expect(
+            page.locator('[data-party-bar] [data-medidor="viveres"][data-valor="2"]')
+        ).toBeAttached();
+    });
+
+    test('travel dialog in viewer mode: plan previews, confirm disabled with hint', async ({ page }) => {
+        // NO session on purpose: previewing routes is legit, travelling records.
+        await page.locator('[data-entity-id="sistema_kessler"]').click();
+        await expect(page.locator('[data-entity-panel="sistema_kessler"]')).toBeVisible();
+        await page.locator('[data-travel-here]').click();
+
+        const dialog = page.locator('[data-travel-dialog]');
+        await expect(dialog).toBeVisible();
+        await expect(dialog.locator('[data-travel-total-dias="8"]')).toBeVisible();
+        await expect(dialog.locator('[data-travel-session-hint]')).toBeVisible();
+        await expect(dialog.locator('[data-travel-confirm]')).toBeDisabled();
+    });
+
+    test('insufficiency warning carries the schedule-derived depletion day', async ({ page }) => {
+        await startSession(page);
+
+        // Drop combustible to 1: the 8-day Kessler run needs ceil(7/4) = 2.
+        await page.locator('[data-quicklog="combustible"]').click();
+        await page.locator('[data-quicklog-pips="combustible"] [data-quicklog-pip="1"]').click();
+        await expect(
+            page.locator('[data-party-bar] [data-medidor="combustible"][data-valor="1"]')
+        ).toBeAttached();
+
+        await page.locator('[data-entity-id="sistema_kessler"]').click();
+        await page.locator('[data-travel-here]').click();
+        const dialog = page.locator('[data-travel-dialog]');
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByText('Combustible insuficiente')).toBeVisible();
+        // Fuel ticks on trip days 5 and 8 (sector leg-days 4 and 7): with 1
+        // in the tank the second tick cannot be covered -> depletion day 8.
+        await expect(dialog.locator('[data-travel-agotamiento-combustible="8"]')).toBeVisible();
+        // GM override stays available (destructive confirm).
+        await expect(dialog.locator('[data-travel-confirm]')).toBeEnabled();
+        await dialog.getByRole('button', { name: 'Cancelar' }).click();
+        await expect(dialog).toBeHidden();
+    });
+
+    test('descanso: quick-log button advances the calendar and ticks víveres', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        // +3 days from 4127 crosses 4128 (multiple of 4) -> exactly 1 ración.
+        await page.locator('[data-quicklog="descanso"]').click();
+        await page.locator('[data-quicklog-descanso-dias="3"]').click();
+
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] descanso: 3 dias/);
+        expect(await readOPFSFile(page, journalPath)).toMatch(
+            /- \[\d{2}:\d{2}\] medidor: viveres 3->2 \| consumo de víveres/
+        );
+        const bar = page.locator('[data-party-bar]');
+        await expect(bar.locator('[data-dia="4130"]')).toBeAttached();
+        await expect(bar.locator('[data-medidor="viveres"][data-valor="2"]')).toBeAttached();
+
+        // Custom amount: +2 from 4130 crosses 4132 -> a second ración.
+        await page.locator('[data-quicklog="descanso"]').click();
+        const custom = page.locator('[data-quicklog-descanso-custom]');
+        await custom.fill('2');
+        await custom.press('Enter');
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] descanso: 2 dias/);
+        await expect(bar.locator('[data-dia="4132"]')).toBeAttached();
+        await expect(bar.locator('[data-medidor="viveres"][data-valor="1"]')).toBeAttached();
+    });
+
+    test('a tick on an empty gauge journals the deficit nota, never medidor 0->0', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        // Empty the pantry, then rest across a ration day (4128).
+        await page.locator('[data-quicklog="viveres"]').click();
+        await page.locator('[data-quicklog-pips="viveres"] [data-quicklog-pip="0"]').click();
+        await expect(
+            page.locator('[data-party-bar] [data-medidor="viveres"][data-valor="0"]')
+        ).toBeAttached();
+
+        await page.locator('[data-quicklog="descanso"]').click();
+        await page.locator('[data-quicklog-descanso-dias="3"]').click();
+
+        // Complication hook: deficit nota + warning toast with the event action.
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] nota: Sin víveres desde el día 4130 — el grupo pasa hambre/);
+        expect(await readOPFSFile(page, journalPath)).not.toMatch(/medidor: viveres 0->0/);
+        await expect(page.getByText('el grupo pasa hambre', { exact: false }).first()).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Tirar evento' })).toBeVisible();
     });
 
     test('estancia event: draw, apply the ganancia efecto, resolve', async ({ page }) => {
@@ -479,11 +635,12 @@ test.describe('World Mode - Travel & events', () => {
     });
 
     test('RoutePreview shows at sector tier for a cross-system selection and hides on drill-in', async ({ page }) => {
-        // porto_verne -> sistema_kessler: 1 intra day + ceil(√45)=7 sector days.
+        // porto_verne -> sistema_kessler: 1 intra day + ceil(√45)=7 sector days;
+        // combustible = ceil(7/4) = 2 (per-day cadence on the sector leg).
         await page.locator('[data-entity-id="sistema_kessler"]').click();
         const preview = page.locator('[data-route-preview]');
         await expect(preview).toBeVisible();
-        await expect(preview).toContainText('8 días · −1 combustible');
+        await expect(preview).toContainText('8 días · −2 combustible');
 
         // System tier renders no routes layer -> the preview is gone.
         await page.locator('[data-entity-id="sistema_verne"]').dblclick();

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -915,3 +915,126 @@ test.describe('World Mode - Console hygiene', () => {
         expect(issues).toEqual([]);
     });
 });
+
+// ── Profile images · player-safe fullscreen · pista detail (M6) ─────────────
+//
+// Player-safety is the headline: the GM projects the fullscreen viewer to the
+// table, so [data-fullscreen-image] must contain the image and NOTHING ELSE
+// (no title, no filename, no chrome) — every test below asserts its trimmed
+// innerText is empty. The CON_ESTADO fixture carries mundo/imagenes/
+// (kovar_iii.svg, kael_voss.svg), a pnj at porto_verne, a porto_verne act
+// image (muelle_7.svg) and a pista with body + recompensa.
+
+test.describe('World Mode - Perfiles, imagen segura y detalle de pistas', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+    });
+
+    /** Asserts the fullscreen overlay shows the image and no other visible content. */
+    async function expectPlayerSafeFullscreen(page: import('@playwright/test').Page): Promise<void> {
+        const overlay = page.locator('[data-fullscreen-image]');
+        await expect(overlay).toBeVisible();
+        // NOTHING but the image may reach the projected screen.
+        expect((await overlay.innerText()).trim()).toBe('');
+        await expect(overlay.locator('img')).toHaveCount(1);
+        await expect(overlay.locator('button')).toHaveCount(0);
+    }
+
+    test('entity panel shows a profile thumbnail that opens the player-safe fullscreen', async ({ page }) => {
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await page.locator('[data-entity-id="kovar_iii"]').click();
+
+        const panel = page.locator('[data-entity-panel="kovar_iii"]');
+        await expect(panel).toBeVisible();
+        const thumb = panel.locator('[data-entity-image]');
+        await expect(thumb).toBeVisible();
+
+        await thumb.click();
+        await expectPlayerSafeFullscreen(page);
+        // Projecting: the document is flagged so GM toasts are CSS-suppressed
+        // (sonner renders above the overlay's z-index otherwise).
+        await expect(page.locator('html[data-projecting]')).toHaveCount(1);
+
+        // Closes on Escape and on a click on the overlay.
+        await page.keyboard.press('Escape');
+        await expect(page.locator('[data-fullscreen-image]')).toHaveCount(0);
+        await expect(page.locator('html[data-projecting]')).toHaveCount(0);
+        await thumb.click();
+        await page.locator('[data-fullscreen-image]').click();
+        await expect(page.locator('[data-fullscreen-image]')).toHaveCount(0);
+    });
+
+    test('place panel lists Personajes and opens a PnjCard dossier', async ({ page }) => {
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await page.locator('[data-entity-id="porto_verne"]').click();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+
+        // Kael Voss lives at porto_verne (ubicacion) -> Personajes link.
+        await page.locator('[data-pnj-link="kael_voss"]').click();
+        const card = page.locator('[data-pnj-card="kael_voss"]');
+        await expect(card).toBeVisible();
+        await expect(card).toContainText('quince anos en los muelles'); // dossier body
+
+        // His portrait opens the same player-safe fullscreen.
+        await card.locator('[data-entity-image]').click();
+        await expectPlayerSafeFullscreen(page);
+        await page.keyboard.press('Escape');
+
+        // Back returns to the place panel.
+        await card.locator('[data-pnj-back]').click();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+    });
+
+    test('ActRunner images display through the player-safe fullscreen (no filename leak)', async ({ page }) => {
+        await openPortoVerneRunner(page);
+
+        // The act carries muelle_7.svg -> its image tab renders the fullscreen viewer.
+        await page.getByRole('tab', { name: 'muelle_7.svg' }).click();
+        await expectPlayerSafeFullscreen(page);
+
+        // Escape returns to the act without leaking the filename onto the screen.
+        await page.keyboard.press('Escape');
+        await expect(page.locator('[data-fullscreen-image]')).toHaveCount(0);
+        await expect(page.locator('[data-act-runner]')).toBeVisible();
+    });
+
+    test('pista row opens a detail view with body + recompensa; transitions do not', async ({ page }) => {
+        // Session active so the transition journals a pista line.
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        const journalPath = `mundo/diario/${journalName}`;
+
+        await page.locator('[data-panel-tab="pistas"]').click();
+        const row = page.locator('[data-lead-id="deuda_kael_zara"]');
+        await expect(row).toBeVisible();
+
+        // A transition on the row must NOT open the detail (stopPropagation).
+        await row.locator('[data-lead-transition="en_curso"]').click();
+        await expect(page.locator('[data-lead-detail]')).toHaveCount(0);
+        await expect(row).toHaveAttribute('data-lead-estado', 'en_curso');
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] pista: deuda_kael_zara activa->en_curso/);
+
+        // Clicking the row body (data-lead-open is on the row itself) opens the
+        // detail with the previously-invisible body. Corner click avoids the
+        // interactive children (transition buttons / donde chip).
+        await row.click({ position: { x: 5, y: 5 } });
+        const detail = page.locator('[data-lead-detail="deuda_kael_zara"]');
+        await expect(detail).toBeVisible();
+        await expect(detail).toContainText('400 creditos'); // recompensa
+        await expect(detail).toContainText('paquete'); // body text
+        await expect(detail).toContainText('creditos>=800'); // requisito verbatim
+
+        // Back returns to the list.
+        await detail.locator('[data-lead-back]').click();
+        await expect(page.locator('[data-leads-panel]')).toBeVisible();
+        await expect(page.locator('[data-lead-detail]')).toHaveCount(0);
+    });
+});

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { MUNDO_CAMPAIGN, MUNDO_CAMPAIGN_CON_ESTADO } from './fixtures/mundoCampaign';
-import { materializeIntoOPFS, openWorldViaOPFS } from './helpers/opfs';
+import type { FileTree } from './fixtures/mundoCampaign';
+import { listOPFSDir, materializeIntoOPFS, openWorldViaOPFS, readOPFSFile } from './helpers/opfs';
 
 // World mode loads the mundoCampaign fixture through the OPFS seam
 // (see e2e/helpers/opfs.ts for the app-side contract these tests rely on).
@@ -198,5 +199,139 @@ test.describe('World Mode - Party readout', () => {
         await expect(page.locator('[data-tier="system"]')).toBeAttached();
         await expect(marker).toBeAttached();
         await expect(marker).not.toHaveAttribute('transform', 'translate(0 0)');
+    });
+});
+
+// ── M3: session recorder (write path via OPFS — no permission prompts) ──────
+//
+// NOTE (h): the permission-DENIED path cannot be exercised through OPFS —
+// its handles always report/grant readwrite without prompting, so there is no
+// way to make requestPermission return 'denied' from Playwright. That branch
+// is covered by unit tests instead: JournalWriter denied/retryNow/flush-reject
+// (lib/world/journalWriter.test.ts) and the failed-close + retryWrites cases
+// (lib/world/partyStore.test.ts).
+
+/** Body of estado/grupo.md (everything after the closing frontmatter fence). */
+function frontmatterBody(fileText: string): string {
+    return fileText.slice(fileText.indexOf('\n---\n', 3) + '\n---\n'.length);
+}
+
+test.describe('World Mode - Session recorder', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+    });
+
+    test('quick-log is disabled until a session starts', async ({ page }) => {
+        await expect(page.locator('[data-quicklog-bar]')).toBeVisible();
+        await expect(page.locator('[data-quicklog="creditos"]')).toBeDisabled();
+        await expect(page.locator('[data-quicklog="mover"]')).toBeDisabled();
+        await expect(page.locator('[data-session-start]')).toBeEnabled();
+    });
+
+    test('full recorder loop: start, quick-logs, mover, undo, end', async ({ page }) => {
+        // (a) Iniciar sesión -> diario file with sesion: 1 + inicio line.
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        expect(journalName).toMatch(/^\d{4}-\d{2}-\d{2}_s01\.md$/);
+        const journalPath = `mundo/diario/${journalName}`;
+
+        const initial = await readOPFSFile(page, journalPath);
+        expect(initial).toContain('tipo: diario');
+        expect(initial).toContain('sesion: 1');
+        expect(initial).toContain('dia_inicio: 4127');
+        expect(initial).toContain('dia_fin: null');
+        expect(initial).toContain('procesado: false');
+        expect(initial).toMatch(/- \[\d{2}:\d{2}\] inicio: dia 4127 @ porto_verne/);
+
+        // (b) gasto 100 via the créditos popover -> toast + journal line + bar.
+        await page.locator('[data-quicklog="creditos"]').click();
+        await page.locator('[data-quicklog-delta="-100"]').click();
+        await expect(page.getByText('-100 créditos anotados')).toBeVisible();
+        await expect(page.locator('[data-party-bar] [data-creditos="1140"]')).toBeVisible();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] gasto: 100/);
+
+        // (c) medidor combustible 2 -> 4 via the pips popover.
+        await page.locator('[data-quicklog="combustible"]').click();
+        await page
+            .locator('[data-quicklog-pips="combustible"] [data-quicklog-pip="4"]')
+            .click();
+        await expect(
+            page.locator('[data-party-bar] [data-medidor="combustible"][data-valor="4"]')
+        ).toBeAttached();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] medidor: combustible 2->4/);
+
+        // (d) nota via the "n" keyboard shortcut.
+        await page.keyboard.press('n');
+        const notaInput = page.locator('[data-quicklog-nota-input]');
+        await expect(notaInput).toBeFocused();
+        await notaInput.fill('los PJ preguntan por Kael');
+        await notaInput.press('Enter');
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] nota: los PJ preguntan por Kael/);
+
+        // (e) Mover to kovar_iii -> llegada line, marker moved, knowledge bump.
+        await page.locator('[data-quicklog="mover"]').click();
+        await page.locator('[data-mover-id="kovar_iii"]').click();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] llegada: kovar_iii \| dia 4127/);
+
+        const bar = page.locator('[data-party-bar]');
+        await expect(bar.getByRole('navigation', { name: 'Ubicación' })).toContainText('Kovar III');
+        // navigateToEntity landed on the system tier; the marker sits on
+        // kovar_iii's own node there, not on the star at (0,0).
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        const marker = page.locator('[data-party-marker]');
+        await expect(marker).toBeAttached();
+        await expect(marker).not.toHaveAttribute('transform', 'translate(0 0)');
+        await expect(page.locator('[data-entity-id="kovar_iii"]')).toHaveAttribute(
+            'data-knowledge',
+            'visitado'
+        );
+
+        // (f) Deshacer última: the llegada line leaves the file and the UI reverts.
+        await page.locator('[data-panel-tab="diario"]').click();
+        await page.locator('[data-journal-undo]').click();
+        await expect.poll(() => readOPFSFile(page, journalPath)).not.toMatch(/llegada: kovar_iii/);
+        await expect(bar.getByRole('navigation', { name: 'Ubicación' })).toContainText(
+            'Porto Verne'
+        );
+
+        // (g) Terminar sesión -> fin line + dia_fin + estado frontmatter updated
+        // with the agent-owned body preserved byte-for-byte.
+        await page.locator('[data-session-end]').click();
+        await page.locator('[data-session-end-confirm-button]').click();
+        await expect(page.locator('[data-session-start]')).toBeVisible();
+
+        const journalFinal = await readOPFSFile(page, journalPath);
+        expect(journalFinal).toMatch(/- \[\d{2}:\d{2}\] fin: dia 4127 @ porto_verne/);
+        expect(journalFinal).toContain('dia_fin: 4127');
+        expect(journalFinal).toContain('procesado: false');
+        expect(journalFinal).not.toContain('llegada: kovar_iii');
+
+        await expect
+            .poll(() => readOPFSFile(page, 'mundo/estado/grupo.md'))
+            .toContain('sesion_activa: false');
+        const estadoFinal = await readOPFSFile(page, 'mundo/estado/grupo.md');
+        expect(estadoFinal).toContain('tipo: estado_grupo');
+        expect(estadoFinal).toContain('creditos: 1140');
+        expect(estadoFinal).toContain('combustible: 4');
+        expect(estadoFinal).toContain('ubicacion: porto_verne');
+
+        const mundoFixture = MUNDO_CAMPAIGN_CON_ESTADO.mundo as FileTree;
+        const grupoFixture = (mundoFixture.estado as FileTree)['grupo.md'] as string;
+        expect(frontmatterBody(estadoFinal)).toBe(frontmatterBody(grupoFixture));
     });
 });

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -422,6 +422,19 @@ test.describe('World Mode - Travel & events', () => {
             .poll(() => readOPFSFile(page, journalPath))
             .toMatch(/- \[\d{2}:\d{2}\] ganancia: 200/);
 
+        // M5 hardening: the second efecto names a gauge that is NOT in
+        // manifest.medidores (oxigeno) — it must degrade to a nota entry +
+        // warning toast instead of journaling a medidor line for an
+        // invisible gauge.
+        await drawer.locator('[data-event-effect="1"]').click();
+        await expect(
+            page.getByText('Medidor desconocido «oxigeno» — anotado como nota')
+        ).toBeVisible();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] nota: Efecto no aplicado: medidor desconocido oxigeno/);
+        expect(await readOPFSFile(page, journalPath)).not.toMatch(/medidor: oxigeno/);
+
         // Resuelto closes the drawer and journals the evento line.
         await drawer.locator('[data-event-outcome="resuelto"]').click();
         await expect(drawer).toHaveAttribute('data-state', 'closed');
@@ -476,5 +489,192 @@ test.describe('World Mode - Travel & events', () => {
         await page.locator('[data-entity-id="sistema_verne"]').dblclick();
         await expect(page.locator('[data-tier="system"]')).toBeAttached();
         await expect(page.locator('[data-route-preview]')).toHaveCount(0);
+    });
+});
+
+// ── M5: ActRunner (scripted acts inside /world) ─────────────────────────────
+//
+// porto_verne is the fixture's playable place: lugares/porto_verne/ holds
+// plan/acto1_regreso.md in `:::` act format (flat plan file -> a single part
+// named "Part 1" by scanSessionFolder's legacy fallback).
+
+/** Selects porto_verne (system tier) and opens its ActRunner via Jugar. */
+async function openPortoVerneRunner(page: import('@playwright/test').Page): Promise<void> {
+    await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+    await page.locator('[data-entity-id="porto_verne"]').click();
+    await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+
+    await page.locator('[data-play-act]').click();
+    await expect(page.locator('[data-act-runner]')).toBeVisible();
+}
+
+test.describe('World Mode - ActRunner', () => {
+    test('Jugar opens the 3-panel act renderer and Cerrar returns to the cockpit', async ({ page }) => {
+        // No estado fixture on purpose: viewing prep without a session is legit.
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        // Header: place name + the part on the act selector.
+        await expect(runner).toContainText('Porto Verne');
+        await expect(runner.locator('[data-act-part="Part 1"]')).toBeVisible();
+
+        // Center column renders the fixture's :::leer read-aloud text...
+        await expect(
+            runner.getByText('Las luces del muelle se encienden en fila', { exact: false })
+        ).toBeVisible();
+        // ...the GM-notes rail carries the act-level :::gm reminder...
+        await expect(runner.getByText('Recordatorios del acto')).toBeVisible();
+        await expect(
+            runner.getByText('Acto de apertura del arco', { exact: false })
+        ).toBeVisible();
+        // ...and the actions rail shows the active section's :::accion card.
+        // (regex, not /^Acciones/: the rail header has a leading text node.)
+        await expect(runner.getByText(/Acciones · 1\. Reentrada/)).toBeVisible();
+        await expect(runner.getByText('Localizar a Kael Voss')).toBeVisible();
+
+        // Cerrar unmounts the overlay and the cockpit map is visible again.
+        await page.locator('[data-act-close]').click();
+        await expect(page.locator('[data-act-runner]')).toHaveCount(0);
+        await expect(page.locator('[data-entity-id="porto_verne"]')).toBeVisible();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+    });
+
+    test('with an active session the journal records the acto iniciado/cerrado notas', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        const journalPath = `mundo/diario/${journalName}`;
+
+        await openPortoVerneRunner(page);
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] nota: Acto iniciado: Part 1 @ Porto Verne/);
+
+        await page.locator('[data-act-close]').click();
+        await expect(page.locator('[data-act-runner]')).toHaveCount(0);
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] nota: Acto cerrado: Part 1 @ Porto Verne/);
+    });
+});
+
+// ── M5: UI persistence (sessionStorage slice, key world.ui.v1) ──────────────
+
+test.describe('World Mode - UI persistence', () => {
+    test('reload restores tier, selection, panel tab and map viewport', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        // Drill into sistema_verne, select porto_verne, switch to Pistas.
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await page.locator('[data-entity-id="porto_verne"]').click();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+        await page.locator('[data-panel-tab="pistas"]').click();
+        await expect(page.locator('[data-leads-panel]')).toBeVisible();
+
+        // Pan the map: StarMap commits the viewport once the gesture ends and
+        // the page remembers it under the tier key 'system:sistema_verne'.
+        const svg = page.locator('svg[aria-label="Mapa del sector"]');
+        const box = await svg.boundingBox();
+        if (!box) throw new Error('mapa no visible');
+        const startX = box.x + box.width / 2;
+        const startY = box.y + box.height - 60; // clear of nodes and overlays
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX + 140, startY + 25, { steps: 5 });
+        await page.mouse.up();
+        const transform = await svg.locator('> g').getAttribute('transform');
+        expect(transform).not.toBeNull();
+
+        // Reload: sessionStorage and OPFS survive; re-open through the hook.
+        await page.reload();
+        await openWorldViaOPFS(page);
+
+        // Tier + panel tab restored (?e= deep-link navigation is skipped when
+        // the persisted selection already matches — module doc "M5 polish").
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await expect(page.locator('[data-leads-panel]')).toBeVisible();
+        // The remembered per-tier viewport beats the fit-to-content compute.
+        await expect(svg.locator('> g')).toHaveAttribute('transform', transform!);
+        // The selection survived too.
+        await page.locator('[data-panel-tab="entidad"]').click();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+    });
+});
+
+// ── M5: console lock-in ─────────────────────────────────────────────────────
+//
+// The world happy path must not emit ANY console error or warning: partyStore
+// deliberately console.warns on misuse (log without session, double start...)
+// and React warns on real bugs (keys, act, hydration), so new noise here is a
+// regression. Either fix it or allowlist it BELOW with a justification.
+//
+// INSPECTED (M5, next dev + Chromium): the happy path currently emits ZERO
+// error/warning-level messages — only `[log] [HMR] connected` and the React
+// DevTools `[info]` ad, both below the filter. The entries here pre-allowlist
+// dev-server tooling chatter whose console channel has shifted between Next
+// versions; they are NOT app messages.
+const CONSOLE_ALLOWLIST: RegExp[] = [
+    // next dev (the e2e web server) Fast Refresh / HMR chatter.
+    /\[Fast Refresh\]/,
+    /\[HMR\]/,
+    // React DevTools advertisement — printed by React development builds.
+    /Download the React DevTools/,
+];
+
+test.describe('World Mode - Console hygiene', () => {
+    test('happy path emits no console errors or warnings', async ({ page }) => {
+        const issues: string[] = [];
+        page.on('console', (message) => {
+            const type = message.type();
+            if (type !== 'error' && type !== 'warning') return;
+            const text = message.text();
+            if (CONSOLE_ALLOWLIST.some((pattern) => pattern.test(text))) return;
+            issues.push(`[${type}] ${text}`);
+        });
+        page.on('pageerror', (error) => issues.push(`[pageerror] ${error.message}`));
+
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        // Session + a quick-log write reaching OPFS.
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await page.locator('[data-quicklog="creditos"]').click();
+        await page.locator('[data-quicklog-delta="100"]').click();
+        await expect(page.locator('[data-party-bar] [data-creditos="1340"]')).toBeVisible();
+
+        // Event draw + resolve.
+        await page.locator('[data-quicklog="evento"]').click();
+        const drawer = page.locator('[data-event-drawer]');
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+        await drawer.locator('[data-event-outcome="ignorado"]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'closed');
+
+        // ActRunner open + close (audio manager mount/unmount included).
+        await openPortoVerneRunner(page);
+        await page.locator('[data-act-close]').click();
+        await expect(page.locator('[data-act-runner]')).toHaveCount(0);
+
+        // End session (journal flush + forced estado write).
+        await page.locator('[data-session-end]').click();
+        await page.locator('[data-session-end-confirm-button]').click();
+        await expect(page.locator('[data-session-start]')).toBeVisible();
+
+        expect(issues).toEqual([]);
     });
 });

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { MUNDO_CAMPAIGN } from './fixtures/mundoCampaign';
+import { materializeIntoOPFS, openWorldViaOPFS } from './helpers/opfs';
+
+// World mode loads the mundoCampaign fixture through the OPFS seam
+// (see e2e/helpers/opfs.ts for the app-side contract these tests rely on).
+test.describe('World Mode - Sector Map', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+    });
+
+    test('renders the 3 systems and the deep-space node at sector tier', async ({ page }) => {
+        // sistema_verne, sistema_kessler, sistema_umbral + nodo_central (own coords).
+        // Plain lugares (kovar_iii, mercado_de_brasa, porto_verne) live inside
+        // systems and must NOT be sector-tier nodes.
+        await expect(page.locator('[data-entity-id]')).toHaveCount(4);
+        await expect(page.locator('[data-entity-id="sistema_verne"]')).toBeVisible();
+        await expect(page.locator('[data-entity-id="sistema_kessler"]')).toBeVisible();
+        // desconocido renders as a low-opacity ghost — assert presence, not visibility.
+        await expect(page.locator('[data-entity-id="sistema_umbral"]')).toBeAttached();
+        await expect(page.locator('[data-entity-id="nodo_central"]')).toBeAttached();
+    });
+
+    test('encodes conocimiento on each node via data-knowledge', async ({ page }) => {
+        await expect(page.locator('[data-entity-id="sistema_umbral"]')).toHaveAttribute(
+            'data-knowledge',
+            'desconocido'
+        );
+        await expect(page.locator('[data-entity-id="sistema_kessler"]')).toHaveAttribute(
+            'data-knowledge',
+            'rumoreado'
+        );
+        await expect(page.locator('[data-entity-id="sistema_verne"]')).toHaveAttribute(
+            'data-knowledge',
+            'visitado'
+        );
+    });
+
+    test('ghost toggle hides desconocido nodes', async ({ page }) => {
+        await expect(page.locator('[data-entity-id="sistema_umbral"]')).toBeAttached();
+
+        // Accessible name contains "desconocidos" (e.g. "Ocultar desconocidos").
+        await page.getByRole('button', { name: /desconocid/i }).click();
+
+        await expect(page.locator('[data-entity-id="sistema_umbral"]')).toBeHidden();
+        // The rest of the sector is unaffected.
+        await expect(page.locator('[data-entity-id="sistema_verne"]')).toBeVisible();
+        await expect(page.locator('[data-entity-id="sistema_kessler"]')).toBeVisible();
+        await expect(page.locator('[data-entity-id="nodo_central"]')).toBeAttached();
+    });
+
+    test('clicking a system opens the entity panel with name and conocimiento badge', async ({ page }) => {
+        await page.locator('[data-entity-id="sistema_verne"]').click();
+
+        const panel = page.locator('[data-entity-panel]');
+        await expect(panel).toBeVisible();
+        await expect(panel).toContainText('Sistema Verne');
+        await expect(panel.getByText(/visitado/i).first()).toBeVisible();
+    });
+
+    test('roto.md surfaces in the Diagnostico panel without breaking the load', async ({ page }) => {
+        // The world loaded degraded (beforeEach already reached "ready" with
+        // roto.md present), and the issue is surfaced to the GM.
+        const diagnostics = page.getByRole('button', { name: /diagn[oó]stico/i });
+        await expect(diagnostics).toBeVisible();
+        await diagnostics.click();
+        await expect(page.getByText(/roto\.md/).first()).toBeVisible();
+    });
+
+    test('scanner ignores PLANTILLAS/ and _-prefixed files', async ({ page }) => {
+        // No map nodes (or any entity-bound elements) for ignored files.
+        await expect(page.locator('[data-entity-id="_borrador"]')).toHaveCount(0);
+        await expect(page.locator('[data-entity-id="borrador"]')).toHaveCount(0);
+        await expect(page.locator('[data-entity-id="pista"]')).toHaveCount(0);
+
+        // Not even as diagnostics: if _borrador.md had been scanned it would
+        // show up as a "lugar without en:/coordenadas" error alongside roto.md.
+        await page.getByRole('button', { name: /diagn[oó]stico/i }).click();
+        await expect(page.getByText(/roto\.md/).first()).toBeVisible();
+        await expect(page.getByText(/_borrador/)).toHaveCount(0);
+        await expect(page.getByText(/PLANTILLAS/)).toHaveCount(0);
+    });
+});

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1297,6 +1297,58 @@ test.describe('World Mode - ActRunner', () => {
         await expect(gmSectionNote).toBeVisible();
     });
 
+    // ── Reto tracker — skill-challenge success/fail counter on a :::accion ──
+    //
+    // acto1_regreso.md's "Localizar a Kael Voss" accion carries
+    // `reto: 4 exitos / 3 fallos`, so its ActionCard renders a tappable tracker.
+    test('reto tracker: taps count successes to SUPERADO and no tracker without reto', async ({
+        page,
+    }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        await openPortoVerneRunner(page);
+        const runner = page.locator('[data-act-runner]');
+
+        // The Kael accion (section 1) is visible by default with its tracker.
+        const tracker = runner.locator('[data-reto-tracker]');
+        await expect(tracker).toBeVisible();
+        // 4 success pips + 3 fail pips + the "0/4 · 0/3" readout.
+        await expect(tracker.locator('[data-reto-exito]')).toHaveCount(4);
+        await expect(tracker.locator('[data-reto-fallo]')).toHaveCount(3);
+        const readout = tracker.locator('[data-reto-readout]');
+        await expect(readout).toContainText('éxitos 0/4');
+        await expect(readout).toContainText('fallos 0/3');
+        await expect(readout).not.toContainText('SUPERADO');
+
+        // Tap the 4th success pip -> 4/4 and SUPERADO shows.
+        await tracker.locator('[data-reto-exito="4"]').click();
+        await expect(readout).toContainText('éxitos 4/4');
+        await expect(readout).toContainText('SUPERADO');
+
+        // Tap the 2nd fail pip -> fallos 2/3 (below the 3 threshold, no FALLADO).
+        await tracker.locator('[data-reto-fallo="2"]').click();
+        await expect(readout).toContainText('fallos 2/3');
+        await expect(readout).not.toContainText('FALLADO');
+        // Tap the 3rd fail pip -> 3/3 FALLADO.
+        await tracker.locator('[data-reto-fallo="3"]').click();
+        await expect(readout).toContainText('fallos 3/3');
+        await expect(readout).toContainText('FALLADO');
+
+        // Unfill: tapping the current-topmost success pip (4th) drops to 3/4.
+        await tracker.locator('[data-reto-exito="4"]').click();
+        await expect(readout).toContainText('éxitos 3/4');
+        await expect(readout).not.toContainText('SUPERADO');
+
+        // The reto tracker is GM bookkeeping: Vista jugador hides it (it lives in
+        // the accion right-rail the toggle removes).
+        const toggle = runner.locator('[data-player-view]');
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(runner.locator('[data-reto-tracker]')).toHaveCount(0);
+    });
+
     test('a node place whose first act is acto2 auto-selects it (no phantom acto1)', async ({
         page,
     }) => {

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { MUNDO_CAMPAIGN } from './fixtures/mundoCampaign';
+import { MUNDO_CAMPAIGN, MUNDO_CAMPAIGN_CON_ESTADO } from './fixtures/mundoCampaign';
 import { materializeIntoOPFS, openWorldViaOPFS } from './helpers/opfs';
 
 // World mode loads the mundoCampaign fixture through the OPFS seam
@@ -81,5 +81,122 @@ test.describe('World Mode - Sector Map', () => {
         await expect(page.getByText(/roto\.md/).first()).toBeVisible();
         await expect(page.getByText(/_borrador/)).toHaveCount(0);
         await expect(page.getByText(/PLANTILLAS/)).toHaveCount(0);
+    });
+});
+
+// ── M2: drill-in / tiers / breadcrumb ───────────────────────────────────────
+
+test.describe('World Mode - Drill-in & tiers', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+    });
+
+    test('double-clicking a sistema drills into the system tier', async ({ page }) => {
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        // Children of sistema_verne render as system-tier nodes...
+        await expect(page.locator('[data-entity-id="kovar_iii"]')).toBeAttached();
+        await expect(page.locator('[data-entity-id="porto_verne"]')).toBeAttached();
+        // ...and sector-only nodes are gone.
+        await expect(page.locator('[data-entity-id="sistema_kessler"]')).toHaveCount(0);
+        await expect(page.locator('[data-entity-id="nodo_central"]')).toHaveCount(0);
+    });
+
+    test('breadcrumb pops back from system to sector', async ({ page }) => {
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+
+        // The sector crumb becomes a button once drilled in.
+        await page.getByRole('button', { name: 'Sector Eloran' }).click();
+
+        await expect(page.locator('[data-tier="system"]')).toHaveCount(0);
+        await expect(page.locator('[data-entity-id]')).toHaveCount(4);
+        await expect(page.locator('[data-entity-id="sistema_kessler"]')).toBeVisible();
+    });
+
+    test('party bar shows the absent-estado hint (fixture has empty estado/)', async ({ page }) => {
+        const bar = page.locator('[data-party-bar]');
+        await expect(bar).toBeVisible();
+        await expect(bar).toContainText('no hay datos del grupo');
+    });
+});
+
+// ── M2: search + deep link ──────────────────────────────────────────────────
+
+test.describe('World Mode - Search & deep link', () => {
+    test('Ctrl+K search finds Porto Verne and Enter navigates to it', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        await page.keyboard.press('ControlOrMeta+k');
+        const input = page.getByPlaceholder('Buscar en el mundo…');
+        await expect(input).toBeVisible();
+        await input.fill('Porto');
+
+        await expect(page.locator('[data-search-result-id="porto_verne"]')).toBeVisible();
+        await input.press('Enter');
+
+        // Selected + navigated to the system tier + deep link written.
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+        await expect(page.locator('[data-entity-panel]')).toContainText('Porto Verne');
+        await expect(page).toHaveURL(/[?&]e=porto_verne/);
+    });
+
+    test('deep link ?e=porto_verne lands selected at the system tier', async ({ page }) => {
+        await page.goto('/world?e=porto_verne');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN);
+        await openWorldViaOPFS(page);
+
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+        await expect(page).toHaveURL(/[?&]e=porto_verne/);
+    });
+});
+
+// ── M2: party readout (estado/grupo.md variant) ─────────────────────────────
+
+test.describe('World Mode - Party readout', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+    });
+
+    test('party bar renders fecha, creditos, gauges and the location breadcrumb', async ({ page }) => {
+        const bar = page.locator('[data-party-bar]');
+        await expect(bar).toBeVisible();
+
+        // Fecha from dia_mundo 4127 under the 4x30 fixture calendar.
+        await expect(bar).toContainText('17 de Cenit, 356 dG');
+        await expect(bar.locator('[data-dia="4127"]')).toBeAttached();
+
+        await expect(bar.locator('[data-creditos="1240"]')).toBeVisible();
+
+        await expect(bar.locator('[data-medidor="viveres"][data-valor="3"]')).toBeAttached();
+        await expect(bar.locator('[data-medidor="combustible"][data-valor="2"]')).toBeAttached();
+        await expect(bar.locator('[data-medidor="nave"][data-valor="2"]')).toBeAttached();
+
+        const breadcrumb = bar.getByRole('navigation', { name: 'Ubicación' });
+        await expect(breadcrumb).toContainText('Sistema Verne');
+        await expect(breadcrumb).toContainText('Porto Verne');
+    });
+
+    test('party marker rolls up to the sistema at sector tier and to the place at system tier', async ({ page }) => {
+        const marker = page.locator('[data-party-marker]');
+
+        // Sector tier: ubicacion porto_verne rolls up to sistema_verne (coords 0,0).
+        await expect(marker).toBeAttached();
+        await expect(marker).toHaveAttribute('transform', 'translate(0 0)');
+
+        // System tier: the marker sits on porto_verne's own node (not the star).
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await expect(marker).toBeAttached();
+        await expect(marker).not.toHaveAttribute('transform', 'translate(0 0)');
     });
 });

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -839,6 +839,120 @@ test.describe('World Mode - Eventos en curso & combate', () => {
     });
 });
 
+// ── Feature: shop system (lugares/porto_verne/tiendas/muelles.md) ───────────
+//
+// The CON_ESTADO fixture adds a shop under porto_verne: "Suministros del Muelle
+// 7", pnj kael_voss, items "Célula de combustible" (120 cr, stock 1) and
+// "Raciones de campo" (40 cr, unlimited). The party starts with 1240 cr.
+
+test.describe('World Mode - Tiendas', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+    });
+
+    /** Starts a session; returns the diario path (single file, sesion 1). */
+    async function startSession(page: import('@playwright/test').Page): Promise<string> {
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        return `mundo/diario/${journalName}`;
+    }
+
+    /** Drills into sistema_verne and selects porto_verne (its EntityPanel). */
+    async function openPortoVernePanel(page: import('@playwright/test').Page): Promise<void> {
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await page.locator('[data-entity-id="porto_verne"]').click();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+    }
+
+    test('open a shop from the Tiendas section and buy an item', async ({ page }) => {
+        const journalPath = await startSession(page);
+        await openPortoVernePanel(page);
+
+        // The Tiendas section lists the shop; clicking the row opens the ShopPanel.
+        const shopLink = page.locator('[data-shop-link="muelles"]');
+        await expect(shopLink).toBeVisible();
+        await shopLink.click();
+        const shop = page.locator('[data-shop-panel="muelles"]');
+        await expect(shop).toBeVisible();
+        await expect(shop).toContainText('Suministros del Muelle 7');
+        await expect(shop).toContainText('Kael Voss'); // shopkeeper chip
+
+        // Buy the unlimited item: creditos drop by 40 (1240 -> 1200).
+        await shop.locator('[data-shop-buy="Raciones de campo"]').click();
+        await expect(page.locator('[data-party-bar] [data-creditos="1200"]')).toBeVisible();
+
+        // Journal carries the gasto with the compra comentario.
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] gasto: 40 \| compra: Raciones de campo/);
+    });
+
+    test('a stock-1 item blocks the second purchase', async ({ page }) => {
+        await startSession(page);
+        await openPortoVernePanel(page);
+        await page.locator('[data-shop-link="muelles"]').click();
+        const shop = page.locator('[data-shop-panel="muelles"]');
+        await expect(shop).toBeVisible();
+
+        const buyCell = shop.locator('[data-shop-buy="Célula de combustible"]');
+        // First buy succeeds: creditos 1240 -> 1120, stock 1 -> 0.
+        await buyCell.click();
+        await expect(page.locator('[data-party-bar] [data-creditos="1120"]')).toBeVisible();
+
+        // Now agotado: the Comprar button is disabled, a second buy does nothing.
+        await expect(buyCell).toBeDisabled();
+        await expect(page.locator('[data-party-bar] [data-creditos="1120"]')).toBeVisible();
+    });
+
+    test('without a session the Comprar buttons are disabled with a hint', async ({ page }) => {
+        // No session started.
+        await openPortoVernePanel(page);
+        await page.locator('[data-shop-link="muelles"]').click();
+        const shop = page.locator('[data-shop-panel="muelles"]');
+        await expect(shop).toBeVisible();
+        await expect(shop.locator('[data-shop-buy="Raciones de campo"]')).toBeDisabled();
+
+        // Back returns to the place panel.
+        await shop.locator('[data-shop-back]').click();
+        await expect(page.locator('[data-entity-panel="porto_verne"]')).toBeVisible();
+    });
+});
+
+// ── Feature: in-app resumen (mundo/resumen.md) ──────────────────────────────
+
+test.describe('World Mode - Resumen', () => {
+    test('the Resumen button opens the recap dialog (CON_ESTADO has resumen.md)', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        const button = page.locator('[data-resumen-open]');
+        await expect(button).toBeVisible();
+        await button.click();
+
+        const dialog = page.locator('[data-resumen-dialog]');
+        await expect(dialog).toBeVisible();
+        await expect(dialog).toContainText('Anteriormente');
+        await expect(dialog).toContainText('bodega medio vacía');
+    });
+
+    test('a world without resumen.md shows no Resumen button (base fixture)', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN); // no resumen.md
+        await openWorldViaOPFS(page);
+
+        await expect(page.locator('[data-world-status="ready"]')).toBeAttached();
+        await expect(page.locator('[data-resumen-open]')).toHaveCount(0);
+    });
+});
+
 // ── M5: ActRunner (scripted acts inside /world) ─────────────────────────────
 //
 // porto_verne is the fixture's playable place: lugares/porto_verne/ holds
@@ -929,14 +1043,14 @@ test.describe('World Mode - Música del mundo', () => {
         await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_MUSICA);
         await openWorldViaOPFS(page);
 
-        // Closed by default: just the toggle button above the QuickLogBar.
-        const toggle = page.locator('[data-world-audio="toggle"]');
+        // Feature 3: the toggle is the QuickLogBar «Música» button now (the old
+        // floating dock toggle was removed). Closed by default, no panel yet.
+        const toggle = page.locator('[data-quicklog="musica"]');
         await expect(toggle).toBeVisible();
-        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
         await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
 
         await toggle.click();
-        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
         const panel = page.locator('[data-world-audio="panel"]');
         await expect(panel).toBeVisible();
 
@@ -954,7 +1068,7 @@ test.describe('World Mode - Música del mundo', () => {
         // Toggle back off: panel gone, button released.
         await toggle.click();
         await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
-        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+        await expect(toggle).not.toHaveAttribute('aria-expanded', 'true');
     });
 
     test('a world without mundo/musica/ still shows the dock, opening to an empty state', async ({ page }) => {
@@ -964,16 +1078,15 @@ test.describe('World Mode - Música del mundo', () => {
 
         await expect(page.locator('[data-world-status="ready"]')).toBeAttached();
 
-        // The toggle is ALWAYS present now (an empty folder must not read as a
-        // broken cockpit) — closed by default, no panel yet.
-        const toggle = page.locator('[data-world-audio="toggle"]');
+        // The QuickLogBar «Música» button is ALWAYS present (an empty folder
+        // must not read as a broken cockpit) — closed by default, no panel yet.
+        const toggle = page.locator('[data-quicklog="musica"]');
         await expect(toggle).toBeVisible();
-        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
         await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
 
         // Open it: the empty-state panel with the "Sin música cargada" hint.
         await toggle.click();
-        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
         const panel = page.locator('[data-world-audio="panel"]');
         await expect(panel).toBeVisible();
         await expect(page.locator('[data-world-audio="panel"][data-world-audio-empty]')).toBeVisible();
@@ -992,22 +1105,23 @@ test.describe('World Mode - Música del mundo', () => {
         await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_MUSICA);
         await openWorldViaOPFS(page);
 
-        // Leave the dock OPEN so the round-trip proves state survival.
-        const toggle = page.locator('[data-world-audio="toggle"]');
+        // Leave the dock OPEN so the round-trip proves state survival. The
+        // toggle is the QuickLogBar «Música» button now (feature 3).
+        const toggle = page.locator('[data-quicklog="musica"]');
         await toggle.click();
         await expect(page.locator('[data-world-audio="panel"]')).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
         // Runner open: the world dock is concealed (still mounted, hidden) —
         // the act music owns the room per the handoff contract.
         await openPortoVerneRunner(page);
-        await expect(toggle).toBeHidden();
         await expect(page.locator('[data-world-audio="panel"]')).toBeHidden();
 
-        // Runner closed: dock back, still open (aria-pressed survived).
+        // Runner closed: dock back, still open (page-owned musicaOpen survived).
         await page.locator('[data-act-close]').click();
         await expect(page.locator('[data-act-runner]')).toHaveCount(0);
         await expect(toggle).toBeVisible();
-        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
         await expect(page.locator('[data-world-audio="panel"]')).toBeVisible();
     });
 });

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1242,6 +1242,39 @@ test.describe('World Mode - ActRunner', () => {
             .toMatch(/- \[\d{2}:\d{2}\] nota: Acto cerrado: Part 1 @ Porto Verne/);
     });
 
+    test('the party strip surfaces créditos + gauges in-act, adjustments journal, and Tienda opens the shop', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        const journalPath = `mundo/diario/${journalName}`;
+
+        await openPortoVerneRunner(page);
+
+        // The cockpit essentials now live INSIDE the fullscreen act (the overlay
+        // hides the PartyStatusBar/QuickLogBar): read-out is always visible.
+        const strip = page.locator('[data-act-party-strip]');
+        await expect(strip).toBeVisible();
+        await expect(strip.locator('[data-strip-creditos-value]')).toBeVisible();
+        const nave = strip.locator('[data-strip-medidor="nave"]');
+        await expect(nave).toHaveAttribute('data-valor', '2');
+
+        // Repair the hull (nave 2 -> 5) from within the act -> journals a medidor.
+        await nave.click();
+        await page.locator('[data-strip-pip="5"]').click();
+        await expect(nave).toHaveAttribute('data-valor', '5');
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] medidor: nave 2->5/);
+
+        // The Tienda button opens the place's shop without leaving the scene.
+        await page.locator('[data-strip-tienda]').click();
+        await expect(page.locator('[data-act-shop-dialog]')).toBeVisible();
+    });
+
     test('Vista jugador hides the GM answer-key rails, then restores them', async ({ page }) => {
         // CON_ESTADO adds an image to porto_verne, so we can assert the player-safe
         // media survives the toggle while the GM rails vanish.

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { MUNDO_CAMPAIGN, MUNDO_CAMPAIGN_CON_ESTADO } from './fixtures/mundoCampaign';
+import {
+    MUNDO_CAMPAIGN,
+    MUNDO_CAMPAIGN_CON_ESTADO,
+    MUNDO_CAMPAIGN_CON_MUSICA,
+} from './fixtures/mundoCampaign';
 import type { FileTree } from './fixtures/mundoCampaign';
 import { listOPFSDir, materializeIntoOPFS, openWorldViaOPFS, readOPFSFile } from './helpers/opfs';
 
@@ -723,6 +727,82 @@ test.describe('World Mode - ActRunner', () => {
         await expect
             .poll(() => readOPFSFile(page, journalPath))
             .toMatch(/- \[\d{2}:\d{2}\] nota: Acto cerrado: Part 1 @ Porto Verne/);
+    });
+});
+
+// ── World-level music (mundo/musica/ -> bottom-left audio dock) ─────────────
+//
+// The dock lists tracks and toggles open/closed; NOTHING here presses play —
+// Playwright cannot verify sound and the fixture "mp3"s are fake bytes that
+// would only error on decode. All assertions ride on data attributes /
+// aria-pressed (the ActRunner-handoff contract in app/world/page.tsx).
+
+test.describe('World Mode - Música del mundo', () => {
+    test('the dock lists the BGM rotation and the event playlist', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_MUSICA);
+        await openWorldViaOPFS(page);
+
+        // Closed by default: just the toggle button above the QuickLogBar.
+        const toggle = page.locator('[data-world-audio="toggle"]');
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+        await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
+
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        const panel = page.locator('[data-world-audio="panel"]');
+        await expect(panel).toBeVisible();
+
+        // 2 root mp3s -> BGM rotation; 1 subfolder -> 1 playlist; the
+        // _instrucciones.md prompt doc counts for neither.
+        await expect(panel.locator('[data-world-audio-bgm-count="2"]')).toBeVisible();
+        await expect(panel.locator('[data-world-audio-playlist-count="1"]')).toBeVisible();
+        await expect(panel).toContainText('2 pistas · 1 lista');
+
+        // The reused AudioControls renders the playlist selector: the BGM
+        // entry plus the eventos_generales subfolder under its display name.
+        await expect(panel.getByRole('button', { name: 'Background Music' })).toBeVisible();
+        await expect(panel.getByRole('button', { name: 'Eventos Generales' })).toBeVisible();
+
+        // Toggle back off: panel gone, button released.
+        await toggle.click();
+        await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
+        await expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    test('a world without mundo/musica/ renders no dock at all', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN); // no musica/ folder
+        await openWorldViaOPFS(page);
+
+        await expect(page.locator('[data-world-status="ready"]')).toBeAttached();
+        await expect(page.locator('[data-world-audio="toggle"]')).toHaveCount(0);
+        await expect(page.locator('[data-world-audio="panel"]')).toHaveCount(0);
+    });
+
+    test('the ActRunner conceals the dock and closing restores it with its state', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_MUSICA);
+        await openWorldViaOPFS(page);
+
+        // Leave the dock OPEN so the round-trip proves state survival.
+        const toggle = page.locator('[data-world-audio="toggle"]');
+        await toggle.click();
+        await expect(page.locator('[data-world-audio="panel"]')).toBeVisible();
+
+        // Runner open: the world dock is concealed (still mounted, hidden) —
+        // the act music owns the room per the handoff contract.
+        await openPortoVerneRunner(page);
+        await expect(toggle).toBeHidden();
+        await expect(page.locator('[data-world-audio="panel"]')).toBeHidden();
+
+        // Runner closed: dock back, still open (aria-pressed survived).
+        await page.locator('[data-act-close]').click();
+        await expect(page.locator('[data-act-runner]')).toHaveCount(0);
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.locator('[data-world-audio="panel"]')).toBeVisible();
     });
 });
 

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1419,6 +1419,34 @@ test.describe('World Mode - Perfiles, imagen segura y detalle de pistas', () => 
         await expect(page.locator('[data-act-runner]')).toBeVisible();
     });
 
+    test('ActRunner surfaces maps/ battlemaps in the pan/zoom/grid viewer', async ({ page }) => {
+        await openPortoVerneRunner(page);
+
+        // maps/muelle_7_battlemap.png -> a battlemap tab (labelled, not the raw
+        // filename with extension). Opening it renders the BattlemapViewer, NOT
+        // the plain FullscreenImage.
+        const tab = page.getByRole('tab', { name: /muelle 7 battlemap/i });
+        await expect(tab).toBeVisible();
+        await tab.click();
+
+        const viewer = page.locator('[data-battlemap-viewer]');
+        await expect(viewer).toBeVisible();
+        await expect(page.locator('[data-fullscreen-image]')).toHaveCount(0);
+        // Player-safety: projecting flag set like the fullscreen viewer.
+        await expect(page.locator('html[data-projecting]')).toHaveCount(1);
+
+        // Grid starts off; the toggle turns the overlay on.
+        await expect(page.locator('[data-battlemap-grid]')).toHaveCount(0);
+        await page.locator('[data-battlemap-grid-toggle]').click();
+        await expect(page.locator('[data-battlemap-grid]')).toBeVisible();
+
+        // Close returns to the act.
+        await page.locator('[data-battlemap-close]').click();
+        await expect(page.locator('[data-battlemap-viewer]')).toHaveCount(0);
+        await expect(page.locator('html[data-projecting]')).toHaveCount(0);
+        await expect(page.locator('[data-act-runner]')).toBeVisible();
+    });
+
     test('pista row opens a detail view with body + recompensa; transitions do not', async ({ page }) => {
         // Session active so the transition journals a pista line.
         await page.locator('[data-session-start]').click();

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -1052,6 +1052,43 @@ test.describe('World Mode - Resumen', () => {
     });
 });
 
+// ── Feature: in-app Guías (curated GM play-aid sheets at mundo/ root) ────────
+
+test.describe('World Mode - Guías', () => {
+    test('the Guías menu lists the sheets and picking one opens its dialog', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO); // has _RUN_OF_SHOW + _MAPA_DE_HILOS
+        await openWorldViaOPFS(page);
+
+        const trigger = page.locator('[data-guias-menu]');
+        await expect(trigger).toBeVisible();
+        await trigger.click();
+
+        // Both allowlisted guías appear: first-heading title for RUN_OF_SHOW,
+        // fallback mapping titulo for MAPA_DE_HILOS (no heading in its file).
+        const runItem = page.locator('[data-guia-item="_RUN_OF_SHOW"]');
+        const mapItem = page.locator('[data-guia-item="_MAPA_DE_HILOS"]');
+        await expect(runItem).toHaveText('Guion de la sesión');
+        await expect(mapItem).toHaveText('Mapa de Hilos');
+
+        // Picking one opens the read-only dialog rendering its markdown.
+        await runItem.click();
+        const dialog = page.locator('[data-guia-dialog]');
+        await expect(dialog).toBeVisible();
+        await expect(dialog).toContainText('Guion de la sesión');
+        await expect(dialog).toContainText('El favor de Kael Voss');
+    });
+
+    test('a world without guía files shows no Guías menu (base fixture)', async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN); // no guía files
+        await openWorldViaOPFS(page);
+
+        await expect(page.locator('[data-world-status="ready"]')).toBeAttached();
+        await expect(page.locator('[data-guias-menu]')).toHaveCount(0);
+    });
+});
+
 // ── M5: ActRunner (scripted acts inside /world) ─────────────────────────────
 //
 // porto_verne is the fixture's playable place: lugares/porto_verne/ holds

--- a/e2e/world.spec.ts
+++ b/e2e/world.spec.ts
@@ -335,3 +335,146 @@ test.describe('World Mode - Session recorder', () => {
         expect(frontmatterBody(estadoFinal)).toBe(frontmatterBody(grupoFixture));
     });
 });
+
+// ── M4: travel + events ─────────────────────────────────────────────────────
+
+test.describe('World Mode - Travel & events', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/world');
+        await materializeIntoOPFS(page, MUNDO_CAMPAIGN_CON_ESTADO);
+        await openWorldViaOPFS(page);
+    });
+
+    /** Starts a session and returns the diario path (single file, sesion 1). */
+    async function startSession(page: import('@playwright/test').Page): Promise<string> {
+        await page.locator('[data-session-start]').click();
+        await expect(page.locator('[data-session-end]')).toBeVisible();
+        await expect
+            .poll(async () => (await listOPFSDir(page, 'mundo/diario')).length)
+            .toBe(1);
+        const [journalName] = await listOPFSDir(page, 'mundo/diario');
+        return `mundo/diario/${journalName}`;
+    }
+
+    test('travel flow: Viajar aquí -> dialog -> stepper -> arrival with journal trail', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        // Select kovar_iii at the system tier (party is at porto_verne).
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await page.locator('[data-entity-id="kovar_iii"]').click();
+        await expect(page.locator('[data-entity-panel="kovar_iii"]')).toBeVisible();
+
+        await page.locator('[data-travel-here]').click();
+        const dialog = page.locator('[data-travel-dialog]');
+        await expect(dialog).toBeVisible();
+        // Intra-system hop: 1 flat day, no consumption (pips stay 2 -> 2).
+        await expect(dialog.locator('[data-travel-total-dias="1"]')).toBeVisible();
+        await expect(
+            dialog.locator('[data-travel-medidor="combustible"][data-antes="2"][data-despues="2"]')
+        ).toBeAttached();
+
+        await page.locator('[data-travel-confirm]').click();
+        const stepper = page.locator('[data-travel-stepper]');
+        await expect(stepper).toBeVisible();
+        await expect(stepper).toHaveAttribute('data-dia', '1');
+        await expect(stepper).toHaveAttribute('data-total-dias', '1');
+
+        // Undo is blocked mid-travel (the stepper's day counter lives outside
+        // the journal, so a replay-undo could not revert it)…
+        await page.locator('[data-panel-tab="diario"]').click();
+        await expect(page.locator('[data-journal-undo]')).toBeDisabled();
+
+        // Continuar on the last day = arrival: stepper gone, breadcrumb moved.
+        await page.locator('[data-travel-next]').click();
+        await expect(page.locator('[data-travel-stepper]')).toHaveCount(0);
+        // …and re-enables once the trip resolves (arrival re-selects the
+        // destination entity, which flips the panel back to Entidad).
+        await page.locator('[data-panel-tab="diario"]').click();
+        await expect(page.locator('[data-journal-undo]')).toBeEnabled();
+        await expect(
+            page.locator('[data-party-bar]').getByRole('navigation', { name: 'Ubicación' })
+        ).toContainText('Kovar III');
+
+        // Full journal trail: rumbo -> dia -> llegada.
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] llegada: kovar_iii \| dia 4128/);
+        const journal = await readOPFSFile(page, journalPath);
+        expect(journal).toMatch(
+            /- \[\d{2}:\d{2}\] rumbo: kovar_iii \| 1 dias, llegada estimada dia 4128/
+        );
+        expect(journal).toMatch(/- \[\d{2}:\d{2}\] dia: 4127->4128/);
+    });
+
+    test('estancia event: draw, apply the ganancia efecto, resolve', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        await page.locator('[data-quicklog="evento"]').click();
+        const drawer = page.locator('[data-event-drawer]');
+        await expect(drawer).toHaveAttribute('data-state', 'open');
+        // The only estancia table in region nucleo has a single si-free event.
+        await expect(drawer).toContainText('Encargo de descarga');
+
+        // One-tap ganancia efecto -> party bar + journal line.
+        await drawer.locator('[data-event-effect="0"]').click();
+        await expect(page.locator('[data-party-bar] [data-creditos="1440"]')).toBeVisible();
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] ganancia: 200/);
+
+        // Resuelto closes the drawer and journals the evento line.
+        await drawer.locator('[data-event-outcome="resuelto"]').click();
+        await expect(drawer).toHaveAttribute('data-state', 'closed');
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] evento: estancia_porto#e01 \| resuelto/);
+    });
+
+    test('LeadsBoard: accionable star, transition, live re-derivation on gasto', async ({ page }) => {
+        const journalPath = await startSession(page);
+
+        // Default tab = Accionables; deuda_kael_zara (creditos>=800 vs 1240) stars.
+        await page.locator('[data-panel-tab="pistas"]').click();
+        const row = page.locator('[data-lead-id="deuda_kael_zara"]');
+        await expect(row).toBeVisible();
+        await expect(row.getByLabel('Accionable')).toBeVisible();
+
+        // One-tap transition activa -> en_curso is journaled.
+        await row.locator('[data-lead-transition="en_curso"]').click();
+        await expect(page.locator('[data-lead-id="deuda_kael_zara"]')).toHaveAttribute(
+            'data-lead-estado',
+            'en_curso'
+        );
+        await expect
+            .poll(() => readOPFSFile(page, journalPath))
+            .toMatch(/- \[\d{2}:\d{2}\] pista: deuda_kael_zara activa->en_curso/);
+
+        // Dropping below 800 credits re-derives: the lead leaves Accionables...
+        await page.locator('[data-quicklog="creditos"]').click();
+        const custom = page.locator('[data-quicklog-creditos-custom]');
+        await custom.fill('-700');
+        await custom.press('Enter');
+        await expect(page.locator('[data-party-bar] [data-creditos="540"]')).toBeVisible();
+        await expect(page.locator('[data-lead-id="deuda_kael_zara"]')).toHaveCount(0);
+
+        // ...and shows starless under Activas.
+        await page.locator('[data-leads-tab="activas"]').click();
+        await expect(page.locator('[data-lead-id="deuda_kael_zara"]')).toBeVisible();
+        await expect(
+            page.locator('[data-lead-id="deuda_kael_zara"]').getByLabel('Accionable')
+        ).toHaveCount(0);
+    });
+
+    test('RoutePreview shows at sector tier for a cross-system selection and hides on drill-in', async ({ page }) => {
+        // porto_verne -> sistema_kessler: 1 intra day + ceil(√45)=7 sector days.
+        await page.locator('[data-entity-id="sistema_kessler"]').click();
+        const preview = page.locator('[data-route-preview]');
+        await expect(preview).toBeVisible();
+        await expect(preview).toContainText('8 días · −1 combustible');
+
+        // System tier renders no routes layer -> the preview is gone.
+        await page.locator('[data-entity-id="sistema_verne"]').dblclick();
+        await expect(page.locator('[data-tier="system"]')).toBeAttached();
+        await expect(page.locator('[data-route-preview]')).toHaveCount(0);
+    });
+});

--- a/lib/actFormat.test.ts
+++ b/lib/actFormat.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 import { test, expect, describe } from 'bun:test';
-import { isActFormat, parseAct, visibleBlocks, sectionBlocks, ActSection } from './actFormat';
+import { isActFormat, parseAct, parseReto, visibleBlocks, sectionBlocks, ActSection } from './actFormat';
 
 const SAMPLE = `# ACTO TEST
 ## Sesión 7 — Relanzamiento
@@ -102,6 +102,62 @@ describe('scope: all three node actions visible across section 5', () => {
     const s2a = byLabel('2A');
     const actions = visibleBlocks(m, s2a.id).filter((b) => b.type === 'accion');
     expect(actions.map((a) => a.name)).toEqual(['Negociar con Kael']); // not Bram (sibling)
+  });
+});
+
+describe('reto: skill-challenge target parsing', () => {
+  test('accepts the canonical "<N> exitos / <M> fallos" form', () => {
+    expect(parseReto('4 exitos / 3 fallos')).toEqual({ exitosMeta: 4, fallosMeta: 3 });
+  });
+  test('accepts accents and casing', () => {
+    expect(parseReto('4 Éxitos / 3 Fallos')).toEqual({ exitosMeta: 4, fallosMeta: 3 });
+  });
+  test('accepts the bare "<N>/<M>" form', () => {
+    expect(parseReto('3/2')).toEqual({ exitosMeta: 3, fallosMeta: 2 });
+  });
+  test('accepts the "<N> exitos antes de <M> fallos" prose form', () => {
+    expect(parseReto('3 exitos antes de 2 fallos')).toEqual({ exitosMeta: 3, fallosMeta: 2 });
+  });
+  test('ignores malformed retos (returns undefined, never throws)', () => {
+    expect(parseReto('muchos exitos')).toBeUndefined();
+    expect(parseReto('4 exitos')).toBeUndefined(); // only one number
+    expect(parseReto('0 / 3')).toBeUndefined(); // non-positive
+    expect(parseReto('4 / 0')).toBeUndefined();
+    expect(parseReto('')).toBeUndefined();
+    expect(parseReto(undefined)).toBeUndefined();
+  });
+
+  test('absent reto leaves the ActionBlock meta undefined (behavior unchanged)', () => {
+    const beatA = sectionBlocks(byLabel('5')).find((b) => b.name === 'Beat A')!;
+    expect(beatA.exitosMeta).toBeUndefined();
+    expect(beatA.fallosMeta).toBeUndefined();
+  });
+
+  test('a :::accion carrying reto: exposes exitosMeta/fallosMeta on the block', () => {
+    const model = parseAct(`# T
+## 1. Reto
+:::accion
+**Desafio**
+- check: Athletics DC 15
+- reto: 4 exitos / 3 fallos
+:::
+`);
+    const block = sectionBlocks(model.sections[0]).find((b) => b.type === 'accion')!;
+    expect(block.exitosMeta).toBe(4);
+    expect(block.fallosMeta).toBe(3);
+  });
+
+  test('a malformed rez: on a :::accion leaves the block meta absent (no throw)', () => {
+    const model = parseAct(`# T
+## 1. Reto
+:::accion
+**Desafio**
+- reto: sin numeros
+:::
+`);
+    const block = sectionBlocks(model.sections[0]).find((b) => b.type === 'accion')!;
+    expect(block.exitosMeta).toBeUndefined();
+    expect(block.fallosMeta).toBeUndefined();
   });
 });
 

--- a/lib/actFormat.ts
+++ b/lib/actFormat.ts
@@ -23,6 +23,14 @@ export interface ActBlock {
   actScope: boolean;
   name?: string;
   fields?: ActField[];
+  /**
+   * Optional skill-challenge target declared by a `reto:` field on a :::accion
+   * (e.g. "4 exitos / 3 fallos"). When present the ActionCard renders a tappable
+   * success/fail tracker. Absent → no counter (current behavior unchanged). A
+   * malformed `reto:` is ignored (never throws), so this stays undefined.
+   */
+  exitosMeta?: number;
+  fallosMeta?: number;
 }
 
 export type ActItem =
@@ -65,6 +73,23 @@ function parseAttrs(raw: string | undefined): Record<string, string> {
     if (k) attrs[k] = v ?? 'true';
   }
   return attrs;
+}
+
+// Tolerantly parses a `reto:` value into its success/fail targets. Accepts:
+//   "4 exitos / 3 fallos", "4/3", "4 exitos antes de 3 fallos" (accents/case
+//   ignored, extra words allowed). Returns undefined when it can't extract two
+//   positive integers — a malformed reto is silently ignored (no counter).
+export function parseReto(
+  value: string | undefined
+): { exitosMeta: number; fallosMeta: number } | undefined {
+  if (!value) return undefined;
+  const nums = value.match(/\d+/g);
+  if (!nums || nums.length < 2) return undefined;
+  const exitosMeta = Number(nums[0]);
+  const fallosMeta = Number(nums[1]);
+  if (!Number.isInteger(exitosMeta) || exitosMeta <= 0) return undefined;
+  if (!Number.isInteger(fallosMeta) || fallosMeta <= 0) return undefined;
+  return { exitosMeta, fallosMeta };
 }
 
 function parseAccion(body: string): { name?: string; fields: ActField[] } {
@@ -146,6 +171,13 @@ export function parseAct(content: string): ActModel {
         const parsed = parseAccion(body);
         block.name = parsed.name;
         block.fields = parsed.fields;
+        // Optional skill-challenge target. A malformed reto is ignored (parseReto
+        // returns undefined), leaving the meta absent so no counter renders.
+        const reto = parseReto(parsed.fields.find((f) => f.key === 'reto')?.value);
+        if (reto) {
+          block.exitosMeta = reto.exitosMeta;
+          block.fallosMeta = reto.fallosMeta;
+        }
       }
       if (block.actScope) model.actBlocks.push(block);
       else current!.content.push({ kind: 'block', block });

--- a/lib/dirHandle.ts
+++ b/lib/dirHandle.ts
@@ -1,0 +1,92 @@
+/**
+ * Campaign directory-handle persistence.
+ *
+ * FileSystemDirectoryHandle cannot go through sessionStorage (not JSON-serializable),
+ * but it IS structured-cloneable, so it survives in IndexedDB. This lets /world
+ * (and eventually /play) reconnect to the campaign folder with one click instead
+ * of re-picking it after every navigation or reload.
+ */
+
+import { get, set, del } from 'idb-keyval';
+
+const KEY = 'campaignDirHandle';
+
+/** In-session singleton — avoids IndexedDB round-trips within one page lifetime. */
+let current: FileSystemDirectoryHandle | null = null;
+
+/** Remember a freshly picked campaign folder handle (memory + IndexedDB). */
+export async function rememberDirHandle(handle: FileSystemDirectoryHandle): Promise<void> {
+  current = handle;
+  try {
+    await set(KEY, handle);
+  } catch {
+    // IndexedDB unavailable (private mode etc.) — the in-memory singleton still works.
+  }
+}
+
+/** The handle for this page lifetime, if any (no permission check). */
+export function getCurrentDirHandle(): FileSystemDirectoryHandle | null {
+  return current;
+}
+
+export type StoredHandleStatus =
+  | { status: 'none' }
+  | { status: 'granted'; handle: FileSystemDirectoryHandle }
+  | { status: 'prompt'; handle: FileSystemDirectoryHandle };
+
+/**
+ * Loads the stored handle and checks (without prompting) whether read permission
+ * is still granted. 'prompt' means a user gesture + requestPermission is needed
+ * (the "Reconectar carpeta" button).
+ */
+export async function loadStoredDirHandle(): Promise<StoredHandleStatus> {
+  if (current) return { status: 'granted', handle: current };
+
+  let handle: FileSystemDirectoryHandle | undefined;
+  try {
+    handle = await get<FileSystemDirectoryHandle>(KEY);
+  } catch {
+    return { status: 'none' };
+  }
+  if (!handle) return { status: 'none' };
+
+  try {
+    const perm = await handle.queryPermission({ mode: 'read' });
+    if (perm === 'granted') {
+      current = handle;
+      return { status: 'granted', handle };
+    }
+    return { status: 'prompt', handle };
+  } catch {
+    return { status: 'none' };
+  }
+}
+
+/**
+ * Re-requests read permission on a stored handle. Must be called from a user gesture.
+ * Returns the handle if granted, null otherwise.
+ */
+export async function reconnectDirHandle(
+  handle: FileSystemDirectoryHandle
+): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    const perm = await handle.requestPermission({ mode: 'read' });
+    if (perm === 'granted') {
+      current = handle;
+      return handle;
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+/** Forget the stored handle (memory + IndexedDB). */
+export async function forgetDirHandle(): Promise<void> {
+  current = null;
+  try {
+    await del(KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/lib/fileSystem.test.ts
+++ b/lib/fileSystem.test.ts
@@ -67,6 +67,35 @@ describe('exists', () => {
     });
 });
 
+describe('deleteFile', () => {
+    test('removes a file from a nested directory', async () => {
+        const { fsm, root } = managerFor({
+            mundo: { diario: { '2026-07-12_s01.md': 'contenido' } },
+        });
+
+        await fsm.deleteFile('mundo/diario/2026-07-12_s01.md');
+
+        expect(root.readFile('mundo/diario/2026-07-12_s01.md')).toBeNull();
+        // The parent directory survives — only the entry is gone.
+        expect(await fsm.exists('mundo/diario')).toBe(true);
+    });
+
+    test('is a no-op when the file is already gone', async () => {
+        const { fsm } = managerFor({ mundo: { diario: {} } });
+        await expect(fsm.deleteFile('mundo/diario/never.md')).resolves.toBeUndefined();
+    });
+
+    test('is a no-op when an intermediate directory is missing', async () => {
+        const { fsm } = managerFor({ mundo: {} });
+        await expect(fsm.deleteFile('mundo/diario/never.md')).resolves.toBeUndefined();
+    });
+
+    test('throws without a directory selected', async () => {
+        const fsm = new FileSystemManager();
+        await expect(fsm.deleteFile('a.md')).rejects.toThrow('No directory selected');
+    });
+});
+
 describe('readTextFile round-trip', () => {
     test('reads back what was written', async () => {
         const { fsm } = managerFor({ mundo: {} });

--- a/lib/fileSystem.test.ts
+++ b/lib/fileSystem.test.ts
@@ -1,0 +1,77 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { FileSystemManager } from './fileSystem';
+import { makeHandle, MockDirectoryHandle } from './testUtils/mockFs';
+
+function managerFor(tree: Parameters<typeof makeHandle>[1]): {
+    fsm: FileSystemManager;
+    root: MockDirectoryHandle;
+} {
+    const handle = makeHandle('campaign', tree);
+    const fsm = new FileSystemManager();
+    fsm.setDirectoryHandle(handle);
+    return { fsm, root: handle as unknown as MockDirectoryHandle };
+}
+
+describe('writeTextFile', () => {
+    test('creates intermediate directories and writes content', async () => {
+        const { fsm, root } = managerFor({ mundo: {} });
+
+        await fsm.writeTextFile('mundo/diario/2026-07-12_s08.md', '- [18:02] inicio: dia 4127 @ porto_verne\n');
+
+        expect(root.readFile('mundo/diario/2026-07-12_s08.md')).toBe(
+            '- [18:02] inicio: dia 4127 @ porto_verne\n'
+        );
+    });
+
+    test('overwrites an existing file completely (full-rewrite semantics)', async () => {
+        const { fsm, root } = managerFor({
+            mundo: { estado: { 'grupo.md': 'old content that is much longer than the new one' } },
+        });
+
+        await fsm.writeTextFile('mundo/estado/grupo.md', 'new');
+
+        expect(root.readFile('mundo/estado/grupo.md')).toBe('new');
+    });
+
+    test('throws without a directory selected', async () => {
+        const fsm = new FileSystemManager();
+        await expect(fsm.writeTextFile('a.md', 'x')).rejects.toThrow('No directory selected');
+    });
+});
+
+describe('exists', () => {
+    const tree = {
+        mundo: {
+            'mundo.md': '---\ntipo: mundo\n---\n',
+            diario: {},
+        },
+    };
+
+    test('finds files and directories', async () => {
+        const { fsm } = managerFor(tree);
+        expect(await fsm.exists('mundo/mundo.md')).toBe(true);
+        expect(await fsm.exists('mundo/diario')).toBe(true);
+        expect(await fsm.exists('mundo')).toBe(true);
+    });
+
+    test('misses absent paths without throwing', async () => {
+        const { fsm } = managerFor(tree);
+        expect(await fsm.exists('mundo/estado/grupo.md')).toBe(false);
+        expect(await fsm.exists('nope')).toBe(false);
+    });
+
+    test('false without a directory selected', async () => {
+        const fsm = new FileSystemManager();
+        expect(await fsm.exists('mundo')).toBe(false);
+    });
+});
+
+describe('readTextFile round-trip', () => {
+    test('reads back what was written', async () => {
+        const { fsm } = managerFor({ mundo: {} });
+        const text = '---\nsesion: 8\nprocesado: false\n---\n- [18:02] inicio: dia 4127 @ porto_verne\n';
+        await fsm.writeTextFile('mundo/diario/x.md', text);
+        expect(await fsm.readTextFile('mundo/diario/x.md')).toBe(text);
+    });
+});

--- a/lib/fileSystem.ts
+++ b/lib/fileSystem.ts
@@ -220,6 +220,37 @@ export class FileSystemManager {
   }
 
   /**
+   * Deletes a file at a relative path. Walks to the parent directory and
+   * removes the entry. A file that is already gone (NotFoundError anywhere on
+   * the walk) resolves to a no-op — deletion is idempotent — while any other
+   * error propagates. Used by the world "Descartar (prueba)" flow to drop a
+   * test session's journal.
+   */
+  async deleteFile(relativePath: string): Promise<void> {
+    if (!this.directoryHandle) {
+      throw new Error('No directory selected');
+    }
+
+    const parts = relativePath.split('/').filter(Boolean);
+    if (parts.length === 0) {
+      throw new Error('Cannot delete: empty path');
+    }
+
+    try {
+      let currentDir = this.directoryHandle;
+      for (let i = 0; i < parts.length - 1; i++) {
+        currentDir = await currentDir.getDirectoryHandle(parts[i]);
+      }
+      await currentDir.removeEntry(parts[parts.length - 1]);
+    } catch (error) {
+      // Idempotent: a missing parent dir or a missing file is already the
+      // desired end state. Anything else (permissions, type mismatch) throws.
+      if ((error as Error).name === 'NotFoundError') return;
+      throw error;
+    }
+  }
+
+  /**
    * Queries write permission on a handle (defaults to the root directory handle)
    */
   async queryWritePermission(handle?: FileSystemDirectoryHandle): Promise<PermissionState> {

--- a/lib/fileSystem.ts
+++ b/lib/fileSystem.ts
@@ -4,13 +4,13 @@ export class FileSystemManager {
   /**
    * Opens a folder picker and returns the directory handle
    */
-  async selectFolder(): Promise<FileSystemDirectoryHandle> {
+  async selectFolder(mode: 'read' | 'readwrite' = 'read'): Promise<FileSystemDirectoryHandle> {
     if (!('showDirectoryPicker' in window)) {
       throw new Error('File System Access API is not supported in this browser. Please use Chrome or Edge.');
     }
 
     this.directoryHandle = await window.showDirectoryPicker({
-      mode: 'read',
+      mode,
     });
 
     return this.directoryHandle;
@@ -164,6 +164,82 @@ export class FileSystemManager {
 
     const fileHandle = await this.getFileHandle(relativePath);
     return await fileHandle.getFile();
+  }
+
+  /**
+   * Checks whether a file or directory exists at a relative path
+   */
+  async exists(relativePath: string): Promise<boolean> {
+    if (!this.directoryHandle) {
+      return false;
+    }
+
+    const parts = relativePath.split('/').filter(Boolean);
+    let currentDir = this.directoryHandle;
+
+    try {
+      for (let i = 0; i < parts.length - 1; i++) {
+        currentDir = await currentDir.getDirectoryHandle(parts[i]);
+      }
+      const last = parts[parts.length - 1];
+      try {
+        await currentDir.getFileHandle(last);
+        return true;
+      } catch {
+        await currentDir.getDirectoryHandle(last);
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Writes a text file at a relative path, creating intermediate directories.
+   * createWritable() writes to a temp file and atomically swaps on close().
+   */
+  async writeTextFile(relativePath: string, content: string): Promise<void> {
+    if (!this.directoryHandle) {
+      throw new Error('No directory selected');
+    }
+
+    const parts = relativePath.split('/').filter(Boolean);
+    let currentDir = this.directoryHandle;
+
+    for (let i = 0; i < parts.length - 1; i++) {
+      currentDir = await currentDir.getDirectoryHandle(parts[i], { create: true });
+    }
+
+    const fileHandle = await currentDir.getFileHandle(parts[parts.length - 1], { create: true });
+    const writable = await fileHandle.createWritable();
+    try {
+      await writable.write(content);
+    } finally {
+      await writable.close();
+    }
+  }
+
+  /**
+   * Queries write permission on a handle (defaults to the root directory handle)
+   */
+  async queryWritePermission(handle?: FileSystemDirectoryHandle): Promise<PermissionState> {
+    const target = handle ?? this.directoryHandle;
+    if (!target) {
+      throw new Error('No directory selected');
+    }
+    return await target.queryPermission({ mode: 'readwrite' });
+  }
+
+  /**
+   * Requests write permission on a handle (defaults to the root directory handle).
+   * Must be called from a user gesture.
+   */
+  async requestWritePermission(handle?: FileSystemDirectoryHandle): Promise<PermissionState> {
+    const target = handle ?? this.directoryHandle;
+    if (!target) {
+      throw new Error('No directory selected');
+    }
+    return await target.requestPermission({ mode: 'readwrite' });
   }
 
   /**

--- a/lib/fsScanUtils.ts
+++ b/lib/fsScanUtils.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared File System Access API scanning helpers.
+ * Used by sessionScanner (classic session folders) and worldScanner (mundo/ folders).
+ */
+
+import { FileReference, AudioFile } from '@/types';
+
+/**
+ * Gets all files from a directory with their relative paths
+ */
+export async function getFilesFromDirectory(
+    handle: FileSystemDirectoryHandle,
+    basePath: string,
+    extensions: readonly string[]
+): Promise<Array<{ name: string; path: string }>> {
+    const files: Array<{ name: string; path: string }> = [];
+
+    for await (const [name, entryHandle] of handle.entries()) {
+        if (entryHandle.kind !== 'file') continue;
+
+        const ext = name.toLowerCase().split('.').pop();
+        if (extensions.includes(ext || '')) {
+            files.push({
+                name,
+                path: `${basePath}/${name}`,
+            });
+        }
+    }
+
+    return files.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Safely gets a subdirectory handle, returning null if not found
+ */
+export async function getSubdirectory(
+    handle: FileSystemDirectoryHandle,
+    ...path: string[]
+): Promise<FileSystemDirectoryHandle | null> {
+    try {
+        let current = handle;
+        for (const segment of path) {
+            current = await current.getDirectoryHandle(segment);
+        }
+        return current;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Creates a FileReference from a file entry
+ */
+export function createFileReference(
+    file: { name: string; path: string },
+    type: 'markdown' | 'image' | 'audio'
+): FileReference {
+    return {
+        path: file.path,
+        name: file.name,
+        type,
+    };
+}
+
+/**
+ * Creates an AudioFile from a file entry
+ */
+export function createAudioFile(file: { name: string; path: string }): AudioFile {
+    return {
+        path: file.path,
+        name: file.name,
+        type: 'audio',
+    };
+}
+
+/**
+ * Reads a file's content from a FileSystemFileHandle
+ */
+export async function readFileContent(fileHandle: FileSystemFileHandle): Promise<string> {
+    try {
+        const file = await fileHandle.getFile();
+        return await file.text();
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Converts a file name to a display name.
+ * Short words (2 letters or less) stay lowercase unless they're the first word
+ */
+export function fileNameToDisplayName(fileName: string): string {
+    // Remove extension
+    const nameWithoutExt = fileName.replace(/\.(md|markdown)$/i, '');
+    // Replace underscores with spaces and capitalize words
+    const words = nameWithoutExt.replace(/_/g, ' ').split(' ');
+    return words
+        .map((word, index) => {
+            if (index === 0 || word.length > 2) {
+                return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+            }
+            return word.toLowerCase();
+        })
+        .join(' ');
+}

--- a/lib/sessionScanner.test.ts
+++ b/lib/sessionScanner.test.ts
@@ -143,3 +143,36 @@ test('backward compat: act-only structure produces no paths and no pathId', asyn
     expect(config.paths == null || config.paths.length === 0).toBe(true);
     expect(config.activePathId == null).toBe(true);
 });
+
+test('maps/ splits image battlemaps from markdown maps', async () => {
+    const handle = makeHandle('sessionMaps', {
+        plan: {
+            act1: { 'opening.md': '# Act 1' },
+        },
+        maps: {
+            act1: {
+                'ascii_layout.md': '```\n#####\n#...#\n#####\n```',
+                'muelle_battlemap.png': 'fake-png-bytes',
+                'plaza.jpg': 'fake-jpg-bytes',
+            },
+        },
+    });
+
+    const config = await scanSessionFolder(handle);
+    expect(config.parts).toHaveLength(1);
+    const [part] = config.parts;
+
+    // Image files -> battlemaps (createFileReference type 'image').
+    const battlemapNames = part.battlemaps.map((b) => b.name).sort();
+    expect(battlemapNames).toEqual(['muelle_battlemap.png', 'plaza.jpg']);
+    for (const bm of part.battlemaps) {
+        expect(bm.type).toBe('image');
+        expect(bm.path).toBe(`maps/act1/${bm.name}`);
+    }
+
+    // Markdown maps still land in supportDocs, NOT battlemaps.
+    const docNames = part.supportDocs.map((d) => d.name);
+    expect(docNames).toContain('ascii_layout.md');
+    expect(part.supportDocs.every((d) => d.type === 'markdown')).toBe(true);
+    expect(part.supportDocs.some((d) => d.name.endsWith('.png'))).toBe(false);
+});

--- a/lib/sessionScanner.ts
+++ b/lib/sessionScanner.ts
@@ -380,6 +380,7 @@ async function scanActFolder(
         name: partName,
         planFile: null,
         images: [],
+        battlemaps: [],
         supportDocs: [],
         bgmPlaylist: [],
         eventPlaylists: [],
@@ -436,7 +437,7 @@ async function scanActFolder(
         part.supportDocs.push(...threatFiles.map(f => createFileReference(f, 'markdown')));
     }
 
-    // Scan maps folder
+    // Scan maps folder: markdown ASCII maps -> supportDocs; image files -> battlemaps.
     const mapsFolder = await getSubdirectory(handle, 'maps', actName);
     if (mapsFolder) {
         const mapFiles = await getFilesFromDirectory(
@@ -445,6 +446,13 @@ async function scanActFolder(
             SUPPORTED_MARKDOWN_EXTENSIONS
         );
         part.supportDocs.push(...mapFiles.map(f => createFileReference(f, 'markdown')));
+
+        const battlemapFiles = await getFilesFromDirectory(
+            mapsFolder,
+            `maps/${actName}`,
+            SUPPORTED_IMAGE_EXTENSIONS
+        );
+        part.battlemaps.push(...battlemapFiles.map(f => createFileReference(f, 'image')));
     }
 
     const musicFolder = await getSubdirectory(handle, 'music', actName);
@@ -522,7 +530,7 @@ async function collectPathSupportContent(
         part.supportDocs.push(...threatFiles.map(f => createFileReference(f, 'markdown')));
     }
 
-    // Maps
+    // Maps: markdown ASCII maps -> supportDocs; image files -> battlemaps.
     const mapsFolder = await getSubdirectory(handle, 'maps', pathFolder);
     if (mapsFolder) {
         const mapFiles = await getFilesFromDirectory(
@@ -531,6 +539,13 @@ async function collectPathSupportContent(
             SUPPORTED_MARKDOWN_EXTENSIONS
         );
         part.supportDocs.push(...mapFiles.map(f => createFileReference(f, 'markdown')));
+
+        const battlemapFiles = await getFilesFromDirectory(
+            mapsFolder,
+            `maps/${pathFolder}`,
+            SUPPORTED_IMAGE_EXTENSIONS
+        );
+        part.battlemaps.push(...battlemapFiles.map(f => createFileReference(f, 'image')));
     }
 
     // Music (BGM tracks + event playlist subfolders), same logic as scanActFolder
@@ -573,6 +588,7 @@ function createPathPart(name: string, pathId: string): Part {
         name,
         planFile: null,
         images: [],
+        battlemaps: [],
         supportDocs: [],
         bgmPlaylist: [],
         eventPlaylists: [],
@@ -636,6 +652,7 @@ async function scanForSinglePart(
         name: partName,
         planFile: null,
         images: [],
+        battlemaps: [],
         supportDocs: [],
         bgmPlaylist: [],
         eventPlaylists: [],
@@ -665,6 +682,13 @@ async function scanForSinglePart(
             const files = await getFilesFromDirectory(folder, folderName, SUPPORTED_AUDIO_EXTENSIONS);
             part.bgmPlaylist = files.map(f => createAudioFile(f));
             if (files.length > 0) hasContent = true;
+        } else if (folderName === 'maps') {
+            // maps/ markdown -> supportDocs; images -> battlemaps.
+            const mapFiles = await getFilesFromDirectory(folder, folderName, SUPPORTED_MARKDOWN_EXTENSIONS);
+            part.supportDocs.push(...mapFiles.map(f => createFileReference(f, 'markdown')));
+            const battlemapFiles = await getFilesFromDirectory(folder, folderName, SUPPORTED_IMAGE_EXTENSIONS);
+            part.battlemaps.push(...battlemapFiles.map(f => createFileReference(f, 'image')));
+            if (mapFiles.length > 0 || battlemapFiles.length > 0) hasContent = true;
         } else {
             const files = await getFilesFromDirectory(folder, folderName, SUPPORTED_MARKDOWN_EXTENSIONS);
             part.supportDocs.push(...files.map(f => createFileReference(f, 'markdown')));

--- a/lib/sessionScanner.ts
+++ b/lib/sessionScanner.ts
@@ -5,6 +5,14 @@ import {
     SUPPORTED_AUDIO_EXTENSIONS,
     SUPPORTED_MARKDOWN_EXTENSIONS
 } from './fileSystem';
+import {
+    getFilesFromDirectory,
+    getSubdirectory,
+    createFileReference,
+    createAudioFile,
+    readFileContent,
+    fileNameToDisplayName,
+} from './fsScanUtils';
 
 /**
  * Expected folder names for auto-detection
@@ -126,74 +134,6 @@ function prettifyPathName(folderName: string): string {
 }
 
 /**
- * Gets all files from a directory with their relative paths
- */
-async function getFilesFromDirectory(
-    handle: FileSystemDirectoryHandle,
-    basePath: string,
-    extensions: readonly string[]
-): Promise<Array<{ name: string; path: string }>> {
-    const files: Array<{ name: string; path: string }> = [];
-
-    for await (const [name, entryHandle] of handle.entries()) {
-        if (entryHandle.kind !== 'file') continue;
-
-        const ext = name.toLowerCase().split('.').pop();
-        if (extensions.includes(ext || '')) {
-            files.push({
-                name,
-                path: `${basePath}/${name}`,
-            });
-        }
-    }
-
-    return files.sort((a, b) => a.name.localeCompare(b.name));
-}
-
-/**
- * Safely gets a subdirectory handle, returning null if not found
- */
-async function getSubdirectory(
-    handle: FileSystemDirectoryHandle,
-    ...path: string[]
-): Promise<FileSystemDirectoryHandle | null> {
-    try {
-        let current = handle;
-        for (const segment of path) {
-            current = await current.getDirectoryHandle(segment);
-        }
-        return current;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * Creates a FileReference from a file entry
- */
-function createFileReference(
-    file: { name: string; path: string },
-    type: 'markdown' | 'image' | 'audio'
-): FileReference {
-    return {
-        path: file.path,
-        name: file.name,
-        type,
-    };
-}
-
-/**
- * Creates an AudioFile from a file entry
- */
-function createAudioFile(file: { name: string; path: string }): AudioFile {
-    return {
-        path: file.path,
-        name: file.name,
-        type: 'audio',
-    };
-}
-
-/**
  * Detects player character names from the characters/PCs folder
  * The filename (without extension) is used as the PC name
  */
@@ -291,18 +231,6 @@ function extractStat(content: string, patterns: RegExp[]): number | null {
 }
 
 /**
- * Reads a file's content from a FileSystemFileHandle
- */
-async function readFileContent(fileHandle: FileSystemFileHandle): Promise<string> {
-    try {
-        const file = await fileHandle.getFile();
-        return await file.text();
-    } catch {
-        return '';
-    }
-}
-
-/**
  * Extracts player character stats (HP, AC/DEF) from character sheet markdown files
  */
 async function extractPCStats(folder: FileSystemDirectoryHandle): Promise<PlayerCharacterStats[]> {
@@ -344,26 +272,6 @@ async function detectPlayerCharacterStats(handle: FileSystemDirectoryHandle): Pr
         return await extractPCStats(pcsLower);
     }
     return await extractPCStats(pcsFolder);
-}
-
-/**
- * Converts a filename to a readable display name
- * Removes extension, replaces underscores with spaces, and capitalizes each word
- * Short words (2 letters or less) stay lowercase unless they're the first word
- */
-function fileNameToDisplayName(fileName: string): string {
-    // Remove extension
-    const nameWithoutExt = fileName.replace(/\.(md|markdown)$/i, '');
-    // Replace underscores with spaces and capitalize words
-    const words = nameWithoutExt.replace(/_/g, ' ').split(' ');
-    return words
-        .map((word, index) => {
-            if (index === 0 || word.length > 2) {
-                return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-            }
-            return word.toLowerCase();
-        })
-        .join(' ');
 }
 
 /**

--- a/lib/testUtils/mockFs.ts
+++ b/lib/testUtils/mockFs.ts
@@ -10,6 +10,13 @@
 
 export type FileTree = { [name: string]: string | FileTree };
 
+/** Builds an Error whose `.name` matches the real FS Access DOMException. */
+function namedError(name: string, message: string): Error {
+    const error = new Error(`${name}: ${message}`);
+    error.name = name;
+    return error;
+}
+
 export class MockFileHandle {
     kind = 'file' as const;
     constructor(public name: string, public content: string) {}
@@ -58,25 +65,34 @@ export class MockDirectoryHandle {
     async getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<MockDirectoryHandle> {
         const child = this.children.get(name);
         if (child && child.kind === 'directory') return child;
-        if (child) throw new Error(`TypeMismatchError: "${name}" is a file in "${this.name}"`);
+        if (child) throw namedError('TypeMismatchError', `"${name}" is a file in "${this.name}"`);
         if (options?.create) {
             const dir = new MockDirectoryHandle(name);
             this.children.set(name, dir);
             return dir;
         }
-        throw new Error(`NotFoundError: directory "${name}" not found in "${this.name}"`);
+        throw namedError('NotFoundError', `directory "${name}" not found in "${this.name}"`);
     }
 
     async getFileHandle(name: string, options?: { create?: boolean }): Promise<MockFileHandle> {
         const child = this.children.get(name);
         if (child && child.kind === 'file') return child;
-        if (child) throw new Error(`TypeMismatchError: "${name}" is a directory in "${this.name}"`);
+        if (child) throw namedError('TypeMismatchError', `"${name}" is a directory in "${this.name}"`);
         if (options?.create) {
             const file = new MockFileHandle(name, '');
             this.children.set(name, file);
             return file;
         }
-        throw new Error(`NotFoundError: file "${name}" not found in "${this.name}"`);
+        throw namedError('NotFoundError', `file "${name}" not found in "${this.name}"`);
+    }
+
+    async removeEntry(name: string, _options?: { recursive?: boolean }): Promise<void> {
+        // Mirrors FileSystemDirectoryHandle.removeEntry: a missing entry throws
+        // a NotFoundError (the app's deleteFile catches it as a no-op).
+        if (!this.children.has(name)) {
+            throw namedError('NotFoundError', `entry "${name}" not found in "${this.name}"`);
+        }
+        this.children.delete(name);
     }
 
     /** Test helper: read a file's content by slash-separated path. */

--- a/lib/testUtils/mockFs.ts
+++ b/lib/testUtils/mockFs.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared in-memory mock of the File System Access API handles for unit tests.
+ * Extends the pattern from sessionScanner.test.ts with write support
+ * (getFileHandle({create}), getDirectoryHandle({create}), createWritable).
+ *
+ * A "tree" is a nested plain object:
+ *   - string value  => a file whose text content is that string
+ *   - object value  => a subdirectory
+ */
+
+export type FileTree = { [name: string]: string | FileTree };
+
+export class MockFileHandle {
+    kind = 'file' as const;
+    constructor(public name: string, public content: string) {}
+
+    async getFile() {
+        const content = this.content;
+        return {
+            text: async () => content,
+        };
+    }
+
+    async createWritable() {
+        let buffer = '';
+        return {
+            write: async (data: string) => {
+                buffer += data;
+            },
+            close: async () => {
+                // Mirrors the real API: content swaps in atomically on close.
+                this.content = buffer;
+            },
+        };
+    }
+}
+
+export class MockDirectoryHandle {
+    kind = 'directory' as const;
+    private children = new Map<string, MockFileHandle | MockDirectoryHandle>();
+
+    constructor(public name: string, tree: FileTree = {}) {
+        for (const [childName, value] of Object.entries(tree)) {
+            if (typeof value === 'string') {
+                this.children.set(childName, new MockFileHandle(childName, value));
+            } else {
+                this.children.set(childName, new MockDirectoryHandle(childName, value));
+            }
+        }
+    }
+
+    async *entries(): AsyncGenerator<[string, MockFileHandle | MockDirectoryHandle]> {
+        for (const [name, handle] of this.children) {
+            yield [name, handle];
+        }
+    }
+
+    async getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<MockDirectoryHandle> {
+        const child = this.children.get(name);
+        if (child && child.kind === 'directory') return child;
+        if (child) throw new Error(`TypeMismatchError: "${name}" is a file in "${this.name}"`);
+        if (options?.create) {
+            const dir = new MockDirectoryHandle(name);
+            this.children.set(name, dir);
+            return dir;
+        }
+        throw new Error(`NotFoundError: directory "${name}" not found in "${this.name}"`);
+    }
+
+    async getFileHandle(name: string, options?: { create?: boolean }): Promise<MockFileHandle> {
+        const child = this.children.get(name);
+        if (child && child.kind === 'file') return child;
+        if (child) throw new Error(`TypeMismatchError: "${name}" is a directory in "${this.name}"`);
+        if (options?.create) {
+            const file = new MockFileHandle(name, '');
+            this.children.set(name, file);
+            return file;
+        }
+        throw new Error(`NotFoundError: file "${name}" not found in "${this.name}"`);
+    }
+
+    /** Test helper: read a file's content by slash-separated path. */
+    readFile(path: string): string | null {
+        const parts = path.split('/').filter(Boolean);
+        let current: MockFileHandle | MockDirectoryHandle | undefined = this as MockDirectoryHandle;
+        for (const part of parts) {
+            if (!current || current.kind !== 'directory') return null;
+            current = (current as MockDirectoryHandle).children.get(part);
+        }
+        return current && current.kind === 'file' ? current.content : null;
+    }
+}
+
+export function makeHandle(name: string, tree: FileTree = {}): FileSystemDirectoryHandle {
+    // The mock implements the subset of FileSystemDirectoryHandle the app touches.
+    return new MockDirectoryHandle(name, tree) as unknown as FileSystemDirectoryHandle;
+}

--- a/lib/world/conditions.test.ts
+++ b/lib/world/conditions.test.ts
@@ -300,6 +300,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         musica: { bgm: [], eventPlaylists: [] },
         tiendas: new Map(),
         resumen: null,
+        guias: [],
     };
 }
 

--- a/lib/world/conditions.test.ts
+++ b/lib/world/conditions.test.ts
@@ -219,7 +219,7 @@ describe('isParseableCondition', () => {
 const MANIFEST: WorldManifest = {
     nombre: 'Sector Test',
     calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
-    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustiblePorTramo: 1, viveresCadaDias: 4 },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustibleCadaDias: 4, viveresCadaDias: 4 },
     medidores: ['viveres', 'combustible', 'nave'],
     regiones: ['nucleo', 'frontera'],
 };

--- a/lib/world/conditions.test.ts
+++ b/lib/world/conditions.test.ts
@@ -298,6 +298,8 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         estadoGrupo: null,
         diario: [],
         musica: { bgm: [], eventPlaylists: [] },
+        tiendas: new Map(),
+        resumen: null,
     };
 }
 

--- a/lib/world/conditions.test.ts
+++ b/lib/world/conditions.test.ts
@@ -297,6 +297,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         childrenOf: new Map(),
         estadoGrupo: null,
         diario: [],
+        musica: { bgm: [], eventPlaylists: [] },
     };
 }
 

--- a/lib/world/conditions.test.ts
+++ b/lib/world/conditions.test.ts
@@ -1,0 +1,385 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import {
+    buildCondContext,
+    evalCondition,
+    evalConditions,
+    isParseableCondition,
+} from './conditions';
+import {
+    CondContext,
+    FactionPresence,
+    Lead,
+    PlaceEntity,
+    SystemEntity,
+    WorldEntityBase,
+    WorldManifest,
+    WorldModel,
+} from '@/types/world';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function ctx(overrides: Partial<CondContext> = {}): CondContext {
+    return {
+        creditos: 500,
+        medidores: { viveres: 3, combustible: 1, nave: 2 },
+        diaMundo: 4160,
+        regionActual: 'frontera',
+        etiquetasActuales: ['pirata', 'ruina'],
+        faccionesActuales: ['consorcio_tetrad'],
+        pistaEstado: (id) => (id === 'deuda_kael' ? 'activa' : null),
+        lugarConocimiento: (id) => (id === 'porto_verne' ? 'conocido' : null),
+        ...overrides,
+    };
+}
+
+// ── Numeric comparisons ─────────────────────────────────────────────────────
+
+describe('evalCondition — numeric', () => {
+    test('creditos with every operator', () => {
+        expect(evalCondition('creditos>=500', ctx())).toBe(true);
+        expect(evalCondition('creditos>=800', ctx())).toBe(false);
+        expect(evalCondition('creditos<=500', ctx())).toBe(true);
+        expect(evalCondition('creditos<500', ctx())).toBe(false);
+        expect(evalCondition('creditos>499', ctx())).toBe(true);
+        expect(evalCondition('creditos=500', ctx())).toBe(true);
+        expect(evalCondition('creditos=501', ctx())).toBe(false);
+        expect(evalCondition('creditos==500', ctx())).toBe(true); // tolerated synonym
+    });
+
+    test('dia reads diaMundo', () => {
+        expect(evalCondition('dia>=4160', ctx())).toBe(true);
+        expect(evalCondition('dia>4160', ctx())).toBe(false);
+    });
+
+    test('any medidor name evaluates against the medidores map', () => {
+        expect(evalCondition('combustible<=1', ctx())).toBe(true);
+        expect(evalCondition('combustible<=0', ctx())).toBe(false);
+        expect(evalCondition('nave>=2', ctx())).toBe(true);
+        expect(
+            evalCondition('oxigeno<=2', ctx({ medidores: { oxigeno: 1 } }))
+        ).toBe(true);
+    });
+
+    test('unknown medidor name is null (unevaluable), not false', () => {
+        expect(evalCondition('oxigeno<=2', ctx())).toBeNull();
+    });
+
+    test('whitespace-tolerant', () => {
+        expect(evalCondition('  creditos >= 100  ', ctx())).toBe(true);
+        expect(evalCondition('combustible <= 1', ctx())).toBe(true);
+    });
+});
+
+// ── Colon forms ─────────────────────────────────────────────────────────────
+
+describe('evalCondition — region/etiqueta/faccion', () => {
+    test('region matches the effective region', () => {
+        expect(evalCondition('region:frontera', ctx())).toBe(true);
+        expect(evalCondition('region:nucleo', ctx())).toBe(false);
+        expect(evalCondition('region: frontera', ctx())).toBe(true); // space after colon
+    });
+
+    test('null region is false (evaluable: the party is nowhere named)', () => {
+        expect(evalCondition('region:frontera', ctx({ regionActual: null }))).toBe(false);
+    });
+
+    test('etiqueta against the current place + ancestors', () => {
+        expect(evalCondition('etiqueta:pirata', ctx())).toBe(true);
+        expect(evalCondition('etiqueta:minera', ctx())).toBe(false);
+    });
+
+    test('faccion against present factions', () => {
+        expect(evalCondition('faccion:consorcio_tetrad', ctx())).toBe(true);
+        expect(evalCondition('faccion:culto_helios', ctx())).toBe(false);
+    });
+});
+
+describe('evalCondition — pista', () => {
+    test('estado equality', () => {
+        expect(evalCondition('pista:deuda_kael:activa', ctx())).toBe(true);
+        expect(evalCondition('pista:deuda_kael:resuelta', ctx())).toBe(false);
+    });
+
+    test('missing pista is null', () => {
+        expect(evalCondition('pista:no_existe:activa', ctx())).toBeNull();
+    });
+
+    test('out-of-vocabulary estado is null (unparseable)', () => {
+        expect(evalCondition('pista:deuda_kael:resuleta', ctx())).toBeNull();
+    });
+});
+
+describe('evalCondition — lugar (conocimiento-min ordering)', () => {
+    test('at-least semantics over desconocido<rumoreado<conocido<visitado', () => {
+        // porto_verne is 'conocido' in the fixture ctx
+        expect(evalCondition('lugar:porto_verne:desconocido', ctx())).toBe(true);
+        expect(evalCondition('lugar:porto_verne:rumoreado', ctx())).toBe(true);
+        expect(evalCondition('lugar:porto_verne:conocido', ctx())).toBe(true);
+        expect(evalCondition('lugar:porto_verne:visitado', ctx())).toBe(false);
+    });
+
+    test('missing lugar is null', () => {
+        expect(evalCondition('lugar:no_existe:conocido', ctx())).toBeNull();
+    });
+
+    test('out-of-vocabulary minimum is null (unparseable)', () => {
+        expect(evalCondition('lugar:porto_verne:famoso', ctx())).toBeNull();
+    });
+});
+
+// ── Unparseable shapes ──────────────────────────────────────────────────────
+
+describe('evalCondition — unknown shapes', () => {
+    test.each([
+        '',
+        '   ',
+        'basura',
+        'manual: pide permiso a Kael',
+        'creditos>=',
+        'creditos~500',
+        'region:',
+        'region:dos palabras',
+        'pista:deuda_kael',
+        'lugar:porto_verne',
+        'quien:sabe:que',
+    ])('null for %j', (cond) => {
+        expect(evalCondition(cond, ctx())).toBeNull();
+    });
+});
+
+// ── Conjunctions ────────────────────────────────────────────────────────────
+
+describe('evalCondition — & conjunction', () => {
+    test('all true', () => {
+        expect(evalCondition('creditos>=100&region:frontera&combustible<=1', ctx())).toBe(true);
+        expect(evalCondition(' etiqueta:pirata & dia>=100 ', ctx())).toBe(true);
+    });
+
+    test('any false makes it false', () => {
+        expect(evalCondition('creditos>=100&region:nucleo', ctx())).toBe(false);
+    });
+
+    test('any unparseable atom makes it null', () => {
+        expect(evalCondition('creditos>=100&basura', ctx())).toBeNull();
+    });
+
+    test('null dominates false (an unevaluable set is never definitively false)', () => {
+        expect(evalCondition('creditos>=99999&oxigeno<=1', ctx())).toBeNull();
+        expect(evalCondition('oxigeno<=1&creditos>=99999', ctx())).toBeNull();
+    });
+});
+
+describe('evalConditions', () => {
+    test('empty list is vacuously true', () => {
+        expect(evalConditions([], ctx())).toBe(true);
+    });
+
+    test('AND over the list', () => {
+        expect(evalConditions(['creditos>=100', 'region:frontera'], ctx())).toBe(true);
+        expect(evalConditions(['creditos>=100', 'region:nucleo'], ctx())).toBe(false);
+    });
+
+    test('null if ANY is null, even alongside a false', () => {
+        expect(evalConditions(['creditos>=99999', 'basura'], ctx())).toBeNull();
+        expect(evalConditions(['basura', 'creditos>=100'], ctx())).toBeNull();
+    });
+});
+
+// ── Syntax-only check ───────────────────────────────────────────────────────
+
+describe('isParseableCondition', () => {
+    test('true for every grammar form', () => {
+        expect(isParseableCondition('combustible<=1')).toBe(true);
+        expect(isParseableCondition('creditos >= 800')).toBe(true);
+        expect(isParseableCondition('dia>=4160')).toBe(true);
+        expect(isParseableCondition('region:frontera')).toBe(true);
+        expect(isParseableCondition('etiqueta:pirata')).toBe(true);
+        expect(isParseableCondition('faccion:consorcio_tetrad')).toBe(true);
+        expect(isParseableCondition('pista:deuda_kael:resuelta')).toBe(true);
+        expect(isParseableCondition('lugar:nodo_sigma:rumoreado')).toBe(true);
+        expect(isParseableCondition('creditos>=800&region:frontera')).toBe(true);
+    });
+
+    test('syntax-only: an unknown medidor NAME still parses', () => {
+        expect(isParseableCondition('oxigeno<=2')).toBe(true);
+    });
+
+    test('false for garbage, manual: and empties', () => {
+        expect(isParseableCondition('')).toBe(false);
+        expect(isParseableCondition('manual: decide el GM')).toBe(false);
+        expect(isParseableCondition('basura')).toBe(false);
+        expect(isParseableCondition('creditos>=100&')).toBe(false);
+        expect(isParseableCondition('pista:x:no_es_estado')).toBe(false);
+    });
+});
+
+// ── buildCondContext ────────────────────────────────────────────────────────
+
+const MANIFEST: WorldManifest = {
+    nombre: 'Sector Test',
+    calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustiblePorTramo: 1, viveresCadaDias: 4 },
+    medidores: ['viveres', 'combustible', 'nave'],
+    regiones: ['nucleo', 'frontera'],
+};
+
+function sistema(id: string, region?: string, etiquetas: string[] = []): SystemEntity {
+    return {
+        id,
+        tipo: 'sistema',
+        nombre: id,
+        filePath: `mundo/sistemas/${id}.md`,
+        conocimiento: 'visitado',
+        etiquetas,
+        raw: {},
+        body: '',
+        coordenadas: { x: 0, y: 0 },
+        region,
+    };
+}
+
+function lugar(
+    id: string,
+    opts: {
+        en?: string;
+        region?: string;
+        etiquetas?: string[];
+        facciones?: FactionPresence[];
+        conocimiento?: PlaceEntity['conocimiento'];
+    } = {}
+): PlaceEntity {
+    return {
+        id,
+        tipo: 'lugar',
+        nombre: id,
+        filePath: `mundo/lugares/${id}.md`,
+        conocimiento: opts.conocimiento ?? 'conocido',
+        etiquetas: opts.etiquetas ?? [],
+        raw: {},
+        body: '',
+        en: opts.en,
+        region: opts.region,
+        servicios: [],
+        facciones: opts.facciones ?? [],
+        acceso: 'normal',
+    };
+}
+
+function pista(id: string, estadoPista: Lead['estadoPista']): Lead {
+    return {
+        id,
+        tipo: 'pista',
+        nombre: id,
+        filePath: `mundo/pistas/${id}.md`,
+        conocimiento: 'desconocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        estadoPista,
+        requisitos: [],
+        accionable: false,
+    };
+}
+
+function makeModel(entities: WorldEntityBase[]): WorldModel {
+    return {
+        manifest: MANIFEST,
+        entidades: new Map(entities.map((entity) => [entity.id, entity])),
+        sistemas: [],
+        lugares: [],
+        facciones: [],
+        pnjs: [],
+        pistas: [],
+        tramas: [],
+        tablas: [],
+        problemas: [],
+        childrenOf: new Map(),
+        estadoGrupo: null,
+        diario: [],
+    };
+}
+
+const PARTY = { creditos: 800, medidores: { combustible: 2 }, diaMundo: 10 };
+
+const MODEL = makeModel([
+    sistema('sys', 'nucleo', ['central']),
+    lugar('planeta', {
+        en: 'sys',
+        etiquetas: ['pirata'],
+        facciones: [{ faccion: 'consorcio', nivel: 'presente' }],
+        conocimiento: 'visitado',
+    }),
+    lugar('sitio', {
+        en: 'planeta',
+        etiquetas: ['ruina', 'pirata'],
+        facciones: [{ faccion: 'culto', nivel: 'encubierta' }],
+    }),
+    lugar('estacion_borde', { en: 'sys', region: 'frontera' }),
+    pista('deuda', 'en_curso'),
+]);
+
+describe('buildCondContext', () => {
+    test('party numbers pass through', () => {
+        const built = buildCondContext(MODEL, PARTY, null);
+        expect(built.creditos).toBe(800);
+        expect(built.medidores).toEqual({ combustible: 2 });
+        expect(built.diaMundo).toBe(10);
+    });
+
+    test('regionActual walks the en: chain to the nearest region', () => {
+        expect(buildCondContext(MODEL, PARTY, 'sitio').regionActual).toBe('nucleo');
+        expect(buildCondContext(MODEL, PARTY, 'sys').regionActual).toBe('nucleo');
+        // own region wins over the ancestor's
+        expect(buildCondContext(MODEL, PARTY, 'estacion_borde').regionActual).toBe('frontera');
+    });
+
+    test('etiquetasActuales: current place + ancestors, deduplicated', () => {
+        expect(buildCondContext(MODEL, PARTY, 'sitio').etiquetasActuales).toEqual([
+            'ruina',
+            'pirata',
+            'central',
+        ]);
+    });
+
+    test('faccionesActuales: presence at the place or its ancestors', () => {
+        expect(buildCondContext(MODEL, PARTY, 'sitio').faccionesActuales).toEqual([
+            'culto',
+            'consorcio',
+        ]);
+        expect(buildCondContext(MODEL, PARTY, 'planeta').faccionesActuales).toEqual([
+            'consorcio',
+        ]);
+    });
+
+    test('null or unknown current place yields empty place context', () => {
+        for (const id of [null, 'no_existe']) {
+            const built = buildCondContext(MODEL, PARTY, id);
+            expect(built.regionActual).toBeNull();
+            expect(built.etiquetasActuales).toEqual([]);
+            expect(built.faccionesActuales).toEqual([]);
+        }
+    });
+
+    test('pistaEstado closure: Leads only, null otherwise', () => {
+        const built = buildCondContext(MODEL, PARTY, null);
+        expect(built.pistaEstado('deuda')).toBe('en_curso');
+        expect(built.pistaEstado('planeta')).toBeNull(); // exists, not a pista
+        expect(built.pistaEstado('no_existe')).toBeNull();
+    });
+
+    test('lugarConocimiento closure over the entity map', () => {
+        const built = buildCondContext(MODEL, PARTY, null);
+        expect(built.lugarConocimiento('planeta')).toBe('visitado');
+        expect(built.lugarConocimiento('sys')).toBe('visitado');
+        expect(built.lugarConocimiento('no_existe')).toBeNull();
+    });
+
+    test('integrates with evalCondition end to end', () => {
+        const built = buildCondContext(MODEL, PARTY, 'sitio');
+        expect(evalCondition('region:nucleo&etiqueta:pirata&faccion:culto', built)).toBe(true);
+        expect(evalCondition('creditos>=800&combustible<=2', built)).toBe(true);
+        expect(evalCondition('pista:deuda:en_curso&lugar:planeta:conocido', built)).toBe(true);
+        expect(evalCondition('region:frontera', built)).toBe(false);
+    });
+});

--- a/lib/world/conditions.ts
+++ b/lib/world/conditions.ts
@@ -1,0 +1,274 @@
+/**
+ * Condition grammar (plan Part A) — ONE evaluator shared by pista
+ * `requisitos`, event `si` and table `sesgos`:
+ *
+ *     combustible<=1            numeric: creditos / dia / any medidor name,
+ *     creditos>=800             with the operators  <  <=  =  >=  >
+ *     dia>=4160
+ *     region:frontera           party's effective region
+ *     etiqueta:pirata           etiquetas of the current place + its ancestors
+ *     faccion:consorcio_tetrad  faction present at the current place + ancestors
+ *     pista:<id>:<estado>       lead workflow state equals <estado>
+ *     lugar:<id>:<min>          knowledge AT LEAST <min>
+ *                               (desconocido < rumoreado < conocido < visitado)
+ *
+ * Conjunction with `&` (no OR by design — duplicate the owner instead).
+ * Whitespace-tolerant everywhere. NEVER throws.
+ *
+ * Tri-state result: true / false / NULL. Null means "the app cannot evaluate
+ * this" — bad syntax, unknown medidor name, missing pista/lugar id — and the
+ * callers degrade to GM judgment (pista accionable 'manual', event excluded
+ * from automatic draws; both flagged as avisos at scan time). Null DOMINATES
+ * false in every conjunction (evalCondition's `&` and evalConditions alike):
+ * a condition set with an unevaluable member is unevaluable as a whole, never
+ * definitively false — the GM decides, and can override.
+ */
+
+import {
+    CondContext,
+    FactionPresence,
+    Lead,
+    WorldEntityBase,
+    WorldModel,
+} from '@/types/world';
+import { CONOCIMIENTOS, ESTADOS_PISTA } from './constants';
+import { ancestryChain } from './worldNav';
+
+// ── Atom parsing ────────────────────────────────────────────────────────────
+
+type NumericOp = '<' | '<=' | '=' | '>=' | '>';
+
+type CondAtom =
+    | { kind: 'num'; nombre: string; op: NumericOp; valor: number }
+    | { kind: 'region'; tag: string }
+    | { kind: 'etiqueta'; tag: string }
+    | { kind: 'faccion'; id: string }
+    | { kind: 'pista'; id: string; estado: Lead['estadoPista'] }
+    | { kind: 'lugar'; id: string; minimo: (typeof CONOCIMIENTOS)[number] };
+
+/** `nombre <op> N` — name is any run without whitespace/operator/colon chars. */
+const NUMERIC_ATOM = /^([^\s<>=:&|]+)\s*(<=|>=|==|=|<|>)\s*([+-]?\d+(?:\.\d+)?)$/;
+
+const CONOCIMIENTO_RANK = new Map<string, number>(
+    CONOCIMIENTOS.map((nivel, index) => [nivel, index])
+);
+
+/** A colon-form token (id/tag/estado): non-empty, no internal whitespace. */
+function isToken(value: string): boolean {
+    return value !== '' && !/\s/.test(value);
+}
+
+/** One atom of the grammar, or null when it matches no known form. */
+function parseAtom(raw: string): CondAtom | null {
+    const atom = raw.trim();
+    if (atom === '') return null;
+
+    const num = NUMERIC_ATOM.exec(atom);
+    if (num) {
+        const op = num[2] === '==' ? '=' : (num[2] as NumericOp);
+        return { kind: 'num', nombre: num[1], op, valor: Number(num[3]) };
+    }
+
+    const parts = atom.split(':').map((part) => part.trim());
+    switch (parts[0]) {
+        case 'region':
+            if (parts.length === 2 && isToken(parts[1])) {
+                return { kind: 'region', tag: parts[1] };
+            }
+            return null;
+        case 'etiqueta':
+            if (parts.length === 2 && isToken(parts[1])) {
+                return { kind: 'etiqueta', tag: parts[1] };
+            }
+            return null;
+        case 'faccion':
+            if (parts.length === 2 && isToken(parts[1])) {
+                return { kind: 'faccion', id: parts[1] };
+            }
+            return null;
+        case 'pista':
+            if (
+                parts.length === 3 &&
+                isToken(parts[1]) &&
+                (ESTADOS_PISTA as readonly string[]).includes(parts[2])
+            ) {
+                return { kind: 'pista', id: parts[1], estado: parts[2] as Lead['estadoPista'] };
+            }
+            return null;
+        case 'lugar':
+            if (
+                parts.length === 3 &&
+                isToken(parts[1]) &&
+                (CONOCIMIENTOS as readonly string[]).includes(parts[2])
+            ) {
+                return {
+                    kind: 'lugar',
+                    id: parts[1],
+                    minimo: parts[2] as (typeof CONOCIMIENTOS)[number],
+                };
+            }
+            return null;
+        default:
+            return null;
+    }
+}
+
+/**
+ * Syntax-only check (no context): does every `&`-joined atom match a known
+ * grammar form? Used at scan time to aviso bad conditions in pista
+ * `requisitos`, event `si` and table `sesgos`. Note it CANNOT catch
+ * context-dependent nulls (an unknown medidor name parses fine but evaluates
+ * to null against a medidores map that lacks it).
+ */
+export function isParseableCondition(cond: string): boolean {
+    if (cond.trim() === '') return false;
+    return cond.split('&').every((atom) => parseAtom(atom) !== null);
+}
+
+// ── Evaluation ──────────────────────────────────────────────────────────────
+
+function compare(actual: number, op: NumericOp, valor: number): boolean {
+    switch (op) {
+        case '<':
+            return actual < valor;
+        case '<=':
+            return actual <= valor;
+        case '=':
+            return actual === valor;
+        case '>=':
+            return actual >= valor;
+        case '>':
+            return actual > valor;
+    }
+}
+
+function evalAtom(atom: CondAtom, ctx: CondContext): boolean | null {
+    switch (atom.kind) {
+        case 'num': {
+            const actual =
+                atom.nombre === 'creditos'
+                    ? ctx.creditos
+                    : atom.nombre === 'dia'
+                      ? ctx.diaMundo
+                      : ctx.medidores[atom.nombre];
+            if (actual === undefined) return null; // unknown medidor name
+            return compare(actual, atom.op, atom.valor);
+        }
+        case 'region':
+            return ctx.regionActual === atom.tag;
+        case 'etiqueta':
+            return ctx.etiquetasActuales.includes(atom.tag);
+        case 'faccion':
+            return ctx.faccionesActuales.includes(atom.id);
+        case 'pista': {
+            const estado = ctx.pistaEstado(atom.id);
+            if (estado === null) return null; // pista does not exist
+            return estado === atom.estado;
+        }
+        case 'lugar': {
+            const conocimiento = ctx.lugarConocimiento(atom.id);
+            if (conocimiento === null) return null; // lugar does not exist
+            const rank = CONOCIMIENTO_RANK.get(conocimiento);
+            if (rank === undefined) return null;
+            return rank >= (CONOCIMIENTO_RANK.get(atom.minimo) ?? 0);
+        }
+    }
+}
+
+/**
+ * Evaluates one condition string (`&`-conjunctive) against a context.
+ * Returns null when ANY atom is unparseable or unevaluable — even if another
+ * atom is already false (see module doc: null dominates, the GM decides).
+ */
+export function evalCondition(cond: string, ctx: CondContext): boolean | null {
+    const atoms: CondAtom[] = [];
+    for (const raw of cond.split('&')) {
+        const atom = parseAtom(raw);
+        if (atom === null) return null;
+        atoms.push(atom);
+    }
+    if (atoms.length === 0) return null;
+
+    let result = true;
+    for (const atom of atoms) {
+        const value = evalAtom(atom, ctx);
+        if (value === null) return null;
+        if (!value) result = false; // keep scanning: a later null still wins
+    }
+    return result;
+}
+
+/**
+ * AND over a condition list: null if ANY member is null (even when another is
+ * false), else the conjunction. An empty list is vacuously true — gates
+ * without conditions always pass.
+ */
+export function evalConditions(conds: string[], ctx: CondContext): boolean | null {
+    let result = true;
+    for (const cond of conds) {
+        const value = evalCondition(cond, ctx);
+        if (value === null) return null;
+        if (!value) result = false;
+    }
+    return result;
+}
+
+// ── Context construction ────────────────────────────────────────────────────
+
+type PlaceLike = WorldEntityBase & { region?: string; facciones?: FactionPresence[] };
+
+/**
+ * Builds the evaluation context from a world model + the party's live
+ * numbers. The place-derived fields all follow the `en:` ancestry of
+ * `lugarActualId` (cycle-guarded, same walk as the scanner's region
+ * inheritance):
+ *   - regionActual       nearest own/ancestor `region`
+ *   - etiquetasActuales  union of the place's + its ancestors' etiquetas
+ *   - faccionesActuales  faction ids present at the place or its ancestors
+ * A null/unknown current place yields empty place context (region null, no
+ * etiquetas/facciones) — numeric atoms still evaluate.
+ * pistaEstado/lugarConocimiento close over the model's entity map; both
+ * return null for ids that do not resolve.
+ */
+export function buildCondContext(
+    model: WorldModel,
+    party: { creditos: number; medidores: Record<string, number>; diaMundo: number },
+    lugarActualId: string | null
+): CondContext {
+    let regionActual: string | null = null;
+    const etiquetasActuales: string[] = [];
+    const faccionesActuales: string[] = [];
+
+    const chain = lugarActualId === null ? [] : ancestryChain(model, lugarActualId);
+    for (const id of chain) {
+        const entity = model.entidades.get(id) as PlaceLike | undefined;
+        if (!entity) continue;
+        if (regionActual === null && entity.region !== undefined) {
+            regionActual = entity.region;
+        }
+        for (const tag of entity.etiquetas) {
+            if (!etiquetasActuales.includes(tag)) etiquetasActuales.push(tag);
+        }
+        for (const presence of entity.facciones ?? []) {
+            if (!faccionesActuales.includes(presence.faccion)) {
+                faccionesActuales.push(presence.faccion);
+            }
+        }
+    }
+
+    return {
+        creditos: party.creditos,
+        medidores: party.medidores,
+        diaMundo: party.diaMundo,
+        regionActual,
+        etiquetasActuales,
+        faccionesActuales,
+        pistaEstado: (id: string) => {
+            const entity = model.entidades.get(id);
+            return entity !== undefined && 'estadoPista' in entity
+                ? (entity as Lead).estadoPista
+                : null;
+        },
+        lugarConocimiento: (id: string) => model.entidades.get(id)?.conocimiento ?? null,
+    };
+}

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -74,6 +74,14 @@ export const IMAGES_DIR = 'imagenes';
 /** Party-state file inside `mundo/estado/`. */
 export const PARTY_STATE_FILE = 'grupo.md';
 
+/**
+ * Pixels per world coordinate unit on the sector map (1 unit = 1 travel day,
+ * per manifest). Hoisted here so pure map-geometry helpers (worldNav,
+ * threads) can compute map pixels without importing the SectorView React
+ * component; SectorView re-exports it for its existing consumers.
+ */
+export const WORLD_SCALE = 60;
+
 // ── Scanner ignore rules ────────────────────────────────────────────────────
 
 /** Dirs written in ALL-CAPS (e.g. PLANTILLAS) are ignored by the scanner. */

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -164,7 +164,7 @@ export const MANIFEST_DEFAULTS: {
     viaje: {
         diasPorUnidad: 1,
         intrasistemaDias: 1,
-        combustiblePorTramo: 1,
+        combustibleCadaDias: 4,
         viveresCadaDias: 4,
     },
     medidores: ['viveres', 'combustible', 'nave'],

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -45,6 +45,18 @@ export const ENTITY_DIRS = {
 export const PLACE_FOLDER_FILE = 'lugar.md';
 
 /**
+ * Optional shops subfolder inside a place folder `lugares/<id>/tiendas/`: each
+ * `*.md` is one shop (`tipo: tienda`). Absent folder = no shops, no aviso.
+ */
+export const TIENDAS_DIR = 'tiendas';
+
+/**
+ * Optional session-recap file `mundo/resumen.md` (plain markdown, read like the
+ * manifest — one read, never an entity). Absent = no recap, no button.
+ */
+export const RESUMEN_FILE = 'resumen.md';
+
+/**
  * Optional world-level music folder under `mundo/`: audio files at its root
  * are the world BGM rotation, each subfolder a named event playlist. Not an
  * entity dir — its contents are listed (never read) by the scanner.

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -44,6 +44,9 @@ export const ENTITY_DIRS = {
 /** File inside a playable place folder `lugares/<id>/` that holds the entity. */
 export const PLACE_FOLDER_FILE = 'lugar.md';
 
+/** Party-state file inside `mundo/estado/`. */
+export const PARTY_STATE_FILE = 'grupo.md';
+
 // ── Scanner ignore rules ────────────────────────────────────────────────────
 
 /** Dirs written in ALL-CAPS (e.g. PLANTILLAS) are ignored by the scanner. */
@@ -145,6 +148,13 @@ export const ACCESOS: readonly PlaceEntity['acceso'][] = [
 export const DEFAULT_CONOCIMIENTO: Conocimiento = 'desconocido';
 
 export const DEFAULT_ACCESO: PlaceEntity['acceso'] = 'normal';
+
+/** Gauge defaults when estado/grupo.md omits `medidores` (or single entries). */
+export const DEFAULT_MEDIDORES: Readonly<Record<string, number>> = {
+    viveres: 3,
+    combustible: 3,
+    nave: 3,
+};
 
 /** Fallbacks when mundo.md omits travel constants or gauges. */
 export const MANIFEST_DEFAULTS: {

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -57,6 +57,19 @@ export const TIENDAS_DIR = 'tiendas';
 export const RESUMEN_FILE = 'resumen.md';
 
 /**
+ * Curated GM play-aid ("guía") files at the `mundo/` root: an explicit
+ * allowlist so unrelated design docs never leak into the header menu. Each is
+ * OPTIONAL and read like the manifest/resumen (one read, tolerant, never an
+ * entity); an absent file is simply skipped. `titulo` is the fallback display
+ * title when the file has no leading `# heading`.
+ */
+export const GUIA_FILES: readonly { file: string; titulo: string }[] = [
+    { file: '_RUN_OF_SHOW.md', titulo: 'Run of Show' },
+    { file: '_MAPA_DE_HILOS.md', titulo: 'Mapa de Hilos' },
+    { file: '_REPARTO_DE_MANANA.md', titulo: 'Reparto de hoy' },
+];
+
+/**
  * Optional world-level music folder under `mundo/`: audio files at its root
  * are the world BGM rotation, each subfolder a named event playlist. Not an
  * entity dir — its contents are listed (never read) by the scanner.

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -51,6 +51,14 @@ export const PLACE_FOLDER_FILE = 'lugar.md';
  */
 export const MUSIC_DIR = 'musica';
 
+/**
+ * Optional entity profile-image folder under `mundo/`: a file named
+ * `<entity_id>.<ext>` (any supported image extension) is the profile image of
+ * the entity with that id. Not an entity dir — its contents are listed (never
+ * read) by the scanner.
+ */
+export const IMAGES_DIR = 'imagenes';
+
 /** Party-state file inside `mundo/estado/`. */
 export const PARTY_STATE_FILE = 'grupo.md';
 

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -44,6 +44,13 @@ export const ENTITY_DIRS = {
 /** File inside a playable place folder `lugares/<id>/` that holds the entity. */
 export const PLACE_FOLDER_FILE = 'lugar.md';
 
+/**
+ * Optional world-level music folder under `mundo/`: audio files at its root
+ * are the world BGM rotation, each subfolder a named event playlist. Not an
+ * entity dir — its contents are listed (never read) by the scanner.
+ */
+export const MUSIC_DIR = 'musica';
+
 /** Party-state file inside `mundo/estado/`. */
 export const PARTY_STATE_FILE = 'grupo.md';
 

--- a/lib/world/constants.ts
+++ b/lib/world/constants.ts
@@ -1,0 +1,161 @@
+/**
+ * World-mode domain constants: folder layout, scanner ignore rules,
+ * closed vocabularies and defaults. Spanish domain values, English identifiers.
+ */
+
+import {
+    Conocimiento,
+    FactionEntity,
+    FactionPresence,
+    Lead,
+    NpcEntity,
+    PlaceEntity,
+    Trama,
+    WorldManifest,
+} from '@/types/world';
+
+// ── Folder layout ───────────────────────────────────────────────────────────
+
+/** Root folder inside the campaign folder; its presence activates world mode. */
+export const WORLD_DIR = 'mundo';
+
+/** World manifest, at `mundo/mundo.md`. */
+export const MANIFEST_FILE = 'mundo.md';
+
+/** Agent maintenance-loop instructions — never scanned as an entity. */
+export const PROTOCOL_FILE = 'PROTOCOLO.md';
+
+/** Templates dir (ignored by the scanner via the ALL-CAPS rule). */
+export const TEMPLATES_DIR = 'PLANTILLAS';
+
+/** Entity/state directory names under `mundo/`. */
+export const ENTITY_DIRS = {
+    sistemas: 'sistemas',
+    lugares: 'lugares',
+    facciones: 'facciones',
+    pnjs: 'pnjs',
+    pistas: 'pistas',
+    tramas: 'tramas',
+    eventos: 'eventos',
+    estado: 'estado',
+    diario: 'diario',
+} as const;
+
+/** File inside a playable place folder `lugares/<id>/` that holds the entity. */
+export const PLACE_FOLDER_FILE = 'lugar.md';
+
+// ── Scanner ignore rules ────────────────────────────────────────────────────
+
+/** Dirs written in ALL-CAPS (e.g. PLANTILLAS) are ignored by the scanner. */
+export function isIgnoredDir(name: string): boolean {
+    return name === name.toUpperCase() && name !== name.toLowerCase();
+}
+
+/** Files starting with `_` and PROTOCOLO.md are ignored by the scanner. */
+export function isIgnoredFile(name: string): boolean {
+    return name.startsWith('_') || name === PROTOCOL_FILE;
+}
+
+// ── Closed vocabularies ─────────────────────────────────────────────────────
+
+export const CONOCIMIENTOS: readonly Conocimiento[] = [
+    'desconocido',
+    'rumoreado',
+    'conocido',
+    'visitado',
+];
+
+export const SERVICIOS: readonly string[] = [
+    'repostaje',
+    'mercado',
+    'medico',
+    'taller',
+    'astillero',
+    'trabajo',
+    'informacion',
+    'ocio',
+    'refugio',
+    'contrabando',
+];
+
+/** Recommended `tipo:` values for lugares — open list (out-of-vocab is only a warning). */
+export const TIPOS_LUGAR: readonly string[] = [
+    'planeta',
+    'luna',
+    'cinturon',
+    'estacion',
+    'ciudad',
+    'estructura',
+    'ruina',
+    'nodo',
+    'bolsillo',
+    'punto',
+];
+
+export const NIVELES_PRESENCIA: readonly FactionPresence['nivel'][] = [
+    'dominante',
+    'fuerte',
+    'presente',
+    'encubierta',
+];
+
+export const ACTITUDES: readonly FactionEntity['actitud'][] = [
+    'hostil',
+    'rival',
+    'neutral',
+    'aliada',
+];
+
+export const ROLES_PNJ: readonly NpcEntity['rol'][] = [
+    'villano',
+    'aliado',
+    'comodin',
+    'contacto',
+    'neutral',
+];
+
+export const ESTADOS_PISTA: readonly Lead['estadoPista'][] = [
+    'rumor',
+    'activa',
+    'en_curso',
+    'resuelta',
+    'fallida',
+];
+
+export const ROLES_TRAMA: readonly Trama['rol'][] = [
+    'principal',
+    'secundaria',
+    'ambiental',
+];
+
+export const ESTADOS_TRAMA: readonly Trama['estadoTrama'][] = [
+    'latente',
+    'activa',
+    'cerrada',
+];
+
+export const ACCESOS: readonly PlaceEntity['acceso'][] = [
+    'normal',
+    'portal',
+    'restringido',
+];
+
+// ── Defaults ────────────────────────────────────────────────────────────────
+
+export const DEFAULT_CONOCIMIENTO: Conocimiento = 'desconocido';
+
+export const DEFAULT_ACCESO: PlaceEntity['acceso'] = 'normal';
+
+/** Fallbacks when mundo.md omits travel constants or gauges. */
+export const MANIFEST_DEFAULTS: {
+    viaje: WorldManifest['viaje'];
+    medidores: readonly string[];
+} = {
+    viaje: {
+        diasPorUnidad: 1,
+        intrasistemaDias: 1,
+        combustiblePorTramo: 1,
+        viveresCadaDias: 4,
+    },
+    medidores: ['viveres', 'combustible', 'nave'],
+};

--- a/lib/world/deepLink.test.ts
+++ b/lib/world/deepLink.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun-types" />
+import { test, expect, describe, afterEach } from 'bun:test';
+import { readEntityFromUrl, writeEntityToUrl } from './deepLink';
+
+/**
+ * Minimal window stub — bun tests run without a DOM. Captures the URL passed
+ * to history.replaceState and the state object forwarded through.
+ */
+function installWindow(href: string) {
+    const captured: { url: string | null; state: unknown } = { url: null, state: undefined };
+    const parsed = new URL(href);
+    const stub = {
+        location: { href, search: parsed.search },
+        history: {
+            state: { nextInternal: true },
+            replaceState(state: unknown, _unused: string, url?: string | null) {
+                captured.state = state;
+                captured.url = url ?? null;
+            },
+        },
+    };
+    Object.defineProperty(globalThis, 'window', {
+        value: stub,
+        configurable: true,
+        writable: true,
+    });
+    return captured;
+}
+
+function removeWindow() {
+    delete (globalThis as { window?: unknown }).window;
+}
+
+afterEach(removeWindow);
+
+describe('readEntityFromUrl', () => {
+    test('reads ?e= from the current URL', () => {
+        installWindow('https://app.test/world?e=porto_verne');
+        expect(readEntityFromUrl()).toBe('porto_verne');
+    });
+
+    test('null when the param is absent or empty', () => {
+        installWindow('https://app.test/world');
+        expect(readEntityFromUrl()).toBeNull();
+        installWindow('https://app.test/world?e=');
+        expect(readEntityFromUrl()).toBeNull();
+    });
+
+    test('coexists with other query params', () => {
+        installWindow('https://app.test/world?foo=bar&e=kovar_iii');
+        expect(readEntityFromUrl()).toBe('kovar_iii');
+    });
+
+    test('SSR-guarded: returns null without a window', () => {
+        removeWindow();
+        expect(readEntityFromUrl()).toBeNull();
+    });
+});
+
+describe('writeEntityToUrl', () => {
+    test('sets ?e= via history.replaceState, preserving other params and state', () => {
+        const captured = installWindow('https://app.test/world?foo=bar');
+        writeEntityToUrl('porto_verne');
+        expect(captured.url).toBe('https://app.test/world?foo=bar&e=porto_verne');
+        expect(captured.state).toEqual({ nextInternal: true });
+    });
+
+    test('null removes the param', () => {
+        const captured = installWindow('https://app.test/world?e=porto_verne&foo=bar');
+        writeEntityToUrl(null);
+        expect(captured.url).toBe('https://app.test/world?foo=bar');
+    });
+
+    test('overwrites an existing selection', () => {
+        const captured = installWindow('https://app.test/world?e=old_id');
+        writeEntityToUrl('new_id');
+        expect(captured.url).toBe('https://app.test/world?e=new_id');
+    });
+
+    test('SSR-guarded: no-op without a window', () => {
+        removeWindow();
+        expect(() => writeEntityToUrl('porto_verne')).not.toThrow();
+    });
+});

--- a/lib/world/deepLink.ts
+++ b/lib/world/deepLink.ts
@@ -1,0 +1,36 @@
+/**
+ * Entity deep-link plumbing for /world (plan Part B: "selection deep-linked
+ * `?e=<id>` via history.replaceState").
+ *
+ * Static-export-safe on purpose: no next/router (dynamic segments don't
+ * exist in a static export) — plain History API only. Both functions are
+ * SSR-guarded and no-op/return null without a window, so they can be called
+ * from anywhere including module-level effects.
+ */
+
+/** Query param carrying the selected entity id. */
+export const ENTITY_PARAM = 'e';
+
+/** Reads the selected entity id from `?e=` in the current URL (null if absent/empty/SSR). */
+export function readEntityFromUrl(): string | null {
+    if (typeof window === 'undefined') return null;
+    const value = new URLSearchParams(window.location.search).get(ENTITY_PARAM);
+    return value !== null && value !== '' ? value : null;
+}
+
+/**
+ * Writes (id) or removes (null) `?e=` in the current URL without adding a
+ * history entry. Other query params and the hash are preserved, and the
+ * current history.state is passed through untouched (Next's App Router
+ * keeps internal state there — clobbering it breaks back/forward).
+ */
+export function writeEntityToUrl(id: string | null): void {
+    if (typeof window === 'undefined') return;
+    const url = new URL(window.location.href);
+    if (id === null) {
+        url.searchParams.delete(ENTITY_PARAM);
+    } else {
+        url.searchParams.set(ENTITY_PARAM, id);
+    }
+    window.history.replaceState(window.history.state, '', url.toString());
+}

--- a/lib/world/eventEngine.test.ts
+++ b/lib/world/eventEngine.test.ts
@@ -4,6 +4,7 @@ import {
     applicableTables,
     drawEvent,
     eventSeenCounts,
+    extractEfectos,
     parseEventAttrs,
     parseEventTable,
 } from './eventEngine';
@@ -128,6 +129,46 @@ describe('parseEventTable', () => {
         const v02 = parsed.table.eventos[1];
         expect(v02.efectos).toEqual([]);
         expect(v02.cuerpo).toContain(':::gm');
+    });
+
+    // Direct coverage of the ONE grammar the ActRunner reuses to lift an act's
+    // declared :::efecto state-transitions out of its plan file.
+    test('extractEfectos: act plan block -> EventEffect[] + stripped cuerpo', () => {
+        const plan = `# ACTO 2
+
+:::gm
+Recordatorios del acto.
+:::
+
+:::efecto
+- pista: nodo_x rumor->activa | enciende el nodo
+- sabe: nodo_central conocido
+- ganancia: 150
+:::
+
+:::leer
+Texto para leer.
+:::
+`;
+        const { cuerpoLines, efectos } = extractEfectos(plan.split(/\r?\n/));
+        expect(efectos).toEqual([
+            { key: 'pista', value: 'nodo_x rumor->activa | enciende el nodo' },
+            { key: 'sabe', value: 'nodo_central conocido' },
+            { key: 'ganancia', value: '150' },
+        ]);
+        const cuerpo = cuerpoLines.join('\n');
+        expect(cuerpo).toContain(':::gm');
+        expect(cuerpo).toContain(':::leer');
+        expect(cuerpo).not.toContain(':::efecto');
+        expect(cuerpo).not.toContain('nodo_x rumor->activa');
+    });
+
+    test('extractEfectos: no :::efecto block -> empty effects, cuerpo intact', () => {
+        const { cuerpoLines, efectos } = extractEfectos(
+            ':::leer\nSolo narrativa.\n:::'.split(/\r?\n/)
+        );
+        expect(efectos).toEqual([]);
+        expect(cuerpoLines.join('\n')).toContain('Solo narrativa.');
     });
 
     test('bad si: aviso but the event is KEPT', () => {

--- a/lib/world/eventEngine.test.ts
+++ b/lib/world/eventEngine.test.ts
@@ -3,6 +3,7 @@ import { test, expect, describe } from 'bun:test';
 import {
     applicableTables,
     drawEvent,
+    eventSeenCounts,
     parseEventAttrs,
     parseEventTable,
 } from './eventEngine';
@@ -225,6 +226,50 @@ describe('parseEventTable', () => {
         expect(result.table.eventos[0].peso).toBe(1);
         expect(result.issues.some((issue) => issue.mensaje.includes('"peso"'))).toBe(true);
     });
+
+    test('unico: bare token -> true, absent -> false', () => {
+        const result = parseEventTable(
+            '---\ncontexto: viaje\n---\n' +
+                '## v01 — Solo una vez {peso=2; unico; etiquetas=rumor}\n\nCuerpo.\n\n' +
+                '## v02 — Recurrente {peso=1}\n\nOtro.\n',
+            'mundo/eventos/t.md',
+            't'
+        );
+        const [v01, v02] = result.table.eventos;
+        expect(v01.unico).toBe(true);
+        expect(v01.peso).toBe(2); // the bare token does not disturb the other attrs
+        expect(v01.etiquetas).toEqual(['rumor']);
+        expect(v02.unico).toBe(false);
+    });
+});
+
+// ── eventSeenCounts ──────────────────────────────────────────────────────────
+
+describe('eventSeenCounts', () => {
+    test('tallies <tabla>#<id> payloads, ignoring the outcome suffix', () => {
+        const counts = eventSeenCounts([
+            'viaje_frontera#v01',
+            'viaje_frontera#v01 | resuelto',
+            'viaje_frontera#v02',
+            'estancia_porto#e01 | complicación: fuga',
+        ]);
+        expect(counts.get('viaje_frontera#v01')).toBe(2);
+        expect(counts.get('viaje_frontera#v02')).toBe(1);
+        expect(counts.get('estancia_porto#e01')).toBe(1);
+        expect(counts.size).toBe(3);
+    });
+
+    test('accepts full `evento:` lines and ignores non-evento payloads', () => {
+        const counts = eventSeenCounts([
+            'evento: viaje_frontera#v01',
+            'evento: viaje_frontera#v01 | ignorado',
+            'no es un payload de evento',
+            'gasto: 100',
+            '',
+        ]);
+        expect(counts.get('viaje_frontera#v01')).toBe(2);
+        expect(counts.size).toBe(1);
+    });
 });
 
 // ── applicableTables ────────────────────────────────────────────────────────
@@ -248,7 +293,17 @@ function tabla(id: string, overrides: Partial<EventTable> = {}): EventTable {
 }
 
 function evento(id: string, overrides: Partial<WorldEvent> = {}): WorldEvent {
-    return { id, titulo: id, peso: 1, si: [], etiquetas: [], cuerpo: '', efectos: [], ...overrides };
+    return {
+        id,
+        titulo: id,
+        peso: 1,
+        si: [],
+        etiquetas: [],
+        unico: false,
+        cuerpo: '',
+        efectos: [],
+        ...overrides,
+    };
 }
 
 describe('applicableTables', () => {
@@ -401,5 +456,77 @@ describe('drawEvent', () => {
     test('defensive: an rng returning 1 falls back to the last pool entry', () => {
         const table = tabla('t', { eventos: [evento('a'), evento('b')] });
         expect(drawEvent([table], ctx(), () => 1)!.event.id).toBe('b');
+    });
+
+    // ── history model (seenCounts) ────────────────────────────────────────────
+
+    test('an omitted seenCounts is exactly the pre-history behavior', () => {
+        const table = tabla('t', {
+            eventos: [evento('a', { peso: 1, unico: true }), evento('b', { peso: 3 })],
+        });
+        // total 4: a owns [0,1), b owns [1,4) — same as the weighted test above.
+        expect(drawEvent([table], ctx(), () => 0)!.event.id).toBe('a');
+        expect(drawEvent([table], ctx(), () => 0.5)!.event.id).toBe('b');
+    });
+
+    test('a seen unico event is never returned (swept across the whole range)', () => {
+        const table = tabla('t', {
+            eventos: [evento('once', { peso: 5, unico: true }), evento('rep', { peso: 1 })],
+        });
+        const seen = new Map([['t#once', 1]]);
+        // Without exclusion 'once' would own [0,5) of 6 — dominate almost every
+        // roll. With it seen+unico, only 'rep' can ever come out.
+        for (let i = 0; i <= 20; i++) {
+            const roll = i / 21; // 0 .. ~0.95
+            const drawn = drawEvent([table], ctx(), () => roll, seen);
+            expect(drawn!.event.id).toBe('rep');
+        }
+    });
+
+    test('an UNSEEN unico event still draws normally', () => {
+        const table = tabla('t', {
+            eventos: [evento('once', { peso: 5, unico: true }), evento('rep', { peso: 1 })],
+        });
+        // Empty tally: 'once' is eligible and (weight 5 of 6) dominates.
+        expect(drawEvent([table], ctx(), () => 0.1, new Map())!.event.id).toBe('once');
+    });
+
+    test('a seen non-unico event is decayed but still possible', () => {
+        // peso 9, seen 2 -> effective round(9 / 3) = 3; paired with a fresh
+        // peso-1 event the decayed one owns [0,3) of 4 and the fresh one [3,4).
+        const table = tabla('t', {
+            eventos: [evento('warhorse', { peso: 9 }), evento('fresh', { peso: 1 })],
+        });
+        const seen = new Map([['t#warhorse', 2]]);
+        // Still reachable...
+        expect(drawEvent([table], ctx(), () => 0.1, seen)!.event.id).toBe('warhorse');
+        // ...but the fresh event now owns the tail it never would at 9/1.
+        expect(drawEvent([table], ctx(), () => 0.9, seen)!.event.id).toBe('fresh');
+        // Decay floors at 1, never 0 (huge seen count still leaves it drawable).
+        const buried = new Map([['t#warhorse', 999]]);
+        const onlyOne = tabla('t', { eventos: [evento('warhorse', { peso: 9 })] });
+        expect(drawEvent([onlyOne], ctx(), () => 0.5, buried)!.event.id).toBe('warhorse');
+    });
+
+    test('all-unico-seen falls back to the full pool (never a dead-end)', () => {
+        const table = tabla('t', {
+            eventos: [
+                evento('u1', { peso: 2, unico: true }),
+                evento('u2', { peso: 2, unico: true }),
+            ],
+        });
+        const seen = new Map([
+            ['t#u1', 1],
+            ['t#u2', 1],
+        ]);
+        // Both eligible events are unico-and-seen -> live pool empty -> fall
+        // back to the pre-exclusion pool so SOMETHING still comes out.
+        const drawn = drawEvent([table], ctx(), () => 0.5, seen);
+        expect(drawn).not.toBeNull();
+        expect(['u1', 'u2']).toContain(drawn!.event.id);
+    });
+
+    test('empty pool stays null even with a seen tally', () => {
+        expect(drawEvent([], ctx(), () => 0, new Map([['t#a', 1]]))).toBeNull();
     });
 });

--- a/lib/world/eventEngine.test.ts
+++ b/lib/world/eventEngine.test.ts
@@ -1,0 +1,405 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import {
+    applicableTables,
+    drawEvent,
+    parseEventAttrs,
+    parseEventTable,
+} from './eventEngine';
+import { CondContext, EventTable, WorldEvent } from '@/types/world';
+
+// ── parseEventAttrs ─────────────────────────────────────────────────────────
+
+describe('parseEventAttrs', () => {
+    test('splits attrs on ; and key/value on the FIRST = only', () => {
+        expect(parseEventAttrs('{peso=3; si=combustible<=1; etiquetas=recurso,averia}')).toEqual({
+            peso: '3',
+            si: 'combustible<=1', // the <= survives (actFormat parseAttrs would break it)
+            etiquetas: 'recurso,averia',
+        });
+        expect(parseEventAttrs('a=b=c')).toEqual({ a: 'b=c' });
+        expect(parseEventAttrs('si=creditos>=800&dia>=5')).toEqual({
+            si: 'creditos>=800&dia>=5',
+        });
+    });
+
+    test('whitespace-tolerant and brace-optional', () => {
+        expect(parseEventAttrs('{ peso = 2 ;  si = dia >= 5 }')).toEqual({
+            peso: '2',
+            si: 'dia >= 5',
+        });
+        expect(parseEventAttrs('peso=1')).toEqual({ peso: '1' });
+    });
+
+    test('a key without = gets the value "true"', () => {
+        expect(parseEventAttrs('{unico; peso=1}')).toEqual({ unico: 'true', peso: '1' });
+    });
+
+    test('empty input and empty parts', () => {
+        expect(parseEventAttrs('')).toEqual({});
+        expect(parseEventAttrs('{}')).toEqual({});
+        expect(parseEventAttrs('{; ;}')).toEqual({});
+    });
+});
+
+// ── parseEventTable ─────────────────────────────────────────────────────────
+
+const TABLE_MD = `---
+tipo: eventos
+nombre: Viajes por la frontera
+contexto: viaje
+regiones: [frontera, nucleo]
+sesgos:
+  - {si: combustible<=1, etiquetas: [averia], peso: 2}
+  - {si: esto no parsea, etiquetas: [social], peso: 1}
+---
+Texto introductorio de la tabla.
+
+## v01 — Baliza de socorro {peso=3; si=region:frontera&combustible<=2; etiquetas=recurso, social}
+
+:::leer
+Una baliza parpadea en el vacio.
+:::
+
+:::efecto
+- ganancia: 400 | chatarra recuperada
+- medidor: combustible -1
+sigue en la linea anterior
+:::
+
+Texto tras el efecto.
+
+## v02 — Fallo de motor {etiquetas=averia}
+
+:::gm
+Tirada de nave CD 17.
+:::
+
+## v03 — Encuentro raro {si=cuando quiera el GM}
+
+Cuerpo del encuentro.
+
+## rotura sin patron
+
+Perdido.
+`;
+
+describe('parseEventTable', () => {
+    const parsed = parseEventTable(TABLE_MD, 'mundo/eventos/viaje_frontera.md', 'viaje_frontera');
+
+    test('frontmatter: contexto, regiones, sesgos (bad sesgo si kept + aviso)', () => {
+        expect(parsed.table.id).toBe('viaje_frontera');
+        expect(parsed.table.nombre).toBe('Viajes por la frontera');
+        expect(parsed.table.contexto).toBe('viaje');
+        expect(parsed.table.regiones).toEqual(['frontera', 'nucleo']);
+        expect(parsed.table.sesgos).toEqual([
+            { si: 'combustible<=1', etiquetas: ['averia'], peso: 2 },
+            { si: 'esto no parsea', etiquetas: ['social'], peso: 1 },
+        ]);
+    });
+
+    test('events from ## id — titulo {attrs} sections', () => {
+        expect(parsed.table.eventos.map((e) => e.id)).toEqual(['v01', 'v02', 'v03']);
+        const v01 = parsed.table.eventos[0];
+        expect(v01.titulo).toBe('Baliza de socorro');
+        expect(v01.peso).toBe(3);
+        expect(v01.si).toEqual(['region:frontera', 'combustible<=2']); // & split
+        expect(v01.etiquetas).toEqual(['recurso', 'social']);
+
+        const v02 = parsed.table.eventos[1];
+        expect(v02.peso).toBe(1); // default
+        expect(v02.si).toEqual([]);
+        expect(v02.etiquetas).toEqual(['averia']);
+    });
+
+    test(':::efecto extracted as fields and stripped from the cuerpo', () => {
+        const v01 = parsed.table.eventos[0];
+        expect(v01.efectos).toEqual([
+            { key: 'ganancia', value: '400 | chatarra recuperada' },
+            { key: 'medidor', value: 'combustible -1 sigue en la linea anterior' },
+        ]);
+        expect(v01.cuerpo).toContain(':::leer');
+        expect(v01.cuerpo).toContain('Una baliza parpadea');
+        expect(v01.cuerpo).toContain('Texto tras el efecto.');
+        expect(v01.cuerpo).not.toContain(':::efecto');
+        expect(v01.cuerpo).not.toContain('ganancia:');
+
+        const v02 = parsed.table.eventos[1];
+        expect(v02.efectos).toEqual([]);
+        expect(v02.cuerpo).toContain(':::gm');
+    });
+
+    test('bad si: aviso but the event is KEPT', () => {
+        const v03 = parsed.table.eventos[2];
+        expect(v03.si).toEqual(['cuando quiera el GM']);
+        expect(
+            parsed.issues.some(
+                (issue) =>
+                    issue.nivel === 'aviso' &&
+                    issue.mensaje.includes('Condición no interpretable en "si"') &&
+                    issue.mensaje.includes('v03')
+            )
+        ).toBe(true);
+    });
+
+    test('bad heading: aviso, section dropped', () => {
+        expect(parsed.table.eventos.some((e) => e.id === 'rotura')).toBe(false);
+        expect(
+            parsed.issues.some(
+                (issue) =>
+                    issue.nivel === 'aviso' &&
+                    issue.mensaje.includes('Encabezado de evento no interpretable') &&
+                    issue.mensaje.includes('rotura sin patron')
+            )
+        ).toBe(true);
+    });
+
+    test('issue inventory: sesgo + v03 si + heading = 3 avisos', () => {
+        expect(parsed.issues).toHaveLength(3);
+        expect(parsed.issues.every((issue) => issue.nivel === 'aviso')).toBe(true);
+        expect(
+            parsed.issues.every((issue) => issue.archivo === 'mundo/eventos/viaje_frontera.md')
+        ).toBe(true);
+    });
+
+    test('missing contexto: aviso + ambas', () => {
+        const result = parseEventTable('---\nregiones: []\n---\n', 'mundo/eventos/t.md', 't');
+        expect(result.table.contexto).toBe('ambas');
+        expect(result.issues.some((issue) => issue.mensaje.includes('Falta "contexto"'))).toBe(
+            true
+        );
+    });
+
+    test('out-of-vocabulary contexto: aviso + ambas', () => {
+        const result = parseEventTable(
+            '---\ncontexto: siempre\n---\n',
+            'mundo/eventos/t.md',
+            't'
+        );
+        expect(result.table.contexto).toBe('ambas');
+        expect(result.issues.some((issue) => issue.mensaje.includes('"siempre"'))).toBe(true);
+    });
+
+    test('malformed YAML degrades: error issue, table still loads', () => {
+        const result = parseEventTable(
+            '---\nnombre: "sin cierre\n---\n## v01 — Algo\n\nCuerpo.\n',
+            'mundo/eventos/rota.md',
+            'rota'
+        );
+        expect(
+            result.issues.some(
+                (issue) => issue.nivel === 'error' && issue.mensaje.includes('YAML inválido')
+            )
+        ).toBe(true);
+        expect(result.table.nombre).toBe('Rota'); // filename fallback
+        expect(result.table.eventos.map((e) => e.id)).toEqual(['v01']);
+    });
+
+    test('sesgos that is not a list: aviso + ignored', () => {
+        const result = parseEventTable(
+            '---\ncontexto: viaje\nsesgos: nope\n---\n',
+            'mundo/eventos/t.md',
+            't'
+        );
+        expect(result.table.sesgos).toEqual([]);
+        expect(result.issues.some((issue) => issue.mensaje.includes('"sesgos"'))).toBe(true);
+    });
+
+    test('duplicate event id: first wins + aviso', () => {
+        const result = parseEventTable(
+            '---\ncontexto: viaje\n---\n## v01 — Primero\n\nA.\n\n## v01 — Segundo\n\nB.\n',
+            'mundo/eventos/t.md',
+            't'
+        );
+        expect(result.table.eventos).toHaveLength(1);
+        expect(result.table.eventos[0].titulo).toBe('Primero');
+        expect(result.issues.some((issue) => issue.mensaje.includes('duplicado'))).toBe(true);
+    });
+
+    test('non-numeric peso: aviso + default 1', () => {
+        const result = parseEventTable(
+            '---\ncontexto: viaje\n---\n## v01 — Algo {peso=mucho}\n',
+            'mundo/eventos/t.md',
+            't'
+        );
+        expect(result.table.eventos[0].peso).toBe(1);
+        expect(result.issues.some((issue) => issue.mensaje.includes('"peso"'))).toBe(true);
+    });
+});
+
+// ── applicableTables ────────────────────────────────────────────────────────
+
+function tabla(id: string, overrides: Partial<EventTable> = {}): EventTable {
+    return {
+        id,
+        tipo: 'eventos',
+        nombre: id,
+        filePath: `mundo/eventos/${id}.md`,
+        conocimiento: 'desconocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        contexto: 'ambas',
+        regiones: [],
+        sesgos: [],
+        eventos: [],
+        ...overrides,
+    };
+}
+
+function evento(id: string, overrides: Partial<WorldEvent> = {}): WorldEvent {
+    return { id, titulo: id, peso: 1, si: [], etiquetas: [], cuerpo: '', efectos: [], ...overrides };
+}
+
+describe('applicableTables', () => {
+    const viaje = tabla('t_viaje', { contexto: 'viaje' });
+    const estancia = tabla('t_estancia', { contexto: 'estancia' });
+    const ambas = tabla('t_ambas', { contexto: 'ambas' });
+    const frontera = tabla('t_frontera', { contexto: 'viaje', regiones: ['frontera'] });
+    const all = [viaje, estancia, ambas, frontera];
+
+    test('contexto gate: exact match or ambas', () => {
+        expect(applicableTables(all, 'viaje', 'frontera').map((t) => t.id)).toEqual([
+            't_viaje',
+            't_ambas',
+            't_frontera',
+        ]);
+        expect(applicableTables(all, 'estancia', 'frontera').map((t) => t.id)).toEqual([
+            't_estancia',
+            't_ambas',
+        ]);
+    });
+
+    test('regiones gate: empty = universal, else must include the current region', () => {
+        expect(applicableTables([frontera], 'viaje', 'nucleo')).toEqual([]);
+        expect(applicableTables([frontera], 'viaje', 'frontera')).toEqual([frontera]);
+    });
+
+    test('null region only matches universal tables', () => {
+        expect(applicableTables(all, 'viaje', null).map((t) => t.id)).toEqual([
+            't_viaje',
+            't_ambas',
+        ]);
+    });
+});
+
+// ── drawEvent ───────────────────────────────────────────────────────────────
+
+function ctx(overrides: Partial<CondContext> = {}): CondContext {
+    return {
+        creditos: 500,
+        medidores: { viveres: 3, combustible: 3, nave: 3 },
+        diaMundo: 100,
+        regionActual: 'frontera',
+        etiquetasActuales: [],
+        faccionesActuales: [],
+        pistaEstado: () => null,
+        lugarConocimiento: () => null,
+        ...overrides,
+    };
+}
+
+describe('drawEvent', () => {
+    test('empty pool is null (no tables / every si fails)', () => {
+        expect(drawEvent([], ctx(), () => 0)).toBeNull();
+        const table = tabla('t', {
+            eventos: [evento('a', { si: ['creditos>=99999'] })],
+        });
+        expect(drawEvent([table], ctx(), () => 0)).toBeNull();
+    });
+
+    test('si filters the pool; null-si events are excluded silently', () => {
+        const table = tabla('t', {
+            eventos: [
+                evento('gated_out', { si: ['creditos>=99999'] }),
+                evento('unevaluable', { si: ['esto no parsea'] }),
+                evento('ok', { si: ['creditos>=100', 'region:frontera'] }),
+            ],
+        });
+        // Whatever the roll, only 'ok' can come out.
+        for (const roll of [0, 0.5, 0.99]) {
+            const drawn = drawEvent([table], ctx(), () => roll);
+            expect(drawn).not.toBeNull();
+            expect(drawn!.event.id).toBe('ok');
+            expect(drawn!.table.id).toBe('t');
+        }
+    });
+
+    test('weighted draw: deterministic picks across the cumulative ranges', () => {
+        const table = tabla('t', {
+            eventos: [evento('a', { peso: 1 }), evento('b', { peso: 3 })],
+        });
+        // total 4: a owns [0,1), b owns [1,4)
+        expect(drawEvent([table], ctx(), () => 0)!.event.id).toBe('a');
+        expect(drawEvent([table], ctx(), () => 0.24)!.event.id).toBe('a');
+        expect(drawEvent([table], ctx(), () => 0.26)!.event.id).toBe('b');
+        expect(drawEvent([table], ctx(), () => 0.99)!.event.id).toBe('b');
+    });
+
+    test('pool spans several tables', () => {
+        const t1 = tabla('t1', { eventos: [evento('a')] });
+        const t2 = tabla('t2', { eventos: [evento('b')] });
+        expect(drawEvent([t1, t2], ctx(), () => 0.1)!.table.id).toBe('t1');
+        expect(drawEvent([t1, t2], ctx(), () => 0.9)!.table.id).toBe('t2');
+    });
+
+    test('sesgo shifts the distribution when its si holds and etiquetas overlap', () => {
+        const table = tabla('t', {
+            sesgos: [{ si: 'combustible<=1', etiquetas: ['averia'], peso: 4 }],
+            eventos: [
+                evento('averia_evt', { peso: 1, etiquetas: ['averia'] }),
+                evento('otro_evt', { peso: 1, etiquetas: ['social'] }),
+            ],
+        });
+        // Same roll, different fuel: sesgo inactive -> weights 1/1 -> 'otro_evt';
+        // fuel low -> weights 5/1 -> the SAME roll now lands on 'averia_evt'.
+        const fullTank = ctx();
+        const lowTank = ctx({ medidores: { viveres: 3, combustible: 1, nave: 3 } });
+        expect(drawEvent([table], fullTank, () => 0.5)!.event.id).toBe('otro_evt');
+        expect(drawEvent([table], lowTank, () => 0.5)!.event.id).toBe('averia_evt');
+        // and the tail of the range still reaches 'otro_evt' (weight 1 of 6)
+        expect(drawEvent([table], lowTank, () => 0.9)!.event.id).toBe('otro_evt');
+    });
+
+    test('sesgo without a shared etiqueta never applies', () => {
+        const table = tabla('t', {
+            sesgos: [{ si: 'combustible<=1', etiquetas: ['pirata'], peso: 10 }],
+            eventos: [
+                evento('a', { peso: 1, etiquetas: ['averia'] }),
+                evento('b', { peso: 1, etiquetas: [] }),
+            ],
+        });
+        const lowTank = ctx({ medidores: { viveres: 3, combustible: 1, nave: 3 } });
+        // weights stay 1/1: 0.6 * 2 = 1.2 -> lands on b
+        expect(drawEvent([table], lowTank, () => 0.6)!.event.id).toBe('b');
+    });
+
+    test('sesgo with unevaluable si never applies (already avisado at scan)', () => {
+        const table = tabla('t', {
+            sesgos: [{ si: 'esto no parsea', etiquetas: ['averia'], peso: 10 }],
+            eventos: [
+                evento('a', { peso: 1, etiquetas: ['averia'] }),
+                evento('b', { peso: 1 }),
+            ],
+        });
+        expect(drawEvent([table], ctx(), () => 0.6)!.event.id).toBe('b');
+    });
+
+    test('effective weight floors at 1 (negative sesgos cannot erase an event)', () => {
+        const table = tabla('t', {
+            sesgos: [{ si: 'combustible<=1', etiquetas: ['averia'], peso: -10 }],
+            eventos: [
+                evento('a', { peso: 1, etiquetas: ['averia'] }),
+                evento('b', { peso: 1 }),
+            ],
+        });
+        const lowTank = ctx({ medidores: { viveres: 3, combustible: 1, nave: 3 } });
+        // floored weights 1/1 (total 2): 0.4 * 2 = 0.8 -> still draws 'a'
+        expect(drawEvent([table], lowTank, () => 0.4)!.event.id).toBe('a');
+    });
+
+    test('defensive: an rng returning 1 falls back to the last pool entry', () => {
+        const table = tabla('t', { eventos: [evento('a'), evento('b')] });
+        expect(drawEvent([table], ctx(), () => 1)!.event.id).toBe('b');
+    });
+});

--- a/lib/world/eventEngine.ts
+++ b/lib/world/eventEngine.ts
@@ -122,8 +122,12 @@ const BLOCK_CLOSE = /^:::\s*$/;
  * fields, everything else stays as cuerpo (so parseAct — which does not know
  * `efecto` — never sees the block as stray prose). An unclosed block runs to
  * the end of the section, mirroring parseAct's tolerance.
+ *
+ * Exported so the ActRunner reuses this ONE grammar to lift an act's
+ * `:::efecto` state-transitions out of its plan file (the same blocks the
+ * event scanner turns into `event.efectos`) — never a second parser.
  */
-function extractEfectos(lines: string[]): { cuerpoLines: string[]; efectos: EventEffect[] } {
+export function extractEfectos(lines: string[]): { cuerpoLines: string[]; efectos: EventEffect[] } {
     const cuerpoLines: string[] = [];
     const efectoLines: string[] = [];
     let inEfecto = false;

--- a/lib/world/eventEngine.ts
+++ b/lib/world/eventEngine.ts
@@ -1,0 +1,385 @@
+/**
+ * Event engine (M4, plan Part A "Event tables" + Part B "EventDrawer"):
+ * parses `eventos/*.md` tables and performs the weighted draw.
+ *
+ * File shape:
+ *   - frontmatter: `contexto: viaje|estancia|ambas`, `regiones: [...]`,
+ *     `sesgos: [{si, etiquetas, peso}]`
+ *   - one event per `##` section: `## v01 — Baliza de socorro {peso=3;
+ *     si=combustible<=1; etiquetas=recurso,averia}` — the body until the next
+ *     `##` is the event's `cuerpo` (its `:::leer/:::gm/:::accion` blocks
+ *     render later through the EXISTING parseAct), except `:::efecto` blocks,
+ *     which are stripped from the cuerpo and parsed into EventEffect fields
+ *     (ActField semantics: `- key: valor` bullets, continuation lines append).
+ *
+ * Attr parsing caveat (plan): actFormat's parseAttrs splits on EVERY `=` and
+ * would break `si=combustible<=1`, so parseEventAttrs splits attrs on `;` and
+ * key/value on the FIRST `=` only. Do not reuse parseAttrs here.
+ *
+ * All parsing is tolerant and never throws: problems degrade into avisos and
+ * the table still loads (scanner contract). Draws are pure with an injectable
+ * rng so tests are deterministic.
+ */
+
+import {
+    CondContext,
+    EventEffect,
+    EventTable,
+    ValidationIssue,
+    WorldEvent,
+} from '@/types/world';
+import { fileNameToDisplayName } from '@/lib/fsScanUtils';
+import { evalCondition, evalConditions, isParseableCondition } from './conditions';
+import { CONOCIMIENTOS, DEFAULT_CONOCIMIENTO } from './constants';
+import { asNumber, asString, asStringArray, normalizeKeys, parseFrontmatter } from './frontmatter';
+
+/** `contexto:` vocabulary of an event table. */
+export const CONTEXTOS_EVENTO: readonly EventTable['contexto'][] = [
+    'viaje',
+    'estancia',
+    'ambas',
+];
+
+type EventBias = EventTable['sesgos'][number];
+
+// ── Attr parsing ────────────────────────────────────────────────────────────
+
+/**
+ * `{peso=3; si=combustible<=1; etiquetas=recurso}` -> record. Optional
+ * surrounding braces are stripped; attrs split on `;`; key/value split on the
+ * FIRST `=` only (values legally contain `=`, e.g. `si=creditos>=800`).
+ * A key without `=` gets the value 'true'. Whitespace-tolerant.
+ */
+export function parseEventAttrs(raw: string): Record<string, string> {
+    const attrs: Record<string, string> = {};
+    const inner = raw.trim().replace(/^\{/, '').replace(/\}$/, '');
+    for (const part of inner.split(';')) {
+        const trimmed = part.trim();
+        if (trimmed === '') continue;
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) {
+            attrs[trimmed] = 'true';
+            continue;
+        }
+        const key = trimmed.slice(0, eq).trim();
+        if (key === '') continue;
+        attrs[key] = trimmed.slice(eq + 1).trim();
+    }
+    return attrs;
+}
+
+// ── Table parsing ───────────────────────────────────────────────────────────
+
+export interface ParsedEventTable {
+    table: EventTable;
+    issues: ValidationIssue[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseSesgos(value: unknown, aviso: (mensaje: string) => void): EventBias[] {
+    if (value === undefined) return [];
+    if (!Array.isArray(value)) {
+        aviso('"sesgos" debe ser una lista de {si, etiquetas, peso} — se ignora');
+        return [];
+    }
+
+    const sesgos: EventBias[] = [];
+    for (const item of value) {
+        if (!isRecord(item)) {
+            aviso('Entrada de "sesgos" que no es un mapa {si, etiquetas, peso} — se omite');
+            continue;
+        }
+        const data = normalizeKeys(item);
+        const si = asString(data.si);
+        const peso = asNumber(data.peso);
+        if (si === undefined || peso === undefined) {
+            aviso('Entrada de "sesgos" sin "si" o "peso" válidos — se omite');
+            continue;
+        }
+        if (!isParseableCondition(si)) {
+            aviso(`Condición no interpretable en "sesgos": "${si}" — el sesgo no se aplicará`);
+        }
+        sesgos.push({ si, etiquetas: asStringArray(data.etiquetas), peso });
+    }
+    return sesgos;
+}
+
+/** `## ` heading (exactly two hashes). */
+const HEADING_LINE = /^##(?!#)\s+(.*)$/;
+/** Trailing `{...}` attrs on a heading. */
+const HEADING_ATTRS = /\{[^}]*\}\s*$/;
+/** `id — Título` (id has no whitespace/em-dash; separator -, – or —). */
+const HEADING_ID_TITLE = /^([^\s—–]+)\s*[—–-]\s+(.+)$/;
+
+const EFECTO_OPEN = /^:::efecto\b.*$/;
+const BLOCK_CLOSE = /^:::\s*$/;
+
+/**
+ * Splits `:::efecto` blocks out of a section: their lines become EventEffect
+ * fields, everything else stays as cuerpo (so parseAct — which does not know
+ * `efecto` — never sees the block as stray prose). An unclosed block runs to
+ * the end of the section, mirroring parseAct's tolerance.
+ */
+function extractEfectos(lines: string[]): { cuerpoLines: string[]; efectos: EventEffect[] } {
+    const cuerpoLines: string[] = [];
+    const efectoLines: string[] = [];
+    let inEfecto = false;
+
+    for (const line of lines) {
+        if (inEfecto) {
+            if (BLOCK_CLOSE.test(line)) {
+                inEfecto = false;
+            } else {
+                efectoLines.push(line);
+            }
+            continue;
+        }
+        if (EFECTO_OPEN.test(line)) {
+            inEfecto = true;
+            continue;
+        }
+        cuerpoLines.push(line);
+    }
+
+    return { cuerpoLines, efectos: parseEfectoFields(efectoLines) };
+}
+
+/**
+ * ActField semantics (mirrors actFormat's parseAccion, minus the bold name):
+ * `- key: valor` bullets (dash optional), keys lowercased; non-field lines
+ * append to the previous field's value, or open a leading 'nota' field.
+ */
+function parseEfectoFields(lines: string[]): EventEffect[] {
+    const efectos: EventEffect[] = [];
+    for (const rawLine of lines) {
+        const trimmed = rawLine.trim();
+        if (!trimmed) continue;
+        const stripped = trimmed.replace(/^[-*]\s*/, '');
+        const field = stripped.match(/^([A-Za-zÁÉÍÓÚÑáéíóúñ][\wÁÉÍÓÚÑáéíóúñ-]*)\s*:\s*(.+)$/);
+        if (field) {
+            efectos.push({ key: field[1].toLowerCase(), value: field[2].trim() });
+        } else if (efectos.length > 0) {
+            efectos[efectos.length - 1].value += ' ' + stripped;
+        } else {
+            efectos.push({ key: 'nota', value: stripped });
+        }
+    }
+    return efectos;
+}
+
+function parseEventos(body: string, aviso: (mensaje: string) => void): WorldEvent[] {
+    const eventos: WorldEvent[] = [];
+    const seen = new Set<string>();
+
+    let current: { id: string; titulo: string; attrs: Record<string, string> } | null = null;
+    let sectionLines: string[] = [];
+
+    const flush = () => {
+        if (!current) return;
+        const { id, titulo, attrs } = current;
+
+        let peso = 1;
+        if (attrs.peso !== undefined) {
+            const parsed = asNumber(attrs.peso);
+            if (parsed === undefined) {
+                aviso(`"peso" no numérico en el evento "${id}": "${attrs.peso}" — se usa 1`);
+            } else {
+                peso = parsed;
+            }
+        }
+
+        const si =
+            attrs.si === undefined
+                ? []
+                : attrs.si
+                      .split('&')
+                      .map((part) => part.trim())
+                      .filter((part) => part !== '');
+        for (const cond of si) {
+            if (!isParseableCondition(cond)) {
+                aviso(
+                    `Condición no interpretable en "si" del evento "${id}": "${cond}" — ` +
+                        'el evento queda fuera de las tiradas automáticas'
+                );
+            }
+        }
+
+        const etiquetas =
+            attrs.etiquetas === undefined
+                ? []
+                : attrs.etiquetas
+                      .split(',')
+                      .map((part) => part.trim())
+                      .filter((part) => part !== '');
+
+        const { cuerpoLines, efectos } = extractEfectos(sectionLines);
+
+        if (seen.has(id)) {
+            aviso(`id de evento duplicado: "${id}" — se conserva el primero`);
+        } else {
+            seen.add(id);
+            eventos.push({ id, titulo, peso, si, etiquetas, cuerpo: cuerpoLines.join('\n').trim(), efectos });
+        }
+    };
+
+    for (const line of body.split(/\r?\n/)) {
+        const heading = HEADING_LINE.exec(line);
+        if (!heading) {
+            if (current) sectionLines.push(line);
+            continue;
+        }
+
+        flush();
+        current = null;
+        sectionLines = [];
+
+        const headText = heading[1].trim();
+        const attrsMatch = HEADING_ATTRS.exec(headText);
+        const idTitle = HEADING_ID_TITLE.exec(
+            attrsMatch ? headText.slice(0, attrsMatch.index).trim() : headText
+        );
+        if (!idTitle) {
+            aviso(
+                `Encabezado de evento no interpretable: "## ${headText}" — ` +
+                    'se esperaba "## id — Título {atributos}"'
+            );
+            continue; // its section content belongs to no event
+        }
+        current = {
+            id: idTitle[1],
+            titulo: idTitle[2].trim(),
+            attrs: parseEventAttrs(attrsMatch ? attrsMatch[0] : ''),
+        };
+    }
+    flush();
+
+    return eventos;
+}
+
+/**
+ * Parses one `eventos/*.md` file into an EventTable. Never throws; every
+ * problem is an aviso (the frontmatter parser may add its own error) and the
+ * table always loads, however degraded. `id` = filename minus .md, like every
+ * other entity; `body` keeps the raw markdown below the frontmatter.
+ */
+export function parseEventTable(
+    content: string,
+    filePath: string,
+    id: string
+): ParsedEventTable {
+    const issues: ValidationIssue[] = [];
+    const aviso = (mensaje: string) => {
+        issues.push({ nivel: 'aviso', archivo: filePath, mensaje });
+    };
+
+    const parsed = parseFrontmatter(content, filePath);
+    if (parsed.issue) issues.push(parsed.issue);
+    const data = normalizeKeys(parsed.data);
+
+    let contexto: EventTable['contexto'] = 'ambas';
+    const contextoRaw = asString(data.contexto);
+    if (contextoRaw === undefined) {
+        aviso('Falta "contexto" en la tabla de eventos — se usa "ambas"');
+    } else if ((CONTEXTOS_EVENTO as readonly string[]).includes(contextoRaw)) {
+        contexto = contextoRaw as EventTable['contexto'];
+    } else {
+        aviso(`Valor fuera de vocabulario en "contexto": "${contextoRaw}" — se usa "ambas"`);
+    }
+
+    let conocimiento = DEFAULT_CONOCIMIENTO;
+    const conocimientoRaw = asString(data.conocimiento);
+    if (conocimientoRaw !== undefined) {
+        if ((CONOCIMIENTOS as readonly string[]).includes(conocimientoRaw)) {
+            conocimiento = conocimientoRaw as EventTable['conocimiento'];
+        } else {
+            aviso(
+                `Valor fuera de vocabulario en "conocimiento": "${conocimientoRaw}" — ` +
+                    `se usa "${DEFAULT_CONOCIMIENTO}"`
+            );
+        }
+    }
+
+    const table: EventTable = {
+        id,
+        tipo: asString(data.tipo) ?? 'eventos',
+        nombre: asString(data.nombre) ?? fileNameToDisplayName(id),
+        filePath,
+        conocimiento,
+        etiquetas: asStringArray(data.etiquetas),
+        resumen: asString(data.resumen),
+        estado: asString(data.estado),
+        raw: data,
+        body: parsed.body,
+        contexto,
+        regiones: asStringArray(data.regiones),
+        sesgos: parseSesgos(data.sesgos, aviso),
+        eventos: parseEventos(parsed.body, aviso),
+    };
+
+    return { table, issues };
+}
+
+// ── Gating + weighted draw ──────────────────────────────────────────────────
+
+/**
+ * Tables usable right now: `contexto` matches (or is 'ambas') AND the table
+ * is universal (empty `regiones`) or lists the party's current region. A null
+ * region only matches universal tables.
+ */
+export function applicableTables(
+    tablas: EventTable[],
+    contexto: 'viaje' | 'estancia',
+    regionActual: string | null
+): EventTable[] {
+    return tablas.filter(
+        (table) =>
+            (table.contexto === contexto || table.contexto === 'ambas') &&
+            (table.regiones.length === 0 ||
+                (regionActual !== null && table.regiones.includes(regionActual)))
+    );
+}
+
+/**
+ * Weighted draw over every event of every table whose `si` all hold.
+ * Null-condition events are EXCLUDED silently (they were already avisado at
+ * scan time). Effective weight = peso + sum of the table's matching sesgos —
+ * a sesgo matches when its own `si` holds (null = never) AND it shares at
+ * least one etiqueta with the event — floored at 1. `rng` returns [0, 1)
+ * (injectable for deterministic tests). Empty pool = null.
+ */
+export function drawEvent(
+    tables: EventTable[],
+    ctx: CondContext,
+    rng: () => number
+): { table: EventTable; event: WorldEvent } | null {
+    const pool: Array<{ table: EventTable; event: WorldEvent; weight: number }> = [];
+
+    for (const table of tables) {
+        const activeBiases = table.sesgos.filter((sesgo) => evalCondition(sesgo.si, ctx) === true);
+        for (const event of table.eventos) {
+            if (evalConditions(event.si, ctx) !== true) continue;
+            let weight = event.peso;
+            for (const sesgo of activeBiases) {
+                if (sesgo.etiquetas.some((tag) => event.etiquetas.includes(tag))) {
+                    weight += sesgo.peso;
+                }
+            }
+            pool.push({ table, event, weight: Math.max(1, weight) });
+        }
+    }
+
+    if (pool.length === 0) return null;
+
+    const total = pool.reduce((sum, entry) => sum + entry.weight, 0);
+    let roll = rng() * total;
+    for (const entry of pool) {
+        roll -= entry.weight;
+        if (roll < 0) return { table: entry.table, event: entry.event };
+    }
+    // rng defensively returned >= 1: fall back to the last entry.
+    const last = pool[pool.length - 1];
+    return { table: last.table, event: last.event };
+}

--- a/lib/world/eventEngine.ts
+++ b/lib/world/eventEngine.ts
@@ -215,13 +215,26 @@ function parseEventos(body: string, aviso: (mensaje: string) => void): WorldEven
                       .map((part) => part.trim())
                       .filter((part) => part !== '');
 
+        // `unico` is a bare presence token: parseEventAttrs maps it to the
+        // value 'true' (any value present ⇒ once-only; absent ⇒ false).
+        const unico = attrs.unico !== undefined;
+
         const { cuerpoLines, efectos } = extractEfectos(sectionLines);
 
         if (seen.has(id)) {
             aviso(`id de evento duplicado: "${id}" — se conserva el primero`);
         } else {
             seen.add(id);
-            eventos.push({ id, titulo, peso, si, etiquetas, cuerpo: cuerpoLines.join('\n').trim(), efectos });
+            eventos.push({
+                id,
+                titulo,
+                peso,
+                si,
+                etiquetas,
+                unico,
+                cuerpo: cuerpoLines.join('\n').trim(),
+                efectos,
+            });
         }
     };
 
@@ -343,19 +356,57 @@ export function applicableTables(
 }
 
 /**
+ * Tallies how many times each event was already drawn, keyed by
+ * `<tabla>#<id>` — the same id key drawEvent uses. Accepts the raw
+ * `evento:` payload strings (`<tabla>#<id>` optionally with a ` | outcome`
+ * suffix, which is ignored) OR full `evento: <payload>` lines; any string
+ * whose `<tabla>#<id>` head parses out is counted, everything else ignored.
+ * The count is what the history model decays / hard-excludes against.
+ */
+export function eventSeenCounts(payloads: Iterable<string>): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const raw of payloads) {
+        // Drop an `evento:` prefix if a full journal line was passed, then the
+        // ` | outcome` suffix, then match the `<tabla>#<id>` head.
+        const body = raw.replace(/^\s*evento:\s*/i, '');
+        const head = body.split('|', 1)[0].trim();
+        const match = /^([^#\s]+)#(\S+)$/.exec(head);
+        if (!match) continue;
+        const key = `${match[1]}#${match[2]}`;
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+}
+
+/**
  * Weighted draw over every event of every table whose `si` all hold.
  * Null-condition events are EXCLUDED silently (they were already avisado at
  * scan time). Effective weight = peso + sum of the table's matching sesgos —
  * a sesgo matches when its own `si` holds (null = never) AND it shares at
  * least one etiqueta with the event — floored at 1. `rng` returns [0, 1)
  * (injectable for deterministic tests). Empty pool = null.
+ *
+ * HISTORY MODEL (optional `seenCounts`, keyed `<tabla>#<id>` — see
+ * eventSeenCounts): a `unico` event already seen is HARD-excluded; a
+ * non-unico seen event decays to effectiveWeight = max(1, round(peso /
+ * (1 + seenCount))) so it grows rare but never impossible. If excluding the
+ * seen-unico events empties the pool (everything eligible was unico-and-seen)
+ * the draw FALLS BACK to the pre-exclusion pool so a draw is always returned
+ * (never a dead-end). Omitting `seenCounts` is exactly the pre-history
+ * behavior.
  */
 export function drawEvent(
     tables: EventTable[],
     ctx: CondContext,
-    rng: () => number
+    rng: () => number,
+    seenCounts?: Map<string, number>
 ): { table: EventTable; event: WorldEvent } | null {
-    const pool: Array<{ table: EventTable; event: WorldEvent; weight: number }> = [];
+    type Entry = { table: EventTable; event: WorldEvent; weight: number };
+    // Full gated pool (pre-exclusion, undecayed weights) — the fallback when
+    // exclusion empties the live pool.
+    const fullPool: Entry[] = [];
+    // Live pool: seen-unico excluded, non-unico decayed by seenCount.
+    const pool: Entry[] = [];
 
     for (const table of tables) {
         const activeBiases = table.sesgos.filter((sesgo) => evalCondition(sesgo.si, ctx) === true);
@@ -367,19 +418,28 @@ export function drawEvent(
                     weight += sesgo.peso;
                 }
             }
-            pool.push({ table, event, weight: Math.max(1, weight) });
+            weight = Math.max(1, weight);
+            fullPool.push({ table, event, weight });
+
+            const seen = seenCounts?.get(`${table.id}#${event.id}`) ?? 0;
+            if (seen > 0 && event.unico) continue; // hard-exclude seen unico
+            const effective = seen > 0 ? Math.max(1, Math.round(weight / (1 + seen))) : weight;
+            pool.push({ table, event, weight: effective });
         }
     }
 
-    if (pool.length === 0) return null;
+    // Exclusion emptied the live pool (all eligible events were unico-and-seen)
+    // but real candidates existed — never dead-end, draw over the full pool.
+    const active = pool.length > 0 ? pool : fullPool;
+    if (active.length === 0) return null;
 
-    const total = pool.reduce((sum, entry) => sum + entry.weight, 0);
+    const total = active.reduce((sum, entry) => sum + entry.weight, 0);
     let roll = rng() * total;
-    for (const entry of pool) {
+    for (const entry of active) {
         roll -= entry.weight;
         if (roll < 0) return { table: entry.table, event: entry.event };
     }
     // rng defensively returned >= 1: fall back to the last entry.
-    const last = pool[pool.length - 1];
+    const last = active[active.length - 1];
     return { table: last.table, event: last.event };
 }

--- a/lib/world/frontmatter.test.ts
+++ b/lib/world/frontmatter.test.ts
@@ -1,0 +1,344 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import {
+    splitFrontmatter,
+    parseFrontmatter,
+    normalizeKeys,
+    asString,
+    asNumber,
+    asStringArray,
+    asCoords,
+} from './frontmatter';
+
+describe('splitFrontmatter', () => {
+    test('splits a valid frontmatter fence from the body', () => {
+        const result = splitFrontmatter('---\ntipo: sistema\nnombre: Verne\n---\n# Verne\n\nProsa.\n');
+        expect(result.yamlText).toBe('tipo: sistema\nnombre: Verne\n');
+        expect(result.body).toBe('# Verne\n\nProsa.\n');
+    });
+
+    test('no frontmatter: whole content is body, yamlText null', () => {
+        const result = splitFrontmatter('# Solo prosa\n\nSin fence.\n');
+        expect(result.yamlText).toBeNull();
+        expect(result.body).toBe('# Solo prosa\n\nSin fence.\n');
+    });
+
+    test('tolerates CRLF line endings', () => {
+        const result = splitFrontmatter('---\r\ntipo: lugar\r\n---\r\ncuerpo\r\n');
+        expect(result.yamlText).toBe('tipo: lugar\r\n');
+        expect(result.body).toBe('cuerpo\r\n');
+    });
+
+    test('tolerates a leading BOM', () => {
+        const result = splitFrontmatter('\uFEFF' + '---\ntipo: pnj\n---\nbody');
+        expect(result.yamlText).toBe('tipo: pnj\n');
+        expect(result.body).toBe('body');
+    });
+
+    test('strips the BOM even when there is no frontmatter', () => {
+        const result = splitFrontmatter('\uFEFF' + 'solo texto');
+        expect(result.yamlText).toBeNull();
+        expect(result.body).toBe('solo texto');
+    });
+
+    test('empty frontmatter block', () => {
+        const result = splitFrontmatter('---\n---\ncuerpo\n');
+        expect(result.yamlText).toBe('');
+        expect(result.body).toBe('cuerpo\n');
+    });
+
+    test('unclosed fence is treated as no frontmatter', () => {
+        const content = '---\ntipo: sistema\nsin cierre\n';
+        const result = splitFrontmatter(content);
+        expect(result.yamlText).toBeNull();
+        expect(result.body).toBe(content);
+    });
+
+    test('fence not at file start is not frontmatter', () => {
+        const content = '\n---\ntipo: sistema\n---\n';
+        const result = splitFrontmatter(content);
+        expect(result.yamlText).toBeNull();
+        expect(result.body).toBe(content);
+    });
+
+    test('tolerates trailing spaces on the fence lines', () => {
+        const result = splitFrontmatter('---  \ntipo: trama\n---\t\ncuerpo');
+        expect(result.yamlText).toBe('tipo: trama\n');
+        expect(result.body).toBe('cuerpo');
+    });
+
+    test('closing fence at EOF without trailing newline', () => {
+        const result = splitFrontmatter('---\ntipo: pista\n---');
+        expect(result.yamlText).toBe('tipo: pista\n');
+        expect(result.body).toBe('');
+    });
+
+    test('a later --- hr stays in the body', () => {
+        const result = splitFrontmatter('---\na: 1\n---\narriba\n---\nabajo\n');
+        expect(result.yamlText).toBe('a: 1\n');
+        expect(result.body).toBe('arriba\n---\nabajo\n');
+    });
+});
+
+describe('parseFrontmatter', () => {
+    test('valid frontmatter: data + body, no issue', () => {
+        const result = parseFrontmatter(
+            '---\ntipo: sistema\ncoordenadas: {x: 3, y: -2}\netiquetas: [pirata, frontera]\n---\nProsa.\n',
+            'mundo/sistemas/verne.md'
+        );
+        expect(result.issue).toBeUndefined();
+        expect(result.data.tipo).toBe('sistema');
+        expect(result.data.coordenadas).toEqual({ x: 3, y: -2 });
+        expect(result.data.etiquetas).toEqual(['pirata', 'frontera']);
+        expect(result.body).toBe('Prosa.\n');
+    });
+
+    test('malformed YAML: never throws, empty data + nivel error issue with file path', () => {
+        const result = parseFrontmatter(
+            '---\nnombre: [sin cerrar\n---\ncuerpo intacto\n',
+            'mundo/lugares/roto.md'
+        );
+        expect(result.data).toEqual({});
+        expect(result.body).toBe('cuerpo intacto\n');
+        expect(result.issue).toBeDefined();
+        expect(result.issue?.nivel).toBe('error');
+        expect(result.issue?.archivo).toBe('mundo/lugares/roto.md');
+        expect(result.issue?.mensaje).toContain('YAML');
+    });
+
+    test('non-map frontmatter (list) is an error issue', () => {
+        const result = parseFrontmatter('---\n- a\n- b\n---\ncuerpo\n', 'mundo/pistas/lista.md');
+        expect(result.data).toEqual({});
+        expect(result.issue?.nivel).toBe('error');
+        expect(result.issue?.archivo).toBe('mundo/pistas/lista.md');
+    });
+
+    test('non-map frontmatter (scalar) is an error issue', () => {
+        const result = parseFrontmatter('---\nsolo texto\n---\n', 'mundo/pnjs/escalar.md');
+        expect(result.data).toEqual({});
+        expect(result.issue?.nivel).toBe('error');
+    });
+
+    test('empty frontmatter: empty data, no issue', () => {
+        const result = parseFrontmatter('---\n---\ncuerpo\n', 'mundo/x.md');
+        expect(result.data).toEqual({});
+        expect(result.issue).toBeUndefined();
+        expect(result.body).toBe('cuerpo\n');
+    });
+
+    test('no frontmatter: empty data, no issue, body intact', () => {
+        const result = parseFrontmatter('# Titulo\n', 'mundo/x.md');
+        expect(result.data).toEqual({});
+        expect(result.issue).toBeUndefined();
+        expect(result.body).toBe('# Titulo\n');
+    });
+
+    test('CRLF file parses data correctly', () => {
+        const result = parseFrontmatter(
+            '---\r\ntipo: lugar\r\norbita: 2\r\n---\r\ncuerpo\r\n',
+            'mundo/lugares/kovar_iii.md'
+        );
+        expect(result.issue).toBeUndefined();
+        expect(result.data).toEqual({ tipo: 'lugar', orbita: 2 });
+    });
+
+    test('multiline estado blurb (folded scalar) survives', () => {
+        const result = parseFrontmatter(
+            '---\nestado: >\n  Bloqueo naval\n  tras el incidente.\n---\n',
+            'mundo/sistemas/s.md'
+        );
+        expect(result.issue).toBeUndefined();
+        expect(result.data.estado).toBe('Bloqueo naval tras el incidente.\n');
+    });
+});
+
+describe('normalizeKeys', () => {
+    test('maps every english alias to its spanish canonical key', () => {
+        const result = normalizeKeys({
+            type: 'lugar',
+            name: 'Porto Verne',
+            in: 'sistema_verne',
+            tags: ['puerto'],
+            knowledge: 'visitado',
+            status: 'bullicio',
+            summary: 'Puerto franco',
+            services: ['mercado'],
+            coords: { x: 1, y: 2 },
+            orbit: 3,
+            weight: 5,
+            if: 'combustible<=2',
+            context: 'viaje',
+        });
+        expect(result).toEqual({
+            tipo: 'lugar',
+            nombre: 'Porto Verne',
+            en: 'sistema_verne',
+            etiquetas: ['puerto'],
+            conocimiento: 'visitado',
+            estado: 'bullicio',
+            resumen: 'Puerto franco',
+            servicios: ['mercado'],
+            coordenadas: { x: 1, y: 2 },
+            orbita: 3,
+            peso: 5,
+            si: 'combustible<=2',
+            contexto: 'viaje',
+        });
+    });
+
+    test('spanish wins when both forms are present, regardless of key order', () => {
+        expect(normalizeKeys({ type: 'ingles', tipo: 'espanol' })).toEqual({ tipo: 'espanol' });
+        expect(normalizeKeys({ nombre: 'espanol', name: 'ingles' })).toEqual({ nombre: 'espanol' });
+    });
+
+    test('unknown keys pass through untouched', () => {
+        expect(normalizeKeys({ peligro: 4, faccion: 'consorcio' })).toEqual({
+            peligro: 4,
+            faccion: 'consorcio',
+        });
+    });
+
+    test('shallow: nested objects are not normalized', () => {
+        const result = normalizeKeys({ coords: { x: 1, y: 2 }, extra: { type: 'anidado' } });
+        expect(result.coordenadas).toEqual({ x: 1, y: 2 });
+        expect(result.extra).toEqual({ type: 'anidado' });
+    });
+
+    test('empty object stays empty', () => {
+        expect(normalizeKeys({})).toEqual({});
+    });
+});
+
+describe('asString', () => {
+    test('passes strings through, trimmed', () => {
+        expect(asString('hola')).toBe('hola');
+        expect(asString('  con espacios  ')).toBe('con espacios');
+    });
+
+    test('empty and whitespace-only strings are undefined', () => {
+        expect(asString('')).toBeUndefined();
+        expect(asString('   ')).toBeUndefined();
+    });
+
+    test('numbers and booleans stringify', () => {
+        expect(asString(42)).toBe('42');
+        expect(asString(3.5)).toBe('3.5');
+        expect(asString(true)).toBe('true');
+    });
+
+    test('null, undefined, objects and arrays are undefined', () => {
+        expect(asString(null)).toBeUndefined();
+        expect(asString(undefined)).toBeUndefined();
+        expect(asString({})).toBeUndefined();
+        expect(asString(['a'])).toBeUndefined();
+    });
+});
+
+describe('asNumber', () => {
+    test('passes finite numbers through (including 0 and negatives)', () => {
+        expect(asNumber(3)).toBe(3);
+        expect(asNumber(0)).toBe(0);
+        expect(asNumber(-2.5)).toBe(-2.5);
+    });
+
+    test('coerces numeric strings', () => {
+        expect(asNumber('42')).toBe(42);
+        expect(asNumber(' 7 ')).toBe(7);
+        expect(asNumber('-3.14')).toBe(-3.14);
+    });
+
+    test('rejects non-numeric strings and empty strings', () => {
+        expect(asNumber('abc')).toBeUndefined();
+        expect(asNumber('')).toBeUndefined();
+        expect(asNumber('  ')).toBeUndefined();
+    });
+
+    test('rejects NaN and Infinity', () => {
+        expect(asNumber(NaN)).toBeUndefined();
+        expect(asNumber(Infinity)).toBeUndefined();
+        expect(asNumber('Infinity')).toBeUndefined();
+    });
+
+    test('rejects null, booleans, objects and arrays', () => {
+        expect(asNumber(null)).toBeUndefined();
+        expect(asNumber(true)).toBeUndefined();
+        expect(asNumber({})).toBeUndefined();
+        expect(asNumber([1])).toBeUndefined();
+    });
+});
+
+describe('asStringArray', () => {
+    test('passes string arrays through', () => {
+        expect(asStringArray(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    test('coerces scalar items and drops uncoercible ones', () => {
+        expect(asStringArray([1, 'x', null, {}, '', 'y'])).toEqual(['1', 'x', 'y']);
+    });
+
+    test('wraps a lone scalar (etiquetas: pirata written without brackets)', () => {
+        expect(asStringArray('pirata')).toEqual(['pirata']);
+        expect(asStringArray(5)).toEqual(['5']);
+    });
+
+    test('null, undefined, objects and empty strings yield []', () => {
+        expect(asStringArray(null)).toEqual([]);
+        expect(asStringArray(undefined)).toEqual([]);
+        expect(asStringArray({})).toEqual([]);
+        expect(asStringArray('')).toEqual([]);
+    });
+
+    test('empty array stays empty', () => {
+        expect(asStringArray([])).toEqual([]);
+    });
+});
+
+describe('asCoords', () => {
+    test('accepts {x, y} with numbers (including 0)', () => {
+        expect(asCoords({ x: 3, y: -2 })).toEqual({ x: 3, y: -2 });
+        expect(asCoords({ x: 0, y: 0 })).toEqual({ x: 0, y: 0 });
+    });
+
+    test('coerces numeric-string members', () => {
+        expect(asCoords({ x: '3', y: '4.5' })).toEqual({ x: 3, y: 4.5 });
+    });
+
+    test('ignores extra keys', () => {
+        expect(asCoords({ x: 1, y: 2, z: 9 })).toEqual({ x: 1, y: 2 });
+    });
+
+    test('rejects missing or non-numeric members', () => {
+        expect(asCoords({ x: 1 })).toBeUndefined();
+        expect(asCoords({ y: 2 })).toBeUndefined();
+        expect(asCoords({ x: 1, y: 'norte' })).toBeUndefined();
+        expect(asCoords({ x: NaN, y: 2 })).toBeUndefined();
+    });
+
+    test('rejects non-object values', () => {
+        expect(asCoords(null)).toBeUndefined();
+        expect(asCoords(undefined)).toBeUndefined();
+        expect(asCoords([1, 2])).toBeUndefined();
+        expect(asCoords('1,2')).toBeUndefined();
+        expect(asCoords(7)).toBeUndefined();
+    });
+});
+
+describe('integration: parse + normalize on an english-authored file', () => {
+    test('an entity written with english keys normalizes to the spanish schema', () => {
+        const parsed = parseFrontmatter(
+            '---\ntype: estacion\nname: Puerto Kovar\nin: sistema_kovar\ntags: [comercio]\nknowledge: rumoreado\norbit: 2\nservices:\n  - mercado\n  - repostaje\n---\nProsa del lugar.\n',
+            'mundo/lugares/puerto_kovar.md'
+        );
+        expect(parsed.issue).toBeUndefined();
+
+        const data = normalizeKeys(parsed.data);
+        expect(data.tipo).toBe('estacion');
+        expect(data.nombre).toBe('Puerto Kovar');
+        expect(data.en).toBe('sistema_kovar');
+        expect(asStringArray(data.etiquetas)).toEqual(['comercio']);
+        expect(data.conocimiento).toBe('rumoreado');
+        expect(asNumber(data.orbita)).toBe(2);
+        expect(asStringArray(data.servicios)).toEqual(['mercado', 'repostaje']);
+        expect(parsed.body).toBe('Prosa del lugar.\n');
+    });
+});

--- a/lib/world/frontmatter.ts
+++ b/lib/world/frontmatter.ts
@@ -1,0 +1,183 @@
+/**
+ * Browser-safe YAML frontmatter parsing for world-mode markdown files.
+ * Uses the `yaml` package (eemeli — no Buffer/Node deps); never throws:
+ * malformed YAML degrades into a ValidationIssue so the world always loads.
+ */
+
+import { parse as parseYaml } from 'yaml';
+import { ValidationIssue } from '@/types/world';
+
+export interface SplitFrontmatterResult {
+    /** Raw YAML between the fences, or null when the file has no frontmatter. */
+    yamlText: string | null;
+    /** Markdown content below the closing fence (whole file when no frontmatter). */
+    body: string;
+}
+
+export interface ParsedFrontmatter {
+    data: Record<string, unknown>;
+    body: string;
+    issue?: ValidationIssue;
+}
+
+const OPEN_FENCE = /^---[ \t]*\r?\n/;
+const CLOSE_FENCE = /^---[ \t]*(?:\r?\n|$)/m;
+
+/**
+ * Splits a leading `---` frontmatter fence off a markdown file.
+ * Tolerant of CRLF line endings and a UTF-8 BOM. The fence must open at the
+ * very start of the file; an unclosed fence is treated as no frontmatter.
+ */
+export function splitFrontmatter(content: string): SplitFrontmatterResult {
+    const src = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+
+    const open = OPEN_FENCE.exec(src);
+    if (!open) {
+        return { yamlText: null, body: src };
+    }
+
+    const afterOpen = src.slice(open[0].length);
+    const close = CLOSE_FENCE.exec(afterOpen);
+    if (!close) {
+        return { yamlText: null, body: src };
+    }
+
+    return {
+        yamlText: afterOpen.slice(0, close.index),
+        body: afterOpen.slice(close.index + close[0].length),
+    };
+}
+
+/**
+ * Parses a markdown file into frontmatter data + body. NEVER throws:
+ * YAML errors (or non-map frontmatter) yield empty data plus an
+ * `issue` with nivel 'error' pointing at `filePath`.
+ */
+export function parseFrontmatter(content: string, filePath: string): ParsedFrontmatter {
+    const { yamlText, body } = splitFrontmatter(content);
+    if (yamlText === null) {
+        return { data: {}, body };
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = parseYaml(yamlText);
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return {
+            data: {},
+            body,
+            issue: {
+                nivel: 'error',
+                archivo: filePath,
+                mensaje: `YAML inválido en el frontmatter: ${detail}`,
+            },
+        };
+    }
+
+    if (parsed === null || parsed === undefined) {
+        return { data: {}, body };
+    }
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return {
+            data: {},
+            body,
+            issue: {
+                nivel: 'error',
+                archivo: filePath,
+                mensaje: 'El frontmatter no es un mapa YAML de clave: valor',
+            },
+        };
+    }
+
+    return { data: parsed as Record<string, unknown>, body };
+}
+
+/** English → Spanish frontmatter key aliases. Spanish is canonical and wins on conflict. */
+const KEY_ALIASES: Record<string, string> = {
+    type: 'tipo',
+    name: 'nombre',
+    in: 'en',
+    tags: 'etiquetas',
+    knowledge: 'conocimiento',
+    status: 'estado',
+    summary: 'resumen',
+    services: 'servicios',
+    coords: 'coordenadas',
+    orbit: 'orbita',
+    weight: 'peso',
+    if: 'si',
+    context: 'contexto',
+};
+
+/**
+ * Maps English alias keys to their Spanish canonical form — shallow (top level
+ * only). When both forms are present the Spanish value wins and the English
+ * one is dropped.
+ */
+export function normalizeKeys(data: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+        const canonical = KEY_ALIASES[key] ?? key;
+        if (canonical !== key && canonical in data) {
+            continue; // Spanish key also present — it wins
+        }
+        result[canonical] = value;
+    }
+    return result;
+}
+
+// ── Safe coercers (used by the scanner; never throw) ───────────────────────
+
+/** Trimmed string, or undefined for empty/non-scalar values. Numbers/booleans stringify. */
+export function asString(value: unknown): string | undefined {
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        return trimmed === '' ? undefined : trimmed;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    return undefined;
+}
+
+/** Finite number, coercing numeric strings; undefined otherwise. */
+export function asNumber(value: unknown): number | undefined {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined;
+    }
+    if (typeof value === 'string' && value.trim() !== '') {
+        const num = Number(value);
+        return Number.isFinite(num) ? num : undefined;
+    }
+    return undefined;
+}
+
+/**
+ * String array; non-string items are coerced via asString and dropped when
+ * uncoercible. A lone scalar becomes a one-element array (tolerates
+ * `etiquetas: pirata` written without brackets); anything else yields [].
+ */
+export function asStringArray(value: unknown): string[] {
+    if (Array.isArray(value)) {
+        return value
+            .map(asString)
+            .filter((item): item is string => item !== undefined);
+    }
+    const single = asString(value);
+    return single === undefined ? [] : [single];
+}
+
+/** `{x, y}` with finite numeric members (numeric strings coerced); undefined otherwise. */
+export function asCoords(value: unknown): { x: number; y: number } | undefined {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return undefined;
+    }
+    const record = value as Record<string, unknown>;
+    const x = asNumber(record.x);
+    const y = asNumber(record.y);
+    if (x === undefined || y === undefined) {
+        return undefined;
+    }
+    return { x, y };
+}

--- a/lib/world/journalWriter.test.ts
+++ b/lib/world/journalWriter.test.ts
@@ -1,0 +1,253 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { JournalDay } from '@/types/world';
+import { JournalWriter, WriteStatus, nextJournalFile } from './journalWriter';
+
+function day(sesion: number, fechaReal: string, overrides: Partial<JournalDay> = {}): JournalDay {
+    return {
+        filePath: `mundo/diario/${fechaReal}_s${String(sesion).padStart(2, '0')}.md`,
+        sesion,
+        fechaReal,
+        diaInicio: 1,
+        diaFin: null,
+        procesado: true,
+        entradas: [],
+        ...overrides,
+    };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// ── nextJournalFile ─────────────────────────────────────────────────────────
+
+describe('nextJournalFile', () => {
+    test('empty world starts at s01', () => {
+        expect(nextJournalFile([], '2026-07-12')).toEqual({
+            fileName: '2026-07-12_s01.md',
+            sesion: 1,
+        });
+    });
+
+    test('sesion = max + 1, tolerating gaps', () => {
+        const existing = [day(2, '2026-06-01'), day(7, '2026-07-01')];
+        expect(nextJournalFile(existing, '2026-07-12')).toEqual({
+            fileName: '2026-07-12_s08.md',
+            sesion: 8,
+        });
+    });
+
+    test('second session on the same real day gets the next NN', () => {
+        const existing = [day(8, '2026-07-12')];
+        expect(nextJournalFile(existing, '2026-07-12')).toEqual({
+            fileName: '2026-07-12_s09.md',
+            sesion: 9,
+        });
+    });
+
+    test('fallback count + 1 when no journal carries a usable sesion', () => {
+        const existing = [day(0, '2026-06-01'), day(Number.NaN, '2026-06-08')];
+        expect(nextJournalFile(existing, '2026-07-12')).toEqual({
+            fileName: '2026-07-12_s03.md',
+            sesion: 3,
+        });
+    });
+
+    test('NN pads to 2 but grows past 99', () => {
+        expect(nextJournalFile([day(99, '2026-07-01')], '2026-07-12').fileName).toBe(
+            '2026-07-12_s100.md'
+        );
+    });
+});
+
+// ── JournalWriter queue ─────────────────────────────────────────────────────
+
+interface ManualFs {
+    writes: Array<{ path: string; content: string }>;
+    writeFile: (path: string, content: string) => Promise<void>;
+    /** Resolve (or reject) the oldest unresolved write. */
+    settle: (error?: Error) => void;
+    pending: () => number;
+}
+
+/** writeFile whose promises resolve only when the test says so. */
+function manualFs(): ManualFs {
+    const writes: Array<{ path: string; content: string }> = [];
+    const settlers: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+    return {
+        writes,
+        writeFile(path: string, content: string) {
+            writes.push({ path, content });
+            return new Promise<void>((resolve, reject) => {
+                settlers.push({ resolve, reject });
+            });
+        },
+        settle(error?: Error) {
+            const settler = settlers.shift();
+            if (!settler) throw new Error('no pending write to settle');
+            if (error) settler.reject(error);
+            else settler.resolve();
+        },
+        pending: () => settlers.length,
+    };
+}
+
+describe('JournalWriter — serialized coalescing queue', () => {
+    test('open writes immediately', async () => {
+        const writes: Array<{ path: string; content: string }> = [];
+        const writer = new JournalWriter({
+            writeFile: async (path, content) => {
+                writes.push({ path, content });
+            },
+        });
+        await writer.open('mundo/diario/2026-07-12_s08.md', 'v0');
+        expect(writes).toEqual([{ path: 'mundo/diario/2026-07-12_s08.md', content: 'v0' }]);
+        expect(writer.writeStatus).toBe('ok');
+    });
+
+    test('burst of rewrites coalesces: only the latest queued text is written next', async () => {
+        const fs = manualFs();
+        const writer = new JournalWriter({ writeFile: fs.writeFile });
+
+        const opened = writer.open('mundo/diario/2026-07-12_s08.md', 'v0');
+        expect(fs.writes.map((w) => w.content)).toEqual(['v0']); // in flight
+
+        writer.rewrite('v1');
+        writer.rewrite('v2');
+        writer.rewrite('v3');
+        expect(writer.writeStatus).toBe('pending');
+
+        fs.settle(); // v0 lands
+        await tick();
+        // v1/v2 were skipped; v3 is the single follow-up write
+        expect(fs.writes.map((w) => w.content)).toEqual(['v0', 'v3']);
+
+        fs.settle(); // v3 lands
+        await opened;
+        await writer.flush();
+        expect(fs.writes.map((w) => w.content)).toEqual(['v0', 'v3']);
+        expect(writer.writeStatus).toBe('ok');
+        expect(writer.text).toBe('v3');
+    });
+
+    test('flush resolves once the queue drains', async () => {
+        const fs = manualFs();
+        const writer = new JournalWriter({ writeFile: fs.writeFile });
+        void writer.open('mundo/diario/x.md', 'v0');
+        writer.rewrite('v1');
+
+        let flushed = false;
+        const flushPromise = writer.flush().then(() => {
+            flushed = true;
+        });
+
+        fs.settle();
+        await tick();
+        expect(flushed).toBe(false); // v1 still in flight
+        fs.settle();
+        await flushPromise;
+        expect(flushed).toBe(true);
+        expect(fs.writes.map((w) => w.content)).toEqual(['v0', 'v1']);
+    });
+
+    test('flush on an idle writer resolves immediately', async () => {
+        const writer = new JournalWriter({ writeFile: async () => {} });
+        await writer.flush();
+    });
+
+    test('denied on failure, holds the text, retryNow() recovers', async () => {
+        let fail = true;
+        const written: string[] = [];
+        const writer = new JournalWriter({
+            writeFile: async (_path, content) => {
+                if (fail) {
+                    const error = new Error('NotAllowedError');
+                    error.name = 'NotAllowedError';
+                    throw error;
+                }
+                written.push(content);
+            },
+        });
+        const statuses: WriteStatus[] = [];
+        writer.onStatus((status) => statuses.push(status));
+
+        // open never rejects — the denial surfaces via status instead
+        await writer.open('mundo/diario/x.md', 'v0');
+        expect(writer.writeStatus).toBe('denied');
+        expect(statuses).toEqual(['ok', 'pending', 'denied']);
+
+        // rewrites while denied keep updating the held text without attempts;
+        // flush REJECTS while the queue is stalled denied
+        writer.rewrite('v1');
+        writer.rewrite('v2');
+        await expect(writer.flush()).rejects.toThrow('NotAllowedError');
+        expect(written).toEqual([]);
+        expect(writer.writeStatus).toBe('denied');
+
+        // the user gesture re-attempts the LAST text
+        fail = false;
+        writer.retryNow();
+        await writer.flush();
+        expect(written).toEqual(['v2']);
+        expect(writer.writeStatus).toBe('ok');
+        expect(statuses).toEqual(['ok', 'pending', 'denied', 'pending', 'ok']);
+    });
+
+    test('failure mid-queue keeps rewrites that arrived during the failed write', async () => {
+        const fs = manualFs();
+        const writer = new JournalWriter({ writeFile: fs.writeFile });
+        void writer.open('mundo/diario/x.md', 'v0');
+        writer.rewrite('v1'); // queued while v0 in flight
+
+        fs.settle(new Error('NotAllowedError')); // v0 write fails
+        await tick();
+        expect(writer.writeStatus).toBe('denied');
+
+        writer.retryNow();
+        await tick();
+        fs.settle(); // v1 retry lands
+        await writer.flush();
+        expect(fs.writes.map((w) => w.content)).toEqual(['v0', 'v1']);
+        expect(writer.writeStatus).toBe('ok');
+    });
+
+    test('onStatus fires immediately with the current status', () => {
+        const writer = new JournalWriter({ writeFile: async () => {} });
+        const statuses: WriteStatus[] = [];
+        writer.onStatus((status) => statuses.push(status));
+        expect(statuses).toEqual(['ok']);
+    });
+});
+
+describe('JournalWriter — write-surface enforcement', () => {
+    const writer = () => new JournalWriter({ writeFile: async () => {} });
+
+    test('open under mundo/diario/ and mundo/estado/ is allowed', async () => {
+        await writer().open('mundo/diario/2026-07-12_s08.md', '');
+        await writer().open('mundo/estado/grupo.md', '');
+    });
+
+    test('open outside the surface throws synchronously', () => {
+        expect(() => writer().open('mundo/lugares/porto_verne/lugar.md', 'x')).toThrow(
+            'superficie'
+        );
+        expect(() => writer().open('sesion7/plan/acto1.md', 'x')).toThrow('superficie');
+        expect(() => writer().open('diario/x.md', 'x')).toThrow('superficie');
+    });
+
+    test('path traversal is rejected even under an allowed prefix', () => {
+        expect(() => writer().open('mundo/diario/../../secreto.md', 'x')).toThrow('superficie');
+    });
+
+    test('rewrite before open throws', () => {
+        expect(() => writer().rewrite('x')).toThrow('antes de open');
+    });
+
+    test('custom allowedPrefixes are honored', async () => {
+        const custom = new JournalWriter({ writeFile: async () => {} }, ['tmp/']);
+        await custom.open('tmp/x.md', '');
+        expect(() => custom.open('mundo/diario/x.md', '')).toThrow('superficie');
+    });
+});
+
+// Crash-mirror coverage lives in lib/world/partyStore.test.ts — the canonical
+// SessionMirror (with the session-start snapshot) is owned by the party store.

--- a/lib/world/journalWriter.ts
+++ b/lib/world/journalWriter.ts
@@ -1,0 +1,213 @@
+/**
+ * Serialized journal write queue (M3, plan Part B).
+ *
+ * The session's full journal text lives in memory and is FULL-REWRITTEN on
+ * every change through a single-consumer async queue (append == undo == same
+ * path; the FS Access API has no true append and journals stay <100 KB).
+ * Bursts coalesce: while a write is in flight only the LATEST queued text is
+ * written next — intermediate versions are skipped.
+ *
+ * Failure model: a failed write keeps the pending text, flips the status to
+ * 'denied' and stalls the queue until retryNow() is called from a user
+ * gesture (Chrome may require one to re-grant write permission). flush()
+ * rejects while the queue is stalled; open() and retryNow() never reject —
+ * they report through the status callback and are safe to fire-and-forget.
+ *
+ * Write-surface rule (plan Part A): during a session the app writes ONLY
+ * under `mundo/diario/` and `mundo/estado/` — enforced here in code.
+ *
+ * Crash safety lives in the party store (lib/world/stores.ts): its
+ * SessionMirror carries the session-start snapshot needed for replay, so the
+ * writer itself mirrors nothing.
+ */
+
+import { JournalDay } from '@/types/world';
+
+export type WriteStatus = 'ok' | 'pending' | 'denied';
+
+export interface JournalWriterDeps {
+    /** e.g. FileSystemManager.writeTextFile bound to the campaign folder. */
+    writeFile: (path: string, content: string) => Promise<void>;
+}
+
+/** The only paths the app may write while a session is active. */
+export const DEFAULT_WRITE_PREFIXES: readonly string[] = ['mundo/diario/', 'mundo/estado/'];
+
+// ── nextJournalFile ─────────────────────────────────────────────────────────
+
+/**
+ * Names the next journal file for a session on `fechaReal` (YYYY-MM-DD):
+ * sesion = max existing sesion + 1 (fallback count + 1 when no journal
+ * carries a usable number); file name `AAAA-MM-DD_sNN.md`, NN zero-padded
+ * to 2. A second session on the same real day simply gets the next NN.
+ */
+export function nextJournalFile(
+    existing: JournalDay[],
+    fechaReal: string
+): { fileName: string; sesion: number } {
+    let max = 0;
+    for (const day of existing) {
+        if (Number.isFinite(day.sesion) && day.sesion > max) max = day.sesion;
+    }
+    const sesion = max > 0 ? max + 1 : existing.length + 1;
+    const nn = String(sesion).padStart(2, '0');
+    return { fileName: `${fechaReal}_s${nn}.md`, sesion };
+}
+
+// ── JournalWriter ───────────────────────────────────────────────────────────
+
+export class JournalWriter {
+    private readonly deps: JournalWriterDeps;
+    private readonly allowedPrefixes: readonly string[];
+
+    private path: string | null = null;
+    /** Latest full text the file should hold (the coalescing "queue of one"). */
+    private desiredText = '';
+    /** True when desiredText has not been persisted yet. */
+    private dirty = false;
+    /** True while a writeFile call is in flight. */
+    private busy = false;
+    private status: WriteStatus = 'ok';
+    private statusCb: ((status: WriteStatus) => void) | null = null;
+    private lastError: unknown = null;
+    private flushWaiters: Array<{ resolve: () => void; reject: (error: unknown) => void }> = [];
+
+    constructor(deps: JournalWriterDeps, allowedPrefixes: readonly string[] = DEFAULT_WRITE_PREFIXES) {
+        this.deps = deps;
+        this.allowedPrefixes = allowedPrefixes;
+    }
+
+    /** Current in-memory journal text (what the file holds or will hold). */
+    get text(): string {
+        return this.desiredText;
+    }
+
+    get writeStatus(): WriteStatus {
+        return this.status;
+    }
+
+    /**
+     * Registers the status listener (ok | pending | denied) and immediately
+     * fires it with the current status; afterwards it fires on every change.
+     */
+    onStatus(cb: (status: WriteStatus) => void): void {
+        this.statusCb = cb;
+        cb(this.status);
+    }
+
+    /**
+     * Binds the writer to a journal file and writes the initial text
+     * immediately. Throws synchronously when the path is outside the allowed
+     * write surface. The returned promise NEVER rejects (open is safe to
+     * fire-and-forget): a denied first write is reported via onStatus /
+     * writeStatus, with the text held for retryNow().
+     */
+    open(filePath: string, initialText: string): Promise<void> {
+        this.assertAllowed(filePath);
+        this.path = filePath;
+        this.desiredText = initialText;
+        this.dirty = true;
+        this.pump();
+        return this.flush().catch(() => undefined);
+    }
+
+    /**
+     * Enqueues a full-rewrite. Coalesces: with a write in flight, repeated
+     * calls just replace the queued text — only the latest is written next.
+     * While denied, the text is retained but nothing is attempted until
+     * retryNow(). Throws before open() or on a path violation.
+     */
+    rewrite(fullText: string): void {
+        if (this.path === null) {
+            throw new Error('JournalWriter.rewrite() llamado antes de open()');
+        }
+        this.desiredText = fullText;
+        this.dirty = true;
+        this.pump();
+    }
+
+    /**
+     * Re-attempts the last text after a denial (call from a user gesture).
+     * Fire-and-forget: the outcome is reported via onStatus/writeStatus (and
+     * observable through flush()).
+     */
+    retryNow(): void {
+        this.pump(true);
+    }
+
+    /**
+     * Resolves once everything is persisted (queue drained, status 'ok').
+     * REJECTS with the underlying write error when the queue stalls denied
+     * with unpersisted text — callers decide (e.g. endSession keeps the
+     * session open and offers retryNow()).
+     */
+    flush(): Promise<void> {
+        if (!this.busy) {
+            if (!this.dirty) return Promise.resolve();
+            if (this.status === 'denied') {
+                return Promise.reject(this.lastError ?? new Error('Escritura denegada'));
+            }
+        }
+        return new Promise((resolve, reject) => {
+            this.flushWaiters.push({ resolve, reject });
+        });
+    }
+
+    private assertAllowed(path: string): void {
+        const fueraDeSuperficie =
+            !this.allowedPrefixes.some((prefix) => path.startsWith(prefix)) ||
+            path.split('/').includes('..');
+        if (fueraDeSuperficie) {
+            throw new Error(
+                `Escritura fuera de la superficie permitida (${this.allowedPrefixes.join(', ')}): ${path}`
+            );
+        }
+    }
+
+    private setStatus(status: WriteStatus): void {
+        if (status === this.status) return;
+        this.status = status;
+        this.statusCb?.(status);
+    }
+
+    private releaseWaiters(error?: unknown): void {
+        const waiters = this.flushWaiters;
+        this.flushWaiters = [];
+        for (const waiter of waiters) {
+            if (error === undefined) waiter.resolve();
+            else waiter.reject(error);
+        }
+    }
+
+    /** Starts the consumer if there is work; denied stalls unless forced. */
+    private pump(force = false): void {
+        if (this.busy || !this.dirty) return;
+        if (this.status === 'denied' && !force) return;
+        void this.run();
+    }
+
+    private async run(): Promise<void> {
+        this.busy = true;
+        this.setStatus('pending');
+        while (this.dirty) {
+            this.dirty = false;
+            const text = this.desiredText;
+            try {
+                await this.deps.writeFile(this.path!, text);
+            } catch (error) {
+                // Keep the text (latest wins, incl. rewrites during the failed
+                // attempt) and stall until retryNow() — a NotAllowedError needs
+                // a user gesture to re-request permission.
+                this.dirty = true;
+                this.busy = false;
+                this.lastError = error ?? new Error('Escritura denegada');
+                this.setStatus('denied');
+                this.releaseWaiters(this.lastError);
+                return;
+            }
+        }
+        this.busy = false;
+        this.setStatus('ok');
+        this.releaseWaiters();
+    }
+}

--- a/lib/world/logEntries.test.ts
+++ b/lib/world/logEntries.test.ts
@@ -1,0 +1,593 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { JournalEntry, PartySnapshot } from '@/types/world';
+import {
+    applyEntryToSnapshot,
+    makeEntry,
+    parseCantidadPayload,
+    parseDescansoPayload,
+    parseDiaPayload,
+    parseEntryLine,
+    parseEventoPayload,
+    parseInicioFinPayload,
+    parseJournal,
+    parseLlegadaPayload,
+    parseMedidorPayload,
+    parsePistaPayload,
+    parseRumboPayload,
+    parseSabePayload,
+    serializeEntry,
+    serializeJournal,
+} from './logEntries';
+
+/** Deterministic clock: 18:05. */
+const clock = () => new Date(2026, 6, 12, 18, 5, 33);
+
+/** Early-morning clock: 09:07 must zero-pad to "09:07". */
+const earlyClock = () => new Date(2026, 6, 12, 9, 7);
+
+// ── serializeEntry / parseEntryLine round-trip ──────────────────────────────
+
+describe('logEntries — round-trip per tipo', () => {
+    /** Every tipo, built via makeEntry, with and without comentario. */
+    const casesConComentario: Array<[string, JournalEntry, string]> = [
+        [
+            'rumbo',
+            makeEntry.rumbo('kovar_iii', 3, 4131, 'vía la ruta comercial', clock),
+            '- [18:05] rumbo: kovar_iii | 3 dias, llegada estimada dia 4131 | vía la ruta comercial',
+        ],
+        [
+            'llegada',
+            makeEntry.llegada('porto_verne', 4131, 'atracan de noche', clock),
+            '- [18:05] llegada: porto_verne | dia 4131 | atracan de noche',
+        ],
+        [
+            'gasto',
+            makeEntry.gasto(250, 'sobornó al estibador', clock),
+            '- [18:05] gasto: 250 | sobornó al estibador',
+        ],
+        [
+            'ganancia',
+            makeEntry.ganancia(400, 'pago de Kael', clock),
+            '- [18:05] ganancia: 400 | pago de Kael',
+        ],
+        [
+            'medidor',
+            makeEntry.medidor('combustible', 2, 4, 'repostaje completo', clock),
+            '- [18:05] medidor: combustible 2->4 | repostaje completo',
+        ],
+        [
+            'pista',
+            makeEntry.pista('deuda_kael', 'rumor', 'activa', 'confirmada en el bar', clock),
+            '- [18:05] pista: deuda_kael rumor->activa | confirmada en el bar',
+        ],
+        [
+            'sabe',
+            makeEntry.sabe('nodo_sigma', 'desconocido', 'rumoreado', 'mapa robado', clock),
+            '- [18:05] sabe: nodo_sigma desconocido->rumoreado | mapa robado',
+        ],
+        [
+            'evento',
+            makeEntry.evento('viaje_frontera', 'v01', 'avería épica', clock),
+            '- [18:05] evento: viaje_frontera#v01 | avería épica',
+        ],
+        [
+            'descanso',
+            makeEntry.descanso(2, 'reparaciones en dique', clock),
+            '- [18:05] descanso: 2 dias | reparaciones en dique',
+        ],
+        [
+            'dia',
+            makeEntry.dia(4128, 4131, 'elipsis de viaje', clock),
+            '- [18:05] dia: 4128->4131 | elipsis de viaje',
+        ],
+        [
+            'nota',
+            makeEntry.nota('los jugadores sospechan de Kael — ¡ojo! áéíóú ñ', clock),
+            '- [18:05] nota: los jugadores sospechan de Kael — ¡ojo! áéíóú ñ',
+        ],
+    ];
+
+    const casesSinComentario: Array<[string, JournalEntry, string]> = [
+        [
+            'inicio',
+            makeEntry.inicio(4128, 'porto_verne', clock),
+            '- [18:05] inicio: dia 4128 @ porto_verne',
+        ],
+        ['fin', makeEntry.fin(4131, 'kovar_iii', clock), '- [18:05] fin: dia 4131 @ kovar_iii'],
+        [
+            'rumbo',
+            makeEntry.rumbo('kovar_iii', 3, 4131, undefined, clock),
+            '- [18:05] rumbo: kovar_iii | 3 dias, llegada estimada dia 4131',
+        ],
+        [
+            'llegada',
+            makeEntry.llegada('porto_verne', 4131, undefined, clock),
+            '- [18:05] llegada: porto_verne | dia 4131',
+        ],
+        ['gasto', makeEntry.gasto(250, undefined, clock), '- [18:05] gasto: 250'],
+        ['ganancia', makeEntry.ganancia(400, undefined, clock), '- [18:05] ganancia: 400'],
+        [
+            'medidor',
+            makeEntry.medidor('viveres', 3, 2, undefined, clock),
+            '- [18:05] medidor: viveres 3->2',
+        ],
+        [
+            'pista',
+            makeEntry.pista('deuda_kael', 'activa', 'resuelta', undefined, clock),
+            '- [18:05] pista: deuda_kael activa->resuelta',
+        ],
+        [
+            'sabe',
+            makeEntry.sabe('sitio_sigma', 'rumoreado', 'conocido', undefined, clock),
+            '- [18:05] sabe: sitio_sigma rumoreado->conocido',
+        ],
+        [
+            'evento',
+            makeEntry.evento('estancia_nucleo', 'e03', undefined, clock),
+            '- [18:05] evento: estancia_nucleo#e03',
+        ],
+        ['descanso', makeEntry.descanso(1, undefined, clock), '- [18:05] descanso: 1 dias'],
+        ['dia', makeEntry.dia(4131, 4132, undefined, clock), '- [18:05] dia: 4131->4132'],
+    ];
+
+    for (const [nombre, entry, expectedLine] of casesConComentario) {
+        test(`${nombre} (con comentario): exact line + round-trip`, () => {
+            const line = serializeEntry(entry);
+            expect(line).toBe(expectedLine);
+            expect(parseEntryLine(line)).toEqual(entry);
+        });
+    }
+
+    for (const [nombre, entry, expectedLine] of casesSinComentario) {
+        test(`${nombre} (sin comentario): exact line + round-trip`, () => {
+            const line = serializeEntry(entry);
+            expect(line).toBe(expectedLine);
+            expect(parseEntryLine(line)).toEqual(entry);
+        });
+    }
+
+    test('hora is zero-padded from the injected clock', () => {
+        expect(makeEntry.gasto(1, undefined, earlyClock).hora).toBe('09:07');
+    });
+
+    test('makeEntry defaults to the system clock', () => {
+        const entry = makeEntry.nota('sin reloj inyectado');
+        expect(entry.hora).toMatch(/^\d{2}:\d{2}$/);
+    });
+
+    test('inicio/fin with a null location log "desconocida"', () => {
+        expect(makeEntry.inicio(1, null, clock).payload).toBe('dia 1 @ desconocida');
+        expect(makeEntry.fin(1, null, clock).payload).toBe('dia 1 @ desconocida');
+    });
+
+    test('empty/whitespace comentario collapses to no comentario', () => {
+        const entry = makeEntry.gasto(10, '   ', clock);
+        expect(entry.comentario).toBeUndefined();
+        expect(serializeEntry(entry)).toBe('- [18:05] gasto: 10');
+    });
+
+    test('DOCUMENTED: pipe inside comentario is not supported — replaced with "/"', () => {
+        // The pipe is the reserved payload/comentario separator: makeEntry and
+        // serializeEntry replace '|' with '/' so lines stay unambiguous.
+        const entry = makeEntry.gasto(50, 'peaje | propina', clock);
+        expect(entry.comentario).toBe('peaje / propina');
+
+        const line = serializeEntry(entry);
+        expect(line).toBe('- [18:05] gasto: 50 | peaje / propina');
+        expect(parseEntryLine(line)).toEqual(entry);
+
+        // A hand-built entry with a raw pipe does NOT round-trip verbatim:
+        // the written line carries '/' instead.
+        const manual: JournalEntry = {
+            hora: '18:05',
+            tipo: 'gasto',
+            payload: '50',
+            comentario: 'a|b',
+        };
+        expect(parseEntryLine(serializeEntry(manual))).toEqual({
+            hora: '18:05',
+            tipo: 'gasto',
+            payload: '50',
+            comentario: 'a/b',
+        });
+    });
+
+    test('pipe in a llegada comentario stays unambiguous vs the payload pipe', () => {
+        const entry = makeEntry.llegada('porto_verne', 4131, 'muelle 7 | nivel 2', clock);
+        expect(serializeEntry(entry)).toBe(
+            '- [18:05] llegada: porto_verne | dia 4131 | muelle 7 / nivel 2'
+        );
+        expect(parseEntryLine(serializeEntry(entry))).toEqual(entry);
+    });
+
+    test('DOCUMENTED: line breaks in a comentario collapse to a single space', () => {
+        // An entry must serialize to exactly ONE journal line; a raw \n or \r
+        // would split it into a truncated entry plus stray unparseable text.
+        for (const crudo of ['línea1\nlínea2', 'crlf\r\nfin', 'solo\rcr', '\n\nrodeado\n']) {
+            for (const entry of [
+                makeEntry.nota(crudo, clock),
+                makeEntry.gasto(10, crudo, clock),
+                makeEntry.llegada('kovar_iii', 5, crudo, clock),
+            ]) {
+                const line = serializeEntry(entry);
+                expect(line.split(/\r?\n|\r/).length).toBe(1);
+                expect(parseEntryLine(line)).toEqual(entry);
+            }
+        }
+        expect(makeEntry.nota('línea1\nlínea2', clock).comentario).toBe('línea1 línea2');
+    });
+});
+
+// ── parseEntryLine tolerance ────────────────────────────────────────────────
+
+describe('parseEntryLine — strict but whitespace-tolerant', () => {
+    test('extra whitespace everywhere still parses', () => {
+        expect(parseEntryLine('   -   [ 9:05 ]   gasto  :   50   |   con espacios   ')).toEqual({
+            hora: '9:05',
+            tipo: 'gasto',
+            payload: '50',
+            comentario: 'con espacios',
+        });
+    });
+
+    test('unknown tipo returns null', () => {
+        expect(parseEntryLine('- [10:00] teleport: porto_verne')).toBeNull();
+    });
+
+    test('non-entry lines return null', () => {
+        expect(parseEntryLine('')).toBeNull();
+        expect(parseEntryLine('## resumen de la parte 2')).toBeNull();
+        expect(parseEntryLine('- sin hora ni tipo')).toBeNull();
+        expect(parseEntryLine('- [xx:yy] gasto: 5')).toBeNull();
+        expect(parseEntryLine('[10:00] gasto: 5')).toBeNull(); // missing list dash
+    });
+
+    test('trailing empty comentario segment is dropped', () => {
+        expect(parseEntryLine('- [10:00] gasto: 50 |')).toEqual({
+            hora: '10:00',
+            tipo: 'gasto',
+            payload: '50',
+        });
+    });
+
+    test('nota puts everything after the colon into comentario', () => {
+        expect(parseEntryLine('- [22:15] nota: cualquier texto libre')).toEqual({
+            hora: '22:15',
+            tipo: 'nota',
+            payload: '',
+            comentario: 'cualquier texto libre',
+        });
+        expect(parseEntryLine('- [22:15] nota:')).toEqual({
+            hora: '22:15',
+            tipo: 'nota',
+            payload: '',
+        });
+    });
+});
+
+// ── serializeJournal / parseJournal ─────────────────────────────────────────
+
+describe('serializeJournal + parseJournal', () => {
+    const header = {
+        sesion: 8,
+        fechaReal: '2026-07-12',
+        diaInicio: 4128,
+        diaFin: null,
+        procesado: false,
+    };
+
+    test('serializes frontmatter + one line per entry', () => {
+        const entradas = [
+            makeEntry.inicio(4128, 'porto_verne', clock),
+            makeEntry.gasto(250, 'taxi', clock),
+        ];
+        expect(serializeJournal(header, entradas)).toBe(
+            [
+                '---',
+                'tipo: diario',
+                'sesion: 8',
+                'fecha_real: 2026-07-12',
+                'dia_inicio: 4128',
+                'dia_fin: null',
+                'procesado: false',
+                '---',
+                '',
+                '- [18:05] inicio: dia 4128 @ porto_verne',
+                '- [18:05] gasto: 250 | taxi',
+                '',
+            ].join('\n')
+        );
+    });
+
+    test('empty journal is frontmatter only', () => {
+        const text = serializeJournal(header, []);
+        expect(text.endsWith('---\n')).toBe(true);
+        expect(parseJournal(text, 'mundo/diario/2026-07-12_s08.md').entradas).toEqual([]);
+    });
+
+    test('full file round-trip through parseJournal', () => {
+        const entradas = [
+            makeEntry.inicio(4128, 'porto_verne', clock),
+            makeEntry.rumbo('kovar_iii', 3, 4131, undefined, clock),
+            makeEntry.medidor('combustible', 4, 3, undefined, clock),
+            makeEntry.llegada('kovar_iii', 4131, 'sin incidentes', clock),
+            makeEntry.nota('ánimo alto en la mesa', clock),
+            makeEntry.fin(4131, 'kovar_iii', clock),
+        ];
+        const text = serializeJournal({ ...header, diaFin: 4131, procesado: true }, entradas);
+        const day = parseJournal(text, 'mundo/diario/2026-07-12_s08.md');
+
+        expect(day).toEqual({
+            filePath: 'mundo/diario/2026-07-12_s08.md',
+            sesion: 8,
+            fechaReal: '2026-07-12',
+            diaInicio: 4128,
+            diaFin: 4131,
+            procesado: true,
+            entradas,
+        });
+    });
+
+    test('garbage lines are skipped, good ones kept', () => {
+        const text = [
+            '---',
+            'tipo: diario',
+            'sesion: 3',
+            'fecha_real: 2026-07-12',
+            'dia_inicio: 10',
+            'dia_fin: null',
+            'procesado: false',
+            '---',
+            '',
+            '- [18:02] inicio: dia 10 @ porto_verne',
+            'esto no es una entrada',
+            '- [18:30] hackeo: la_red',
+            '- [19:00] gasto: 75 | copas',
+            '   ',
+            '## un titulo perdido',
+        ].join('\n');
+
+        const day = parseJournal(text, 'mundo/diario/2026-07-12_s03.md');
+        expect(day.entradas.map((e) => e.tipo)).toEqual(['inicio', 'gasto']);
+        expect(day.sesion).toBe(3);
+        expect(day.diaInicio).toBe(10);
+        expect(day.diaFin).toBeNull();
+    });
+
+    test('missing frontmatter: filename fallback + safe defaults, never throws', () => {
+        const day = parseJournal('- [18:02] gasto: 5\n', 'mundo/diario/2027-01-03_s12.md');
+        expect(day.sesion).toBe(12);
+        expect(day.fechaReal).toBe('2027-01-03');
+        expect(day.diaInicio).toBeNull();
+        expect(day.diaFin).toBeNull();
+        expect(day.procesado).toBe(false);
+        expect(day.entradas).toHaveLength(1);
+    });
+
+    test('malformed YAML degrades to defaults with the body still parsed', () => {
+        const text = '---\nsesion: "rota\n---\n- [10:00] gasto: 5\n';
+        const day = parseJournal(text, 'mundo/diario/2026-07-12_s09.md');
+        expect(day.sesion).toBe(9); // filename fallback
+        expect(day.entradas).toHaveLength(1);
+    });
+
+    test('unnamed file without frontmatter gets neutral defaults', () => {
+        const day = parseJournal('', 'mundo/diario/apuntes.md');
+        expect(day.sesion).toBe(0);
+        expect(day.fechaReal).toBe('');
+        expect(day.entradas).toEqual([]);
+    });
+});
+
+// ── Payload parse helpers ───────────────────────────────────────────────────
+
+describe('payload grammar parsers', () => {
+    test('parseCantidadPayload', () => {
+        expect(parseCantidadPayload('250')).toBe(250);
+        expect(parseCantidadPayload(' -40 ')).toBe(-40);
+        expect(parseCantidadPayload('abc')).toBeNull();
+        expect(parseCantidadPayload('40 creditos')).toBeNull();
+    });
+
+    test('parseMedidorPayload', () => {
+        expect(parseMedidorPayload('combustible 2->4')).toEqual({
+            nombre: 'combustible',
+            from: 2,
+            to: 4,
+        });
+        expect(parseMedidorPayload('nave 3 -> 1')).toEqual({ nombre: 'nave', from: 3, to: 1 });
+        expect(parseMedidorPayload('combustible dos->tres')).toBeNull();
+        expect(parseMedidorPayload('2->4')).toBeNull();
+    });
+
+    test('parsePistaPayload / parseSabePayload', () => {
+        expect(parsePistaPayload('deuda_kael rumor->activa')).toEqual({
+            id: 'deuda_kael',
+            from: 'rumor',
+            to: 'activa',
+        });
+        expect(parseSabePayload('nodo_sigma desconocido -> rumoreado')).toEqual({
+            id: 'nodo_sigma',
+            from: 'desconocido',
+            to: 'rumoreado',
+        });
+        expect(parsePistaPayload('sin_flecha')).toBeNull();
+        expect(parsePistaPayload('->activa')).toBeNull();
+    });
+
+    test('parseLlegadaPayload', () => {
+        expect(parseLlegadaPayload('porto_verne | dia 4131')).toEqual({
+            lugarId: 'porto_verne',
+            dia: 4131,
+        });
+        expect(parseLlegadaPayload('porto_verne|dia 4131')).toEqual({
+            lugarId: 'porto_verne',
+            dia: 4131,
+        });
+        expect(parseLlegadaPayload('porto_verne')).toBeNull();
+        expect(parseLlegadaPayload('porto_verne | 4131')).toBeNull();
+    });
+
+    test('parseRumboPayload', () => {
+        expect(parseRumboPayload('kovar_iii | 3 dias, llegada estimada dia 4131')).toEqual({
+            destino: 'kovar_iii',
+            dias: 3,
+            llegadaDia: 4131,
+        });
+        expect(parseRumboPayload('kovar_iii | 1 dia, llegada estimada dia 9')).toEqual({
+            destino: 'kovar_iii',
+            dias: 1,
+            llegadaDia: 9,
+        });
+        expect(parseRumboPayload('kovar_iii | tres dias')).toBeNull();
+    });
+
+    test('parseDescansoPayload / parseDiaPayload / parseInicioFinPayload / parseEventoPayload', () => {
+        expect(parseDescansoPayload('2 dias')).toEqual({ dias: 2 });
+        expect(parseDescansoPayload('1 dia')).toEqual({ dias: 1 });
+        expect(parseDescansoPayload('dos dias')).toBeNull();
+
+        expect(parseDiaPayload('4128->4131')).toEqual({ from: 4128, to: 4131 });
+        expect(parseDiaPayload('4128')).toBeNull();
+
+        expect(parseInicioFinPayload('dia 4128 @ porto_verne')).toEqual({
+            dia: 4128,
+            lugarId: 'porto_verne',
+        });
+        expect(parseInicioFinPayload('4128 @ porto_verne')).toBeNull();
+
+        expect(parseEventoPayload('viaje_frontera#v01')).toEqual({
+            tablaId: 'viaje_frontera',
+            eventoId: 'v01',
+        });
+        expect(parseEventoPayload('viaje_frontera v01')).toBeNull();
+    });
+});
+
+// ── applyEntryToSnapshot ────────────────────────────────────────────────────
+
+describe('applyEntryToSnapshot', () => {
+    function baseSnap(): PartySnapshot {
+        return {
+            diaMundo: 4128,
+            ubicacion: 'porto_verne',
+            rumbo: null,
+            creditos: 1200,
+            medidores: { viveres: 3, combustible: 2, nave: 4 },
+        };
+    }
+
+    test('gasto subtracts credits (pure: input untouched)', () => {
+        const snap = baseSnap();
+        const next = applyEntryToSnapshot(snap, makeEntry.gasto(250, undefined, clock));
+        expect(next.creditos).toBe(950);
+        expect(snap.creditos).toBe(1200);
+        expect(next).not.toBe(snap);
+    });
+
+    test('ganancia adds credits', () => {
+        expect(
+            applyEntryToSnapshot(baseSnap(), makeEntry.ganancia(400, undefined, clock)).creditos
+        ).toBe(1600);
+    });
+
+    test('medidor sets the named gauge to the "to" value', () => {
+        const snap = baseSnap();
+        const next = applyEntryToSnapshot(
+            snap,
+            makeEntry.medidor('combustible', 2, 4, undefined, clock)
+        );
+        expect(next.medidores).toEqual({ viveres: 3, combustible: 4, nave: 4 });
+        expect(snap.medidores.combustible).toBe(2); // no mutation
+    });
+
+    test('medidor can introduce a gauge the snapshot did not have', () => {
+        const next = applyEntryToSnapshot(
+            baseSnap(),
+            makeEntry.medidor('moral', 0, 5, undefined, clock)
+        );
+        expect(next.medidores.moral).toBe(5);
+    });
+
+    test('llegada sets ubicacion + diaMundo and clears rumbo', () => {
+        const enRuta: PartySnapshot = {
+            ...baseSnap(),
+            rumbo: { destino: 'kovar_iii', llegadaDia: 4131 },
+        };
+        const next = applyEntryToSnapshot(
+            enRuta,
+            makeEntry.llegada('kovar_iii', 4131, undefined, clock)
+        );
+        expect(next.ubicacion).toBe('kovar_iii');
+        expect(next.diaMundo).toBe(4131);
+        expect(next.rumbo).toBeNull();
+    });
+
+    test('rumbo sets the heading', () => {
+        const next = applyEntryToSnapshot(
+            baseSnap(),
+            makeEntry.rumbo('kovar_iii', 3, 4131, undefined, clock)
+        );
+        expect(next.rumbo).toEqual({ destino: 'kovar_iii', llegadaDia: 4131 });
+    });
+
+    test('descanso advances diaMundo by N', () => {
+        expect(
+            applyEntryToSnapshot(baseSnap(), makeEntry.descanso(2, undefined, clock)).diaMundo
+        ).toBe(4130);
+    });
+
+    test('dia sets diaMundo to the "to" value', () => {
+        expect(
+            applyEntryToSnapshot(baseSnap(), makeEntry.dia(4128, 4131, undefined, clock)).diaMundo
+        ).toBe(4131);
+    });
+
+    test('inicio/fin/nota/pista/sabe/evento leave the snapshot unchanged (same object)', () => {
+        const snap = baseSnap();
+        const neutral = [
+            makeEntry.inicio(4128, 'porto_verne', clock),
+            makeEntry.fin(4128, 'porto_verne', clock),
+            makeEntry.nota('sin efecto', clock),
+            makeEntry.pista('deuda_kael', 'rumor', 'activa', undefined, clock),
+            makeEntry.sabe('nodo_sigma', 'desconocido', 'rumoreado', undefined, clock),
+            makeEntry.evento('viaje_frontera', 'v01', undefined, clock),
+        ];
+        for (const entry of neutral) {
+            expect(applyEntryToSnapshot(snap, entry)).toBe(snap);
+        }
+    });
+
+    test('unparseable payload is a no-op, never a throw', () => {
+        const snap = baseSnap();
+        const roto: JournalEntry = { hora: '10:00', tipo: 'gasto', payload: 'muchos' };
+        expect(applyEntryToSnapshot(snap, roto)).toBe(snap);
+
+        const medidorRoto: JournalEntry = { hora: '10:00', tipo: 'medidor', payload: 'combustible' };
+        expect(applyEntryToSnapshot(snap, medidorRoto)).toBe(snap);
+    });
+
+    test('replay: folding entries over a snapshot reproduces the session', () => {
+        const entries = [
+            makeEntry.inicio(4128, 'porto_verne', clock),
+            makeEntry.gasto(200, undefined, clock),
+            makeEntry.rumbo('kovar_iii', 3, 4131, undefined, clock),
+            makeEntry.medidor('combustible', 2, 1, undefined, clock),
+            makeEntry.llegada('kovar_iii', 4131, undefined, clock),
+            makeEntry.ganancia(500, undefined, clock),
+        ];
+        const final = entries.reduce(applyEntryToSnapshot, baseSnap());
+        expect(final).toEqual({
+            diaMundo: 4131,
+            ubicacion: 'kovar_iii',
+            rumbo: null,
+            creditos: 1500,
+            medidores: { viveres: 3, combustible: 1, nave: 4 },
+        });
+
+        // undo-last = replay all but the last entry over the start snapshot
+        const undone = entries.slice(0, -1).reduce(applyEntryToSnapshot, baseSnap());
+        expect(undone.creditos).toBe(1000);
+    });
+});

--- a/lib/world/logEntries.ts
+++ b/lib/world/logEntries.ts
@@ -1,0 +1,464 @@
+/**
+ * Journal line format for `mundo/diario/AAAA-MM-DD_sNN.md` (M3, plan Part A).
+ *
+ * One entry per line, strict, human-readable AND machine-parseable:
+ *
+ *     - [HH:MM] tipo: payload | comentario libre opcional
+ *
+ * Payload grammar per tipo (the strict line format IS the machine format):
+ *
+ *     inicio / fin   dia N @ <lugar>                              dia 4128 @ porto_verne
+ *     rumbo          <lugar> | N dias, llegada estimada dia M     kovar_iii | 3 dias, llegada estimada dia 4131
+ *     llegada        <lugar> | dia N                              porto_verne | dia 4131
+ *     gasto/ganancia N                                            250
+ *     medidor        <nombre> A->B                                combustible 2->4
+ *     pista          <id> estadoA->estadoB                        deuda_kael rumor->activa
+ *     sabe           <entidad> nivelA->nivelB                     nodo_sigma desconocido->rumoreado
+ *     evento         <tabla>#<id>                                 viaje_frontera#v01
+ *     descanso       N dias                                       2 dias
+ *     dia            A->B                                         4128->4131
+ *     nota           (payload vacío; el texto libre va en comentario)
+ *
+ * The `|` pipe is the RESERVED separator between payload and comentario (and
+ * inside the llegada/rumbo payloads), and an entry must serialize to exactly
+ * ONE line. Neither pipes nor line breaks are supported inside a comentario:
+ * makeEntry and serializeEntry replace every '|' with '/' and collapse every
+ * CR/LF run to a single space, so the written line always parses back
+ * unambiguously. Entries built through makeEntry therefore always round-trip:
+ * parseEntryLine(serializeEntry(e)) deep-equals e.
+ *
+ * Everything here is pure (no filesystem, no store access) and never throws
+ * on bad content — bad lines parse to null, bad payloads leave the snapshot
+ * reducer a no-op.
+ */
+
+import { JournalDay, JournalEntry, JournalEntryType, PartySnapshot } from '@/types/world';
+import { asNumber, asString, parseFrontmatter } from './frontmatter';
+
+// ── Entry-type vocabulary ───────────────────────────────────────────────────
+
+export const JOURNAL_ENTRY_TYPES: readonly JournalEntryType[] = [
+    'inicio',
+    'fin',
+    'rumbo',
+    'llegada',
+    'gasto',
+    'ganancia',
+    'medidor',
+    'pista',
+    'sabe',
+    'evento',
+    'descanso',
+    'dia',
+    'nota',
+];
+
+export function isJournalEntryType(value: string): value is JournalEntryType {
+    return (JOURNAL_ENTRY_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * How many pipes the payload grammar of a tipo contains. The (budget+1)-th
+ * pipe on a line is the payload/comentario separator.
+ */
+const PAYLOAD_PIPES: Record<JournalEntryType, number> = {
+    inicio: 0,
+    fin: 0,
+    rumbo: 1,
+    llegada: 1,
+    gasto: 0,
+    ganancia: 0,
+    medidor: 0,
+    pista: 0,
+    sabe: 0,
+    evento: 0,
+    descanso: 0,
+    dia: 0,
+    nota: 0,
+};
+
+// ── Line serialization / parsing ────────────────────────────────────────────
+
+/**
+ * Pipes are reserved: a '|' inside a comentario would shift the
+ * payload/comentario split on re-parse, so it is replaced with '/'.
+ * Line breaks would split the entry into a truncated line plus stray
+ * unparseable text, so CR/LF runs collapse to a single space.
+ * Empty/whitespace-only comments collapse to undefined.
+ */
+function sanitizeComentario(comentario: string | undefined): string | undefined {
+    if (comentario === undefined) return undefined;
+    const limpio = comentario
+        .replace(/[\r\n]+/g, ' ')
+        .replace(/\|/g, '/')
+        .trim();
+    return limpio === '' ? undefined : limpio;
+}
+
+/**
+ * Serializes one entry to its journal line (no trailing newline).
+ * `nota` is comment-only: its payload is ignored and the comentario is
+ * written directly after the colon.
+ */
+export function serializeEntry(entry: JournalEntry): string {
+    const comentario = sanitizeComentario(entry.comentario);
+    const cuerpo =
+        entry.tipo === 'nota'
+            ? comentario ?? ''
+            : comentario === undefined
+              ? entry.payload
+              : `${entry.payload} | ${comentario}`;
+    return `- [${entry.hora}] ${entry.tipo}: ${cuerpo}`.trimEnd();
+}
+
+const ENTRY_LINE = /^\s*-\s*\[\s*(\d{1,2}:\d{2})\s*\]\s*([a-z]+)\s*:\s*(.*)$/;
+
+/** Index of the (skip+1)-th '|' in text, or -1. */
+function nthPipeIndex(text: string, skip: number): number {
+    let index = -1;
+    for (let remaining = skip; remaining >= 0; remaining--) {
+        index = text.indexOf('|', index + 1);
+        if (index === -1) return -1;
+    }
+    return index;
+}
+
+/**
+ * Parses one journal line. Strict on shape (list dash, [HH:MM], known tipo)
+ * but tolerant of extra whitespace; payload content is NOT validated here
+ * (the reducer/parse helpers do that). Returns null for anything else —
+ * unknown tipo, prose lines, blank lines.
+ */
+export function parseEntryLine(line: string): JournalEntry | null {
+    const match = ENTRY_LINE.exec(line);
+    if (!match) return null;
+    const hora = match[1];
+    const tipo = match[2];
+    if (!isJournalEntryType(tipo)) return null;
+    const resto = match[3].trim();
+
+    if (tipo === 'nota') {
+        return resto === ''
+            ? { hora, tipo, payload: '' }
+            : { hora, tipo, payload: '', comentario: resto };
+    }
+
+    const separator = nthPipeIndex(resto, PAYLOAD_PIPES[tipo]);
+    if (separator === -1) {
+        return { hora, tipo, payload: resto };
+    }
+    const payload = resto.slice(0, separator).trim();
+    const comentario = resto.slice(separator + 1).trim();
+    return comentario === ''
+        ? { hora, tipo, payload }
+        : { hora, tipo, payload, comentario };
+}
+
+// ── Journal file serialization / parsing ────────────────────────────────────
+
+export type JournalDayHeader = Pick<
+    JournalDay,
+    'sesion' | 'fechaReal' | 'diaInicio' | 'diaFin' | 'procesado'
+>;
+
+/**
+ * Full journal file text: YAML frontmatter + one line per entry.
+ * `dia_fin` stays `null` until the session closes; `procesado` is flipped to
+ * true by the agent after the maintenance loop (never by the app).
+ */
+export function serializeJournal(day: JournalDayHeader, entradas: JournalEntry[]): string {
+    const frontmatter = [
+        '---',
+        'tipo: diario',
+        `sesion: ${day.sesion}`,
+        `fecha_real: ${day.fechaReal}`,
+        `dia_inicio: ${day.diaInicio ?? 'null'}`,
+        `dia_fin: ${day.diaFin ?? 'null'}`,
+        `procesado: ${day.procesado}`,
+        '---',
+    ].join('\n');
+
+    if (entradas.length === 0) return `${frontmatter}\n`;
+    return `${frontmatter}\n\n${entradas.map(serializeEntry).join('\n')}\n`;
+}
+
+/** Boolean, tolerating the string forms "true"/"false". Undefined otherwise. */
+function asBoolean(value: unknown): boolean | undefined {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+        const trimmed = value.trim().toLowerCase();
+        if (trimmed === 'true') return true;
+        if (trimmed === 'false') return false;
+    }
+    return undefined;
+}
+
+const JOURNAL_FILE_NAME = /(\d{4}-\d{2}-\d{2})_s(\d+)\.md$/i;
+
+/**
+ * Parses a `diario/*.md` file. Tolerant, never throws: malformed YAML
+ * degrades to defaults, unparseable lines are skipped, and missing
+ * sesion/fecha_real fall back to the `AAAA-MM-DD_sNN.md` filename.
+ */
+export function parseJournal(content: string, filePath: string): JournalDay {
+    const parsed = parseFrontmatter(content, filePath);
+    const data = parsed.data;
+    const fromName = JOURNAL_FILE_NAME.exec(filePath);
+
+    const entradas: JournalEntry[] = [];
+    for (const line of parsed.body.split(/\r?\n/)) {
+        const entry = parseEntryLine(line);
+        if (entry) entradas.push(entry);
+    }
+
+    return {
+        filePath,
+        sesion: asNumber(data.sesion) ?? (fromName ? Number(fromName[2]) : 0),
+        fechaReal: asString(data.fecha_real) ?? fromName?.[1] ?? '',
+        diaInicio: asNumber(data.dia_inicio) ?? null,
+        diaFin: asNumber(data.dia_fin) ?? null,
+        procesado: asBoolean(data.procesado) ?? false,
+        entradas,
+    };
+}
+
+// ── Payload grammar parsers (each inverts one serialization) ────────────────
+
+/** `N` (gasto/ganancia): integer credits. */
+export function parseCantidadPayload(payload: string): number | null {
+    const match = /^[+-]?\d+$/.exec(payload.trim());
+    return match ? Number(match[0]) : null;
+}
+
+/** `<nombre> A->B` (medidor). */
+export function parseMedidorPayload(
+    payload: string
+): { nombre: string; from: number; to: number } | null {
+    const match = /^(\S+)\s+([+-]?\d+)\s*->\s*([+-]?\d+)$/.exec(payload.trim());
+    if (!match) return null;
+    return { nombre: match[1], from: Number(match[2]), to: Number(match[3]) };
+}
+
+/** `<id> A->B` with string states — shared by pista (estados) and sabe (niveles). */
+export function parseTransicionPayload(
+    payload: string
+): { id: string; from: string; to: string } | null {
+    const match = /^(\S+)\s+(\S+?)\s*->\s*(\S+)$/.exec(payload.trim());
+    if (!match) return null;
+    return { id: match[1], from: match[2], to: match[3] };
+}
+
+/** `<id> estadoA->estadoB` (pista). */
+export const parsePistaPayload = parseTransicionPayload;
+
+/** `<entidad> nivelA->nivelB` (sabe). */
+export const parseSabePayload = parseTransicionPayload;
+
+/** `<lugar> | dia N` (llegada). */
+export function parseLlegadaPayload(
+    payload: string
+): { lugarId: string; dia: number } | null {
+    const match = /^(\S+)\s*\|\s*dia\s+([+-]?\d+)$/.exec(payload.trim());
+    if (!match) return null;
+    return { lugarId: match[1], dia: Number(match[2]) };
+}
+
+/** `<lugar> | N dias, llegada estimada dia M` (rumbo). */
+export function parseRumboPayload(
+    payload: string
+): { destino: string; dias: number; llegadaDia: number } | null {
+    const match = /^(\S+)\s*\|\s*([+-]?\d+)\s+dias?\s*,\s*llegada\s+estimada\s+dia\s+([+-]?\d+)$/.exec(
+        payload.trim()
+    );
+    if (!match) return null;
+    return { destino: match[1], dias: Number(match[2]), llegadaDia: Number(match[3]) };
+}
+
+/** `N dias` (descanso). */
+export function parseDescansoPayload(payload: string): { dias: number } | null {
+    const match = /^([+-]?\d+)\s+dias?$/.exec(payload.trim());
+    return match ? { dias: Number(match[1]) } : null;
+}
+
+/** `A->B` (dia). */
+export function parseDiaPayload(payload: string): { from: number; to: number } | null {
+    const match = /^([+-]?\d+)\s*->\s*([+-]?\d+)$/.exec(payload.trim());
+    if (!match) return null;
+    return { from: Number(match[1]), to: Number(match[2]) };
+}
+
+/** `dia N @ <lugar>` (inicio/fin). */
+export function parseInicioFinPayload(
+    payload: string
+): { dia: number; lugarId: string } | null {
+    const match = /^dia\s+([+-]?\d+)\s+@\s+(\S+)$/.exec(payload.trim());
+    if (!match) return null;
+    return { dia: Number(match[1]), lugarId: match[2] };
+}
+
+/** `<tabla>#<id>` (evento). */
+export function parseEventoPayload(
+    payload: string
+): { tablaId: string; eventoId: string } | null {
+    const match = /^([^#\s]+)#(\S+)$/.exec(payload.trim());
+    if (!match) return null;
+    return { tablaId: match[1], eventoId: match[2] };
+}
+
+// ── Entry factory ───────────────────────────────────────────────────────────
+
+/** Injectable clock (a function returning Date); defaults to the system clock. */
+export type Clock = () => Date;
+
+function horaNow(clock: Clock | undefined): string {
+    const now = clock ? clock() : new Date();
+    const hh = String(now.getHours()).padStart(2, '0');
+    const mm = String(now.getMinutes()).padStart(2, '0');
+    return `${hh}:${mm}`;
+}
+
+function entry(
+    tipo: JournalEntryType,
+    payload: string,
+    comentario: string | undefined,
+    clock: Clock | undefined
+): JournalEntry {
+    const limpio = sanitizeComentario(comentario);
+    return limpio === undefined
+        ? { hora: horaNow(clock), tipo, payload }
+        : { hora: horaNow(clock), tipo, payload, comentario: limpio };
+}
+
+/** When the party's location is unknown, inicio/fin log `desconocida`. */
+const LUGAR_DESCONOCIDO = 'desconocida';
+
+/**
+ * One builder per tipo, each producing a JournalEntry with the exact payload
+ * grammar documented above. The optional trailing `clock` is injectable for
+ * tests; comments have their '|' pipes replaced with '/' (see module doc).
+ */
+export const makeEntry = {
+    inicio(dia: number, lugarId: string | null, clock?: Clock): JournalEntry {
+        return entry('inicio', `dia ${dia} @ ${lugarId ?? LUGAR_DESCONOCIDO}`, undefined, clock);
+    },
+    fin(dia: number, lugarId: string | null, clock?: Clock): JournalEntry {
+        return entry('fin', `dia ${dia} @ ${lugarId ?? LUGAR_DESCONOCIDO}`, undefined, clock);
+    },
+    rumbo(
+        destinoId: string,
+        dias: number,
+        llegadaDia: number,
+        comentario?: string,
+        clock?: Clock
+    ): JournalEntry {
+        return entry(
+            'rumbo',
+            `${destinoId} | ${dias} dias, llegada estimada dia ${llegadaDia}`,
+            comentario,
+            clock
+        );
+    },
+    llegada(lugarId: string, dia: number, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('llegada', `${lugarId} | dia ${dia}`, comentario, clock);
+    },
+    gasto(cantidad: number, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('gasto', `${cantidad}`, comentario, clock);
+    },
+    ganancia(cantidad: number, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('ganancia', `${cantidad}`, comentario, clock);
+    },
+    medidor(
+        nombre: string,
+        from: number,
+        to: number,
+        comentario?: string,
+        clock?: Clock
+    ): JournalEntry {
+        return entry('medidor', `${nombre} ${from}->${to}`, comentario, clock);
+    },
+    pista(id: string, from: string, to: string, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('pista', `${id} ${from}->${to}`, comentario, clock);
+    },
+    sabe(id: string, from: string, to: string, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('sabe', `${id} ${from}->${to}`, comentario, clock);
+    },
+    evento(tablaId: string, eventoId: string, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('evento', `${tablaId}#${eventoId}`, comentario, clock);
+    },
+    descanso(dias: number, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('descanso', `${dias} dias`, comentario, clock);
+    },
+    dia(from: number, to: number, comentario?: string, clock?: Clock): JournalEntry {
+        return entry('dia', `${from}->${to}`, comentario, clock);
+    },
+    nota(comentario: string, clock?: Clock): JournalEntry {
+        return entry('nota', '', comentario, clock);
+    },
+};
+
+// ── Snapshot reducer ────────────────────────────────────────────────────────
+
+/**
+ * Applies one entry to a party snapshot — pure: returns a NEW snapshot when
+ * the entry changes it, the SAME object otherwise. Used both for live apply
+ * (partyStore.log) and replay-undo (re-apply remaining entries over the
+ * session-start snapshot). Unparseable payloads are a no-op, never an error.
+ *
+ *   gasto/ganancia  creditos -/+ N
+ *   medidor         medidores[nombre] = to
+ *   llegada         ubicacion + diaMundo, rumbo cleared
+ *   rumbo           rumbo = {destino, llegadaDia}
+ *   descanso        diaMundo + N
+ *   dia             diaMundo = to
+ *   inicio/fin/nota/pista/sabe/evento — snapshot unchanged
+ */
+export function applyEntryToSnapshot(snap: PartySnapshot, entry: JournalEntry): PartySnapshot {
+    switch (entry.tipo) {
+        case 'gasto': {
+            const cantidad = parseCantidadPayload(entry.payload);
+            if (cantidad === null) return snap;
+            return { ...snap, creditos: snap.creditos - cantidad };
+        }
+        case 'ganancia': {
+            const cantidad = parseCantidadPayload(entry.payload);
+            if (cantidad === null) return snap;
+            return { ...snap, creditos: snap.creditos + cantidad };
+        }
+        case 'medidor': {
+            const medidor = parseMedidorPayload(entry.payload);
+            if (medidor === null) return snap;
+            return {
+                ...snap,
+                medidores: { ...snap.medidores, [medidor.nombre]: medidor.to },
+            };
+        }
+        case 'llegada': {
+            const llegada = parseLlegadaPayload(entry.payload);
+            if (llegada === null) return snap;
+            return { ...snap, ubicacion: llegada.lugarId, diaMundo: llegada.dia, rumbo: null };
+        }
+        case 'rumbo': {
+            const rumbo = parseRumboPayload(entry.payload);
+            if (rumbo === null) return snap;
+            return { ...snap, rumbo: { destino: rumbo.destino, llegadaDia: rumbo.llegadaDia } };
+        }
+        case 'descanso': {
+            const descanso = parseDescansoPayload(entry.payload);
+            if (descanso === null) return snap;
+            return { ...snap, diaMundo: snap.diaMundo + descanso.dias };
+        }
+        case 'dia': {
+            const dia = parseDiaPayload(entry.payload);
+            if (dia === null) return snap;
+            return { ...snap, diaMundo: dia.to };
+        }
+        // Knowledge/lead/event/bookkeeping entries never touch the snapshot.
+        case 'inicio':
+        case 'fin':
+        case 'nota':
+        case 'pista':
+        case 'sabe':
+        case 'evento':
+            return snap;
+    }
+}

--- a/lib/world/ongoingEvents.test.ts
+++ b/lib/world/ongoingEvents.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { EventTable, JournalEntry, WorldEvent } from '@/types/world';
+import { deriveOngoing } from './ongoingEvents';
+
+function evt(id: string, titulo: string): WorldEvent {
+    return { id, titulo, peso: 1, si: [], etiquetas: [], unico: false, cuerpo: '', efectos: [] };
+}
+
+function table(id: string, eventos: WorldEvent[]): EventTable {
+    return {
+        id,
+        tipo: 'eventos',
+        nombre: id,
+        filePath: `mundo/eventos/${id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        contexto: 'estancia',
+        regiones: [],
+        sesgos: [],
+        eventos,
+    };
+}
+
+/** Minimal evento journal entry (payload `<tabla>#<id>`, comentario = outcome). */
+function evento(tabla: string, id: string, comentario: string | undefined, hora = '14:05'): JournalEntry {
+    return { hora, tipo: 'evento', payload: `${tabla}#${id}`, comentario };
+}
+
+const TABLAS: EventTable[] = [
+    table('estancia_porto', [evt('e01', 'Encargo de descarga'), evt('e02', 'Reyerta en el muelle')]),
+    table('viaje_nucleo', [evt('v01', 'Control de aduanas')]),
+];
+
+describe('deriveOngoing', () => {
+    test('en curso => ongoing, resolved states => dropped', () => {
+        const entries: JournalEntry[] = [
+            evento('estancia_porto', 'e01', 'en curso'),
+            evento('estancia_porto', 'e02', 'resuelto'),
+            evento('viaje_nucleo', 'v01', 'ignorado'),
+        ];
+        const ongoing = deriveOngoing(entries, TABLAS);
+        expect(ongoing).toHaveLength(1);
+        expect(ongoing[0]).toEqual({
+            tabla: 'estancia_porto',
+            id: 'e01',
+            titulo: 'Encargo de descarga',
+            tablaNombre: 'estancia_porto',
+            hora: '14:05',
+        });
+    });
+
+    test('latest state per id wins: en curso then resuelto => dropped', () => {
+        const entries: JournalEntry[] = [
+            evento('estancia_porto', 'e01', 'en curso', '14:00'),
+            evento('estancia_porto', 'e01', 'resuelto', '14:30'),
+        ];
+        expect(deriveOngoing(entries, TABLAS)).toHaveLength(0);
+    });
+
+    test('re-parking after a resolution puts it back as ongoing with the latest hora', () => {
+        const entries: JournalEntry[] = [
+            evento('estancia_porto', 'e01', 'en curso', '14:00'),
+            evento('estancia_porto', 'e01', 'resuelto', '14:30'),
+            evento('estancia_porto', 'e01', 'en curso', '15:00'),
+        ];
+        const ongoing = deriveOngoing(entries, TABLAS);
+        expect(ongoing).toHaveLength(1);
+        expect(ongoing[0].hora).toBe('15:00');
+    });
+
+    test('complicación and empty/other comentarios never count as ongoing', () => {
+        const entries: JournalEntry[] = [
+            evento('estancia_porto', 'e01', 'complicación: fuga'),
+            evento('estancia_porto', 'e02', undefined),
+            evento('viaje_nucleo', 'v01', 'algo raro'),
+        ];
+        expect(deriveOngoing(entries, TABLAS)).toHaveLength(0);
+    });
+
+    test('ids missing from the model are skipped even when latest is en curso', () => {
+        const entries: JournalEntry[] = [
+            evento('estancia_porto', 'e01', 'en curso'), // valid
+            evento('tabla_borrada', 'x99', 'en curso'), // table gone
+            evento('estancia_porto', 'e_removed', 'en curso'), // event gone
+        ];
+        const ongoing = deriveOngoing(entries, TABLAS);
+        expect(ongoing.map((o) => o.id)).toEqual(['e01']);
+    });
+
+    test('multiple ongoing events keep first-parked order', () => {
+        const entries: JournalEntry[] = [
+            evento('viaje_nucleo', 'v01', 'en curso', '10:00'),
+            evento('estancia_porto', 'e01', 'en curso', '11:00'),
+        ];
+        const ongoing = deriveOngoing(entries, TABLAS);
+        expect(ongoing.map((o) => o.id)).toEqual(['v01', 'e01']);
+    });
+
+    test('non-evento entries and unparseable payloads are ignored', () => {
+        const entries: JournalEntry[] = [
+            { hora: '09:00', tipo: 'nota', payload: '', comentario: 'una nota' },
+            { hora: '09:01', tipo: 'evento', payload: 'sin_almohadilla', comentario: 'en curso' },
+            evento('estancia_porto', 'e01', 'en curso'),
+        ];
+        const ongoing = deriveOngoing(entries, TABLAS);
+        expect(ongoing.map((o) => o.id)).toEqual(['e01']);
+    });
+
+    test('empty inputs yield an empty list', () => {
+        expect(deriveOngoing([], TABLAS)).toEqual([]);
+        expect(deriveOngoing([evento('estancia_porto', 'e01', 'en curso')], [])).toEqual([]);
+    });
+});

--- a/lib/world/ongoingEvents.ts
+++ b/lib/world/ongoingEvents.ts
@@ -1,0 +1,82 @@
+/**
+ * Ongoing-events derivation ("En curso" — feature 1).
+ *
+ * A drawn event is journaled as an `evento` entry (`<tabla>#<id>` payload) with
+ * a comentario carrying its outcome: `resuelto` / `ignorado` / `complicación`
+ * (with or without a nota) — or the new `en curso`, which PARKS the event as
+ * ongoing rather than closing the thread.
+ *
+ * The ongoing list is a PURE projection of the session journal: for each event
+ * id, only its LATEST comentario matters. The event is ONGOING iff that latest
+ * comentario is exactly "en curso"; any other value (resuelto, ignorado,
+ * complicación, anything else — including an empty comentario) means the thread
+ * is resolved and the event drops off the list. So a fight parked "en curso"
+ * and later resolved leaves the ongoing list, and re-parking it puts it back.
+ *
+ * Ids no longer present in the model (renamed/removed tables or events) are
+ * skipped — the ongoing list only ever surfaces reopenable events. Because the
+ * derivation reads only the restored session entries, it reconstructs correctly
+ * after crash recovery.
+ */
+
+import { JournalEntry, EventTable } from '@/types/world';
+import { parseEventoPayload } from './logEntries';
+
+/** The exact comentario an "En curso" outcome writes (feature 1 contract). */
+export const EN_CURSO_COMENTARIO = 'en curso';
+
+/** One ongoing (parked) event, resolved against the live model. */
+export interface OngoingEvent {
+    /** Event-table id (`<tabla>` half of the evento payload). */
+    tabla: string;
+    /** Event id (`<id>` half of the evento payload). */
+    id: string;
+    /** Display title of the WorldEvent, looked up in the model. */
+    titulo: string;
+    /** Display name of the table the event belongs to. */
+    tablaNombre: string;
+    /** Wall-clock HH:MM of the LATEST evento entry that parked it. */
+    hora: string;
+}
+
+/**
+ * Derives the ongoing (parked) events from a session's journal entries.
+ *
+ * Walks the entries in order keeping, per event id, the latest evento entry;
+ * an id whose latest comentario is exactly "en curso" and that still resolves
+ * to a WorldEvent in `tablas` becomes an OngoingEvent (carrying that entry's
+ * hora). Ids resolved elsewhere / missing from the model are dropped. Result
+ * order = first-parked-first (stable insertion order of the latest-per-id map).
+ */
+export function deriveOngoing(entries: JournalEntry[], tablas: EventTable[]): OngoingEvent[] {
+    // Latest evento entry per `<tabla>#<id>` key (later entries overwrite).
+    const latest = new Map<string, { tabla: string; id: string; comentario: string; hora: string }>();
+    for (const entry of entries) {
+        if (entry.tipo !== 'evento') continue;
+        const parsed = parseEventoPayload(entry.payload);
+        if (!parsed) continue;
+        const key = `${parsed.tablaId}#${parsed.eventoId}`;
+        latest.set(key, {
+            tabla: parsed.tablaId,
+            id: parsed.eventoId,
+            comentario: (entry.comentario ?? '').trim(),
+            hora: entry.hora,
+        });
+    }
+
+    const ongoing: OngoingEvent[] = [];
+    for (const record of latest.values()) {
+        if (record.comentario !== EN_CURSO_COMENTARIO) continue;
+        const table = tablas.find((t) => t.id === record.tabla);
+        const event = table?.eventos.find((e) => e.id === record.id);
+        if (!table || !event) continue; // id no longer in the model — not reopenable
+        ongoing.push({
+            tabla: record.tabla,
+            id: record.id,
+            titulo: event.titulo,
+            tablaNombre: table.nombre,
+            hora: record.hora,
+        });
+    }
+    return ongoing;
+}

--- a/lib/world/partyState.test.ts
+++ b/lib/world/partyState.test.ts
@@ -1,0 +1,248 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { WorldManifest } from '@/types/world';
+import { defaultPartyState, formatFecha, parsePartyState } from './partyState';
+
+const FILE_PATH = 'mundo/estado/grupo.md';
+
+// ── parsePartyState ─────────────────────────────────────────────────────────
+
+describe('parsePartyState — full frontmatter', () => {
+    const FULL = `---
+tipo: estado_grupo
+sesion_activa: true
+dia_mundo: 107
+ubicacion: porto_verne
+rumbo:
+  destino: sistema_kovar
+  llegada_dia: 110
+creditos: 850
+medidores:
+  viveres: 2
+  combustible: 1
+  nave: 4
+  moral: 5
+---
+## Inventario
+
+- 3 cargas de mineral
+`;
+
+    test('parses every app-owned field', () => {
+        const { state, issues } = parsePartyState(FULL, FILE_PATH);
+
+        expect(issues).toHaveLength(0);
+        expect(state.sesionActiva).toBe(true);
+        expect(state.diaMundo).toBe(107);
+        expect(state.ubicacion).toBe('porto_verne');
+        expect(state.rumbo).toEqual({ destino: 'sistema_kovar', llegadaDia: 110 });
+        expect(state.creditos).toBe(850);
+        expect(state.medidores).toEqual({ viveres: 2, combustible: 1, nave: 4, moral: 5 });
+        expect(state.filePath).toBe(FILE_PATH);
+        expect(state.bodyMd).toBe('## Inventario\n\n- 3 cargas de mineral\n');
+    });
+});
+
+describe('parsePartyState — tolerant defaults', () => {
+    test('empty frontmatter: silent defaults', () => {
+        const { state, issues } = parsePartyState('---\ntipo: estado_grupo\n---\ncuerpo\n', FILE_PATH);
+
+        expect(issues).toHaveLength(0);
+        expect(state.sesionActiva).toBe(false);
+        expect(state.diaMundo).toBe(1);
+        expect(state.ubicacion).toBeNull();
+        expect(state.rumbo).toBeNull();
+        expect(state.creditos).toBe(0);
+        expect(state.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+    });
+
+    test('defaultPartyState: filePath null when the file is absent', () => {
+        const state = defaultPartyState();
+
+        expect(state.filePath).toBeNull();
+        expect(state.sesionActiva).toBe(false);
+        expect(state.diaMundo).toBe(1);
+        expect(state.creditos).toBe(0);
+        expect(state.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+        expect(state.bodyMd).toBe('');
+    });
+
+    test('defaultPartyState returns a fresh medidores object each call', () => {
+        const a = defaultPartyState();
+        a.medidores.viveres = 0;
+        expect(defaultPartyState().medidores.viveres).toBe(3);
+    });
+
+    test('no frontmatter at all: defaults + whole file as body', () => {
+        const content = 'solo prosa del agente\n';
+        const { state, issues } = parsePartyState(content, FILE_PATH);
+
+        expect(issues).toHaveLength(0);
+        expect(state.diaMundo).toBe(1);
+        expect(state.bodyMd).toBe(content);
+    });
+
+    test('partial medidores overlay the defaults', () => {
+        const { state, issues } = parsePartyState(
+            '---\nmedidores:\n  combustible: 0\n---\n',
+            FILE_PATH
+        );
+
+        expect(issues).toHaveLength(0);
+        expect(state.medidores).toEqual({ viveres: 3, combustible: 0, nave: 3 });
+    });
+
+    test('malformed fields: aviso each, defaults kept', () => {
+        const { state, issues } = parsePartyState(
+            [
+                '---',
+                'sesion_activa: quizas',
+                'dia_mundo: [3]',
+                'creditos: mucho',
+                'rumbo: sistema_kovar',
+                'medidores:',
+                '  viveres: pocos',
+                '---',
+                '',
+            ].join('\n'),
+            FILE_PATH
+        );
+
+        expect(issues).toHaveLength(5);
+        expect(issues.every((issue) => issue.nivel === 'aviso')).toBe(true);
+        expect(issues.every((issue) => issue.archivo === FILE_PATH)).toBe(true);
+        expect(state.sesionActiva).toBe(false);
+        expect(state.diaMundo).toBe(1);
+        expect(state.creditos).toBe(0);
+        expect(state.rumbo).toBeNull();
+        expect(state.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+    });
+
+    test('rumbo without llegada_dia: aviso, stays null', () => {
+        const { state, issues } = parsePartyState(
+            '---\nrumbo:\n  destino: sistema_kovar\n---\n',
+            FILE_PATH
+        );
+
+        expect(state.rumbo).toBeNull();
+        expect(issues).toHaveLength(1);
+        expect(issues[0].mensaje).toContain('rumbo');
+    });
+
+    test('rumbo: null (arrival cleared) is not an aviso', () => {
+        const { state, issues } = parsePartyState('---\nrumbo: null\n---\n', FILE_PATH);
+
+        expect(state.rumbo).toBeNull();
+        expect(issues).toHaveLength(0);
+    });
+
+    test('unexpected tipo earns an aviso', () => {
+        const { issues } = parsePartyState('---\ntipo: lugar\n---\n', FILE_PATH);
+
+        expect(issues).toHaveLength(1);
+        expect(issues[0].nivel).toBe('aviso');
+        expect(issues[0].mensaje).toContain('estado_grupo');
+    });
+
+    test('malformed YAML: error issue, defaults, body preserved', () => {
+        const { state, issues } = parsePartyState(
+            '---\nsesion_activa: [sin cerrar\n---\ncuerpo intacto\n',
+            FILE_PATH
+        );
+
+        expect(issues).toHaveLength(1);
+        expect(issues[0].nivel).toBe('error');
+        expect(issues[0].mensaje).toContain('YAML inválido');
+        expect(state.sesionActiva).toBe(false);
+        expect(state.creditos).toBe(0);
+        expect(state.bodyMd).toBe('cuerpo intacto\n');
+    });
+});
+
+describe('parsePartyState — body preserved byte-for-byte', () => {
+    test('weird spacing, tabs, emoji and no trailing newline', () => {
+        const body =
+            '\n##  Inventario 🎒\n\n- línea con   espacios  \t\n\n\n   sangría rara\nfin sin salto final';
+        const { state } = parsePartyState(`---\ncreditos: 10\n---\n${body}`, FILE_PATH);
+
+        expect(state.bodyMd).toBe(body);
+    });
+
+    test('CRLF line endings survive untouched', () => {
+        const { state } = parsePartyState(
+            '---\r\ncreditos: 5\r\n---\r\nlínea uno\r\n\r\ncohete 🚀\r\n',
+            FILE_PATH
+        );
+
+        expect(state.bodyMd).toBe('línea uno\r\n\r\ncohete 🚀\r\n');
+    });
+
+    test('empty body stays empty', () => {
+        const { state } = parsePartyState('---\ncreditos: 1\n---\n', FILE_PATH);
+
+        expect(state.bodyMd).toBe('');
+    });
+});
+
+// ── formatFecha ─────────────────────────────────────────────────────────────
+
+function makeManifest(calendario?: Partial<WorldManifest['calendario']>): WorldManifest {
+    return {
+        nombre: 'Sector Verne',
+        calendario: {
+            era: 'dG',
+            anoEpoca: 322,
+            diasPorMes: 30,
+            meses: ['Abadius', 'Calistril', 'Pharast', 'Gozran', 'Desnus', 'Sarenith'],
+            ...calendario,
+        },
+        viaje: {
+            diasPorUnidad: 1,
+            intrasistemaDias: 1,
+            combustiblePorTramo: 1,
+            viveresCadaDias: 4,
+        },
+        medidores: ['viveres', 'combustible', 'nave'],
+        regiones: [],
+    };
+}
+
+describe('formatFecha', () => {
+    // 6 meses × 30 días = 180 días por año en el manifest de prueba.
+
+    test('día 1 = day 1 of month 1 of ano_epoca', () => {
+        expect(formatFecha(1, makeManifest())).toBe('1 de Abadius, 322 dG');
+    });
+
+    test('renders the plan example shape: 17 de Gozran, 322 dG', () => {
+        // día 107 = 3 meses completos (90) + 16 días → día 17 de Gozran
+        expect(formatFecha(107, makeManifest())).toBe('17 de Gozran, 322 dG');
+    });
+
+    test('month boundary: last day vs first day of the next month', () => {
+        expect(formatFecha(30, makeManifest())).toBe('30 de Abadius, 322 dG');
+        expect(formatFecha(31, makeManifest())).toBe('1 de Calistril, 322 dG');
+    });
+
+    test('year rollover: last day of the year vs day 1 of the next', () => {
+        expect(formatFecha(180, makeManifest())).toBe('30 de Sarenith, 322 dG');
+        expect(formatFecha(181, makeManifest())).toBe('1 de Abadius, 323 dG');
+        expect(formatFecha(361, makeManifest())).toBe('1 de Abadius, 324 dG');
+    });
+
+    test('non-integer days floor; days below 1 clamp to day 1', () => {
+        expect(formatFecha(31.9, makeManifest())).toBe('1 de Calistril, 322 dG');
+        expect(formatFecha(0, makeManifest())).toBe('1 de Abadius, 322 dG');
+        expect(formatFecha(-14, makeManifest())).toBe('1 de Abadius, 322 dG');
+    });
+
+    test('empty era omits the suffix', () => {
+        expect(formatFecha(107, makeManifest({ era: '' }))).toBe('17 de Gozran, 322');
+    });
+
+    test('degrades to "Día N" without usable calendar data', () => {
+        expect(formatFecha(42, makeManifest({ meses: [] }))).toBe('Día 42');
+        expect(formatFecha(7, makeManifest({ diasPorMes: 0 }))).toBe('Día 7');
+        expect(formatFecha(Number.NaN, makeManifest())).toBe('1 de Abadius, 322 dG');
+    });
+});

--- a/lib/world/partyState.test.ts
+++ b/lib/world/partyState.test.ts
@@ -199,7 +199,7 @@ function makeManifest(calendario?: Partial<WorldManifest['calendario']>): WorldM
         viaje: {
             diasPorUnidad: 1,
             intrasistemaDias: 1,
-            combustiblePorTramo: 1,
+            combustibleCadaDias: 4,
             viveresCadaDias: 4,
         },
         medidores: ['viveres', 'combustible', 'nave'],

--- a/lib/world/partyState.test.ts
+++ b/lib/world/partyState.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { test, expect, describe } from 'bun:test';
 import { WorldManifest } from '@/types/world';
-import { defaultPartyState, formatFecha, parsePartyState } from './partyState';
+import { defaultPartyState, formatFecha, parsePartyState, serializePartyState } from './partyState';
 
 const FILE_PATH = 'mundo/estado/grupo.md';
 
@@ -22,6 +22,7 @@ medidores:
   combustible: 1
   nave: 4
   moral: 5
+personajes: [Xiao, Chesco, Soy]
 ---
 ## Inventario
 
@@ -38,6 +39,7 @@ medidores:
         expect(state.rumbo).toEqual({ destino: 'sistema_kovar', llegadaDia: 110 });
         expect(state.creditos).toBe(850);
         expect(state.medidores).toEqual({ viveres: 2, combustible: 1, nave: 4, moral: 5 });
+        expect(state.personajes).toEqual(['Xiao', 'Chesco', 'Soy']);
         expect(state.filePath).toBe(FILE_PATH);
         expect(state.bodyMd).toBe('## Inventario\n\n- 3 cargas de mineral\n');
     });
@@ -54,6 +56,7 @@ describe('parsePartyState — tolerant defaults', () => {
         expect(state.rumbo).toBeNull();
         expect(state.creditos).toBe(0);
         expect(state.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+        expect(state.personajes).toEqual([]);
     });
 
     test('defaultPartyState: filePath null when the file is absent', () => {
@@ -64,6 +67,7 @@ describe('parsePartyState — tolerant defaults', () => {
         expect(state.diaMundo).toBe(1);
         expect(state.creditos).toBe(0);
         expect(state.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+        expect(state.personajes).toEqual([]);
         expect(state.bodyMd).toBe('');
     });
 
@@ -181,6 +185,52 @@ describe('parsePartyState — body preserved byte-for-byte', () => {
         const { state } = parsePartyState('---\ncreditos: 1\n---\n', FILE_PATH);
 
         expect(state.bodyMd).toBe('');
+    });
+});
+
+// ── personajes (roster) round-trip + serialize preservation ─────────────────
+
+describe('personajes roster', () => {
+    const NOW_ISO = '2026-07-04T12:00:00.000Z';
+
+    test('parses a bracketed list and a lone scalar; omitted stays []', () => {
+        expect(parsePartyState('---\npersonajes: [Xiao, Chesco]\n---\n', FILE_PATH).state.personajes)
+            .toEqual(['Xiao', 'Chesco']);
+        // A lone scalar tolerates `personajes: Xiao` (asStringArray).
+        expect(parsePartyState('---\npersonajes: Xiao\n---\n', FILE_PATH).state.personajes)
+            .toEqual(['Xiao']);
+        // Omitted / null / empty list -> [] (never an aviso).
+        expect(parsePartyState('---\ntipo: estado_grupo\n---\n', FILE_PATH).state.personajes)
+            .toEqual([]);
+        expect(parsePartyState('---\npersonajes: null\n---\n', FILE_PATH).state.personajes)
+            .toEqual([]);
+        expect(parsePartyState('---\npersonajes: []\n---\n', FILE_PATH).state.personajes)
+            .toEqual([]);
+    });
+
+    test('serialize -> parse round-trips the roster', () => {
+        const state = defaultPartyState(FILE_PATH);
+        state.personajes = ['Xiao', 'Chesco', 'Soy'];
+        const text = serializePartyState(state, NOW_ISO);
+        expect(text).toContain('personajes:');
+        expect(parsePartyState(text, FILE_PATH).state.personajes).toEqual(['Xiao', 'Chesco', 'Soy']);
+    });
+
+    test('an empty roster serializes as personajes: [] and round-trips', () => {
+        const text = serializePartyState(defaultPartyState(FILE_PATH), NOW_ISO);
+        expect(text).toContain('personajes: []');
+        expect(parsePartyState(text, FILE_PATH).state.personajes).toEqual([]);
+    });
+
+    test('roster survives a serialize even when every OTHER field is rewritten', () => {
+        // Preservation-through-write: a state carrying only the roster (defaults
+        // elsewhere) must NOT lose it after serialize (the app-owned rewrite).
+        const state = defaultPartyState(FILE_PATH);
+        state.personajes = ['Xiao', 'Chesco'];
+        state.creditos = 999;
+        const reparsed = parsePartyState(serializePartyState(state, NOW_ISO), FILE_PATH).state;
+        expect(reparsed.personajes).toEqual(['Xiao', 'Chesco']);
+        expect(reparsed.creditos).toBe(999);
     });
 });
 

--- a/lib/world/partyState.ts
+++ b/lib/world/partyState.ts
@@ -13,7 +13,7 @@
 import { stringify as stringifyYaml } from 'yaml';
 import { PartyState, ValidationIssue, WorldManifest } from '@/types/world';
 import { DEFAULT_MEDIDORES } from './constants';
-import { asNumber, asString, normalizeKeys, parseFrontmatter } from './frontmatter';
+import { asNumber, asString, asStringArray, normalizeKeys, parseFrontmatter } from './frontmatter';
 
 export interface ParsePartyStateResult {
     state: PartyState;
@@ -32,6 +32,7 @@ export function defaultPartyState(filePath: string | null = null): PartyState {
         rumbo: null,
         creditos: 0,
         medidores: { ...DEFAULT_MEDIDORES },
+        personajes: [],
         bodyMd: '',
         filePath,
     };
@@ -146,6 +147,13 @@ export function parsePartyState(content: string, filePath: string): ParsePartySt
         }
     }
 
+    if (data.personajes !== undefined && data.personajes !== null) {
+        // asStringArray tolerates a lone scalar and drops uncoercible items;
+        // an empty/omitted list simply stays [] (never an aviso — a party may
+        // have no roster recorded yet).
+        state.personajes = asStringArray(data.personajes);
+    }
+
     return { state, issues };
 }
 
@@ -173,7 +181,8 @@ function yamlScalar(value: string | number | boolean): string {
  *
  * Frontmatter key order (stable, human-friendly — documented contract):
  *   tipo, actualizado, sesion_activa, dia_mundo, ubicacion,
- *   rumbo (nested destino / llegada_dia, or null), creditos, medidores.
+ *   rumbo (nested destino / llegada_dia, or null), creditos, medidores,
+ *   personajes (roster — round-tripped so a session write never drops it).
  *
  * `actualizado` is write-time metadata (ISO timestamp) — parsePartyState
  * ignores it by design.
@@ -205,6 +214,17 @@ export function serializePartyState(state: PartyState, nowIso: string): string {
         lines.push('medidores:');
         for (const [nombre, valor] of medidores) {
             lines.push(`  ${yamlScalar(nombre)}: ${yamlScalar(valor)}`);
+        }
+    }
+
+    // Roster: app never edits it, but MUST preserve it byte-equivalently so a
+    // session write does not erase the PCs the cockpit initiative needs.
+    if (state.personajes.length === 0) {
+        lines.push('personajes: []');
+    } else {
+        lines.push('personajes:');
+        for (const nombre of state.personajes) {
+            lines.push(`  - ${yamlScalar(nombre)}`);
         }
     }
 

--- a/lib/world/partyState.ts
+++ b/lib/world/partyState.ts
@@ -10,6 +10,7 @@
  * Pure functions: no filesystem, no store access.
  */
 
+import { stringify as stringifyYaml } from 'yaml';
 import { PartyState, ValidationIssue, WorldManifest } from '@/types/world';
 import { DEFAULT_MEDIDORES } from './constants';
 import { asNumber, asString, normalizeKeys, parseFrontmatter } from './frontmatter';
@@ -146,6 +147,69 @@ export function parsePartyState(content: string, filePath: string): ParsePartySt
     }
 
     return { state, issues };
+}
+
+// ── Serialization (M3 write path) ───────────────────────────────────────────
+
+/**
+ * Dumps a scalar through the yaml package so quoting is always safe; strings
+ * whose dump would span lines (embedded newlines → block scalars) fall back
+ * to JSON quoting, which is valid YAML and keeps the frontmatter line-based.
+ */
+function yamlScalar(value: string | number | boolean): string {
+    const dumped = stringifyYaml(value).trimEnd();
+    return typeof value === 'string' && dumped.includes('\n')
+        ? JSON.stringify(value)
+        : dumped;
+}
+
+/**
+ * Serializes a PartyState back to `estado/grupo.md` text. The app rewrites
+ * ONLY the frontmatter; `bodyMd` is appended EXACTLY as parsed (byte-for-byte
+ * — when bodyMd is empty the output is just the frontmatter block ending in a
+ * newline). Round-trip guarantee: parsePartyState(serializePartyState(s, iso))
+ * reproduces every frontmatter field and bodyMd of `s` (medidores overlay the
+ * three defaults, so an *empty* medidores map parses back as the defaults).
+ *
+ * Frontmatter key order (stable, human-friendly — documented contract):
+ *   tipo, actualizado, sesion_activa, dia_mundo, ubicacion,
+ *   rumbo (nested destino / llegada_dia, or null), creditos, medidores.
+ *
+ * `actualizado` is write-time metadata (ISO timestamp) — parsePartyState
+ * ignores it by design.
+ */
+export function serializePartyState(state: PartyState, nowIso: string): string {
+    const lines: string[] = [
+        '---',
+        'tipo: estado_grupo',
+        `actualizado: ${yamlScalar(nowIso)}`,
+        `sesion_activa: ${state.sesionActiva}`,
+        `dia_mundo: ${yamlScalar(state.diaMundo)}`,
+        `ubicacion: ${state.ubicacion === null ? 'null' : yamlScalar(state.ubicacion)}`,
+    ];
+
+    if (state.rumbo === null) {
+        lines.push('rumbo: null');
+    } else {
+        lines.push('rumbo:');
+        lines.push(`  destino: ${yamlScalar(state.rumbo.destino)}`);
+        lines.push(`  llegada_dia: ${yamlScalar(state.rumbo.llegadaDia)}`);
+    }
+
+    lines.push(`creditos: ${yamlScalar(state.creditos)}`);
+
+    const medidores = Object.entries(state.medidores);
+    if (medidores.length === 0) {
+        lines.push('medidores: {}');
+    } else {
+        lines.push('medidores:');
+        for (const [nombre, valor] of medidores) {
+            lines.push(`  ${yamlScalar(nombre)}: ${yamlScalar(valor)}`);
+        }
+    }
+
+    lines.push('---');
+    return lines.join('\n') + '\n' + state.bodyMd;
 }
 
 // ── In-world date rendering ─────────────────────────────────────────────────

--- a/lib/world/partyState.ts
+++ b/lib/world/partyState.ts
@@ -1,0 +1,180 @@
+/**
+ * Party-state parsing for `mundo/estado/grupo.md` (plan Part A).
+ *
+ * The file is split-owned: frontmatter belongs to the app (session lock, day,
+ * location, heading, credits, gauges), the body belongs to the agent (inventory
+ * prose). Parsing here NEVER throws and never loses body bytes — `bodyMd`
+ * preserves everything below the closing fence byte-for-byte so the M3 writer
+ * can rewrite the header only.
+ *
+ * Pure functions: no filesystem, no store access.
+ */
+
+import { PartyState, ValidationIssue, WorldManifest } from '@/types/world';
+import { DEFAULT_MEDIDORES } from './constants';
+import { asNumber, asString, normalizeKeys, parseFrontmatter } from './frontmatter';
+
+export interface ParsePartyStateResult {
+    state: PartyState;
+    issues: ValidationIssue[];
+}
+
+/**
+ * Tolerant defaults, also used by the scanner when `estado/grupo.md` is absent
+ * (then with `filePath: null`).
+ */
+export function defaultPartyState(filePath: string | null = null): PartyState {
+    return {
+        sesionActiva: false,
+        diaMundo: 1,
+        ubicacion: null,
+        rumbo: null,
+        creditos: 0,
+        medidores: { ...DEFAULT_MEDIDORES },
+        bodyMd: '',
+        filePath,
+    };
+}
+
+/** Boolean, tolerating the string forms "true"/"false". Undefined otherwise. */
+function asBoolean(value: unknown): boolean | undefined {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+        const trimmed = value.trim().toLowerCase();
+        if (trimmed === 'true') return true;
+        if (trimmed === 'false') return false;
+    }
+    return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parses `estado/grupo.md` content into a PartyState.
+ *
+ * Tolerant by design: every missing/uncoercible field falls back to the
+ * defaults (sesionActiva false, diaMundo 1, creditos 0, gauges at 3) — a
+ * malformed field earns an aviso, a missing one is silent. Malformed YAML
+ * degrades to full defaults (plus the frontmatter error) with the body kept.
+ */
+export function parsePartyState(content: string, filePath: string): ParsePartyStateResult {
+    const issues: ValidationIssue[] = [];
+    const state = defaultPartyState(filePath);
+
+    const parsed = parseFrontmatter(content, filePath);
+    if (parsed.issue) issues.push(parsed.issue);
+    state.bodyMd = parsed.body;
+
+    const data = normalizeKeys(parsed.data);
+
+    const aviso = (mensaje: string) => {
+        issues.push({ nivel: 'aviso', archivo: filePath, mensaje });
+    };
+
+    const tipo = asString(data.tipo);
+    if (tipo !== undefined && tipo !== 'estado_grupo') {
+        aviso(`"tipo" inesperado en el estado del grupo: "${tipo}" (se esperaba "estado_grupo")`);
+    }
+
+    if (data.sesion_activa !== undefined) {
+        const sesionActiva = asBoolean(data.sesion_activa);
+        if (sesionActiva === undefined) {
+            aviso('"sesion_activa" no es un booleano — se usa false');
+        } else {
+            state.sesionActiva = sesionActiva;
+        }
+    }
+
+    if (data.dia_mundo !== undefined) {
+        const diaMundo = asNumber(data.dia_mundo);
+        if (diaMundo === undefined) {
+            aviso('"dia_mundo" no es un número — se usa 1');
+        } else {
+            state.diaMundo = diaMundo;
+        }
+    }
+
+    if (data.ubicacion !== undefined && data.ubicacion !== null) {
+        const ubicacion = asString(data.ubicacion);
+        if (ubicacion === undefined) {
+            aviso('"ubicacion" no es un id de lugar — se ignora');
+        } else {
+            state.ubicacion = ubicacion;
+        }
+    }
+
+    if (data.rumbo !== undefined && data.rumbo !== null) {
+        if (!isRecord(data.rumbo)) {
+            aviso('"rumbo" debe ser un mapa {destino, llegada_dia} — se ignora');
+        } else {
+            const destino = asString(data.rumbo.destino);
+            const llegadaDia = asNumber(data.rumbo.llegada_dia);
+            if (destino === undefined || llegadaDia === undefined) {
+                aviso('"rumbo" sin "destino" o "llegada_dia" válidos — se ignora');
+            } else {
+                state.rumbo = { destino, llegadaDia };
+            }
+        }
+    }
+
+    if (data.creditos !== undefined) {
+        const creditos = asNumber(data.creditos);
+        if (creditos === undefined) {
+            aviso('"creditos" no es un número — se usa 0');
+        } else {
+            state.creditos = creditos;
+        }
+    }
+
+    if (data.medidores !== undefined) {
+        if (!isRecord(data.medidores)) {
+            aviso('"medidores" debe ser un mapa nombre: valor — se usan los valores por defecto');
+        } else {
+            // Parsed gauges overlay the defaults, so the standard three always
+            // have a value even when the file lists only a subset.
+            for (const [nombre, raw] of Object.entries(data.medidores)) {
+                const valor = asNumber(raw);
+                if (valor === undefined) {
+                    aviso(`Medidor "${nombre}" sin valor numérico — se ignora`);
+                } else {
+                    state.medidores[nombre] = valor;
+                }
+            }
+        }
+    }
+
+    return { state, issues };
+}
+
+// ── In-world date rendering ─────────────────────────────────────────────────
+
+/**
+ * Renders the in-world date for an integer `dia_mundo`, e.g. "17 de Gozran,
+ * 322 dG". Calendar math per the manifest: day 1 = day 1 of month 1 of
+ * `ano_epoca`; every month has exactly `diasPorMes` days; a year has
+ * `meses.length` months. Days beyond a year roll the year over.
+ *
+ * Degrades safely: without usable calendar data (no months, or a
+ * non-positive `diasPorMes`) it renders "Día N". Non-integer input is
+ * floored; days below 1 clamp to day 1.
+ */
+export function formatFecha(diaMundo: number, manifest: WorldManifest): string {
+    const { era, anoEpoca, diasPorMes, meses } = manifest.calendario;
+    const dia = Number.isFinite(diaMundo) ? Math.max(1, Math.floor(diaMundo)) : 1;
+
+    if (meses.length === 0 || diasPorMes <= 0) {
+        return `Día ${dia}`;
+    }
+
+    const desdeEpoca = dia - 1; // full days elapsed since epoch start
+    const diasPorAno = diasPorMes * meses.length;
+    const ano = anoEpoca + Math.floor(desdeEpoca / diasPorAno);
+    const diaDelAno = desdeEpoca % diasPorAno;
+    const mes = meses[Math.floor(diaDelAno / diasPorMes)];
+    const diaDelMes = (diaDelAno % diasPorMes) + 1;
+
+    const sufijoEra = era === '' ? '' : ` ${era}`;
+    return `${diaDelMes} de ${mes}, ${ano}${sufijoEra}`;
+}

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -97,6 +97,7 @@ function makeModel(estadoGrupo: PartyState | null, diario: JournalDay[] = []): W
         childrenOf: new Map(),
         estadoGrupo,
         diario,
+        musica: { bgm: [], eventPlaylists: [] },
     };
 }
 

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -1,0 +1,557 @@
+/// <reference types="bun-types" />
+import { test, expect, describe, beforeEach } from 'bun:test';
+import { JournalDay, PartyState, WorldManifest, WorldModel } from '@/types/world';
+import { makeEntry } from './logEntries';
+import { defaultPartyState, parsePartyState, serializePartyState } from './partyState';
+import {
+    MirrorStorage,
+    PartyStoreDeps,
+    readSessionMirror,
+    SESSION_MIRROR_KEY,
+    usePartyStore,
+} from './stores';
+
+// ── Fakes ───────────────────────────────────────────────────────────────────
+
+const NOW = new Date('2026-07-12T14:05:00'); // local time
+const CLOCK = () => NOW;
+const HORA = '14:05';
+const TODAY = '2026-07-12';
+
+function makeFakeStorage(): MirrorStorage & { data: Map<string, string> } {
+    const data = new Map<string, string>();
+    return {
+        data,
+        getItem: (key: string) => data.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+            data.set(key, value);
+        },
+        removeItem: (key: string) => {
+            data.delete(key);
+        },
+    };
+}
+
+interface FakeDeps {
+    deps: PartyStoreDeps;
+    estadoWrites: string[];
+    journalTexts: string[];
+    opened: { path: string; text: string }[];
+    storage: ReturnType<typeof makeFakeStorage>;
+    failEstado: { value: boolean };
+    failFlush: { value: boolean };
+}
+
+function makeDeps(): FakeDeps {
+    const estadoWrites: string[] = [];
+    const journalTexts: string[] = [];
+    const opened: { path: string; text: string }[] = [];
+    const storage = makeFakeStorage();
+    const failEstado = { value: false };
+    const failFlush = { value: false };
+    const deps: PartyStoreDeps = {
+        writeEstado: async (text: string) => {
+            if (failEstado.value) throw new Error('NotAllowedError');
+            estadoWrites.push(text);
+        },
+        journal: {
+            open: (path: string, text: string) => {
+                opened.push({ path, text });
+                journalTexts.push(text);
+            },
+            rewrite: (text: string) => {
+                journalTexts.push(text);
+            },
+            flush: async () => {
+                if (failFlush.value) throw new Error('NotAllowedError');
+            },
+            retryNow: () => {},
+        },
+        now: CLOCK,
+        debounceMs: 0, // debounce fires on the next macrotask
+        mirrorStorage: storage,
+    };
+    return { deps, estadoWrites, journalTexts, opened, storage, failEstado, failFlush };
+}
+
+const MANIFEST: WorldManifest = {
+    nombre: 'Sector Test',
+    calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustiblePorTramo: 1, viveresCadaDias: 4 },
+    medidores: ['viveres', 'combustible', 'nave'],
+    regiones: [],
+};
+
+function makeModel(estadoGrupo: PartyState | null, diario: JournalDay[] = []): WorldModel {
+    return {
+        manifest: MANIFEST,
+        entidades: new Map(),
+        sistemas: [],
+        lugares: [],
+        facciones: [],
+        pnjs: [],
+        pistas: [],
+        tramas: [],
+        problemas: [],
+        childrenOf: new Map(),
+        estadoGrupo,
+        diario,
+    };
+}
+
+function makeEstado(overrides: Partial<PartyState> = {}): PartyState {
+    return {
+        ...defaultPartyState('mundo/estado/grupo.md'),
+        diaMundo: 12,
+        ubicacion: 'porto_verne',
+        creditos: 500,
+        medidores: { viveres: 3, combustible: 3, nave: 3 },
+        bodyMd: '## Inventario\n\n- 3 cargas de mineral\n',
+        ...overrides,
+    };
+}
+
+const actions = () => usePartyStore.getState().actions;
+
+/** Waits until the 0ms-debounced estado write has settled. */
+async function settle() {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await usePartyStore.getState().actions.flushEstado();
+}
+
+let fake: FakeDeps;
+
+beforeEach(() => {
+    actions().reset();
+    fake = makeDeps();
+    actions().setDeps(fake.deps);
+    actions().hydrate(makeModel(makeEstado()));
+});
+
+// ── startSession ────────────────────────────────────────────────────────────
+
+describe('startSession', () => {
+    test('opens the next journal file with frontmatter + inicio line and takes the snapshot', () => {
+        const day = actions().startSession([], TODAY);
+
+        expect(day).not.toBeNull();
+        expect(day!.filePath).toBe('mundo/diario/2026-07-12_s01.md');
+        expect(day!.sesion).toBe(1);
+        expect(day!.diaInicio).toBe(12);
+
+        expect(fake.opened).toHaveLength(1);
+        expect(fake.opened[0].path).toBe('mundo/diario/2026-07-12_s01.md');
+        expect(fake.opened[0].text).toBe(
+            [
+                '---',
+                'tipo: diario',
+                'sesion: 1',
+                'fecha_real: 2026-07-12',
+                'dia_inicio: 12',
+                'dia_fin: null',
+                'procesado: false',
+                '---',
+                '',
+                `- [${HORA}] inicio: dia 12 @ porto_verne`,
+                '',
+            ].join('\n')
+        );
+
+        const { session } = usePartyStore.getState();
+        expect(session.active).toBe(true);
+        expect(session.journalPath).toBe('mundo/diario/2026-07-12_s01.md');
+        expect(session.startedAt).toBe(NOW.getTime());
+        expect(session.entries).toHaveLength(1);
+        expect(session.snapshot).toEqual({
+            diaMundo: 12,
+            ubicacion: 'porto_verne',
+            rumbo: null,
+            creditos: 500,
+            medidores: { viveres: 3, combustible: 3, nave: 3 },
+        });
+    });
+
+    test('numbers the session after the highest existing diario sesion', () => {
+        const prior: JournalDay = {
+            filePath: 'mundo/diario/2026-06-01_s07.md',
+            sesion: 7,
+            fechaReal: '2026-06-01',
+            diaInicio: 5,
+            diaFin: 8,
+            procesado: true,
+            entradas: [],
+        };
+        const day = actions().startSession([prior], TODAY);
+        expect(day!.sesion).toBe(8);
+        expect(day!.filePath).toBe('mundo/diario/2026-07-12_s08.md');
+    });
+
+    test('schedules the estado write with sesion_activa true', async () => {
+        actions().startSession([], TODAY);
+        await settle();
+        expect(fake.estadoWrites.length).toBeGreaterThanOrEqual(1);
+        const text = fake.estadoWrites[fake.estadoWrites.length - 1];
+        expect(text).toContain('sesion_activa: true');
+        expect(text).toContain('dia_mundo: 12');
+    });
+
+    test('no-ops when a session is already active', () => {
+        actions().startSession([], TODAY);
+        expect(actions().startSession([], TODAY)).toBeNull();
+        expect(fake.opened).toHaveLength(1);
+    });
+});
+
+// ── log ─────────────────────────────────────────────────────────────────────
+
+describe('log', () => {
+    test('warns and returns null when no session is active', () => {
+        const result = actions().log(makeEntry.gasto(100, undefined, CLOCK));
+        expect(result).toBeNull();
+        expect(fake.journalTexts).toHaveLength(0);
+    });
+
+    test('gasto mutates creditos, rewrites the journal with 2 lines, schedules estado', async () => {
+        actions().startSession([], TODAY);
+        const entry = actions().log(makeEntry.gasto(200, 'soborno', CLOCK));
+
+        expect(entry).not.toBeNull();
+        expect(usePartyStore.getState().creditos).toBe(300);
+
+        const lastJournal = fake.journalTexts[fake.journalTexts.length - 1];
+        const lines = lastJournal.trimEnd().split('\n').filter((l) => l.startsWith('- ['));
+        expect(lines).toHaveLength(2);
+        expect(lines[1]).toBe(`- [${HORA}] gasto: 200 | soborno`);
+
+        await settle();
+        const estado = fake.estadoWrites[fake.estadoWrites.length - 1];
+        expect(estado).toContain('creditos: 300');
+        expect(estado).toContain('sesion_activa: true');
+    });
+
+    test('medidor, rumbo and llegada entries update the live fields', () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.medidor('combustible', 3, 2, undefined, CLOCK));
+        expect(usePartyStore.getState().medidores.combustible).toBe(2);
+
+        actions().log(makeEntry.rumbo('sistema_kovar', 3, 15, undefined, CLOCK));
+        expect(usePartyStore.getState().rumbo).toEqual({ destino: 'sistema_kovar', llegadaDia: 15 });
+
+        actions().log(makeEntry.llegada('sistema_kovar', 15, undefined, CLOCK));
+        const s = usePartyStore.getState();
+        expect(s.ubicacion).toBe('sistema_kovar');
+        expect(s.rumbo).toBeNull();
+        expect(s.diaMundo).toBe(15);
+    });
+});
+
+// ── undoLast ────────────────────────────────────────────────────────────────
+
+describe('undoLast', () => {
+    test('replays the remaining entries over the snapshot', () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(200, undefined, CLOCK));
+        actions().log(makeEntry.medidor('combustible', 3, 2, undefined, CLOCK));
+
+        const removed = actions().undoLast();
+        expect(removed!.tipo).toBe('medidor');
+
+        const s = usePartyStore.getState();
+        expect(s.medidores.combustible).toBe(3); // medidor gone
+        expect(s.creditos).toBe(300); // gasto still applied
+        expect(s.session.entries).toHaveLength(2); // inicio + gasto
+
+        const lastJournal = fake.journalTexts[fake.journalTexts.length - 1];
+        expect(lastJournal).not.toContain('medidor:');
+        expect(lastJournal).toContain('gasto: 200');
+    });
+
+    test('never removes the inicio entry', () => {
+        actions().startSession([], TODAY);
+        expect(actions().undoLast()).toBeNull();
+        expect(usePartyStore.getState().session.entries).toHaveLength(1);
+    });
+});
+
+// ── endSession ──────────────────────────────────────────────────────────────
+
+describe('endSession', () => {
+    test('appends fin, sets dia_fin, forces estado with sesion_activa false, clears mirror', async () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(200, undefined, CLOCK));
+        actions().log(makeEntry.ganancia(50, undefined, CLOCK));
+
+        const summary = await actions().endSession();
+
+        expect(summary).not.toBeNull();
+        expect(summary!.counts).toEqual({ inicio: 1, gasto: 1, ganancia: 1, fin: 1 });
+        expect(summary!.netCreditos).toBe(-150);
+        expect(summary!.durationMs).toBe(0); // frozen clock
+
+        const lastJournal = fake.journalTexts[fake.journalTexts.length - 1];
+        expect(lastJournal).toContain('dia_fin: 12');
+        expect(lastJournal).toContain(`- [${HORA}] fin: dia 12 @ porto_verne`);
+
+        const estado = fake.estadoWrites[fake.estadoWrites.length - 1];
+        expect(estado).toContain('sesion_activa: false');
+        expect(estado).toContain('creditos: 350');
+
+        expect(usePartyStore.getState().session.active).toBe(false);
+        expect(fake.storage.getItem(SESSION_MIRROR_KEY)).toBeNull();
+    });
+
+    test('keeps the session active (and the mirror) when the journal flush fails', async () => {
+        actions().startSession([], TODAY);
+        fake.failFlush.value = true;
+
+        const summary = await actions().endSession();
+
+        expect(summary).toBeNull();
+        const { session } = usePartyStore.getState();
+        expect(session.active).toBe(true);
+        expect(session.writeStatus).toBe('denied');
+        expect(fake.storage.getItem(SESSION_MIRROR_KEY)).not.toBeNull();
+    });
+
+    test('keeps the session active when flush resolves but the writer reports denied', async () => {
+        actions().startSession([], TODAY);
+        // JournalWriter.flush never rejects: denial arrives via onStatus.
+        actions().setJournalStatus('denied');
+
+        const summary = await actions().endSession();
+
+        expect(summary).toBeNull();
+        expect(usePartyStore.getState().session.active).toBe(true);
+        expect(fake.storage.getItem(SESSION_MIRROR_KEY)).not.toBeNull();
+
+        // After the writer recovers, closing works and does not duplicate fin.
+        actions().setJournalStatus('ok');
+        const second = await actions().endSession();
+        expect(second).not.toBeNull();
+        expect(second!.counts.fin).toBe(1);
+        expect(usePartyStore.getState().session.active).toBe(false);
+    });
+
+    test('a fin stranded by a failed close + later logging is dropped, not duplicated', async () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(100, undefined, CLOCK));
+
+        // First close fails: fin is appended but the session stays active.
+        actions().setJournalStatus('denied');
+        expect(await actions().endSession()).toBeNull();
+
+        // GM keeps playing: the old fin is now stranded mid-journal.
+        actions().log(makeEntry.gasto(50, undefined, CLOCK));
+
+        // Second close succeeds: exactly ONE fin, and it is the FINAL entry.
+        actions().setJournalStatus('ok');
+        const summary = await actions().endSession();
+        expect(summary).not.toBeNull();
+        expect(summary!.counts.fin).toBe(1);
+        const lastText = fake.journalTexts[fake.journalTexts.length - 1];
+        const finLines = lastText.split('\n').filter((l: string) => /^- \[\d\d:\d\d\] fin:/.test(l));
+        expect(finLines).toHaveLength(1);
+        const lines = lastText.trimEnd().split('\n');
+        expect(lines[lines.length - 1]).toMatch(/^- \[\d\d:\d\d\] fin:/);
+    });
+});
+
+// ── serializePartyState round-trip ──────────────────────────────────────────
+
+describe('serializePartyState', () => {
+    const NOW_ISO = '2026-07-12T14:05:00.000Z';
+
+    test('estado body is preserved byte-for-byte through weird content', () => {
+        const weirdBody =
+            '\n## Inventario\n\n---\nfalsa valla\n---\n\t tabs y  espacios  \n- créditos: "raros" | tubería\nsin salto final';
+        const state = makeEstado({ bodyMd: weirdBody, rumbo: { destino: 'x', llegadaDia: 9 } });
+
+        const text = serializePartyState(state, NOW_ISO);
+        expect(text.endsWith(weirdBody)).toBe(true);
+
+        const { state: reparsed } = parsePartyState(text, 'mundo/estado/grupo.md');
+        expect(reparsed.bodyMd).toBe(weirdBody);
+        expect(reparsed.diaMundo).toBe(state.diaMundo);
+        expect(reparsed.ubicacion).toBe(state.ubicacion);
+        expect(reparsed.rumbo).toEqual(state.rumbo);
+        expect(reparsed.creditos).toBe(state.creditos);
+        expect(reparsed.medidores).toEqual(state.medidores);
+        expect(reparsed.sesionActiva).toBe(state.sesionActiva);
+    });
+
+    test('empty body emits just frontmatter ending in a newline', () => {
+        const text = serializePartyState(makeEstado({ bodyMd: '' }), NOW_ISO);
+        expect(text.endsWith('---\n')).toBe(true);
+        const { state: reparsed } = parsePartyState(text, 'mundo/estado/grupo.md');
+        expect(reparsed.bodyMd).toBe('');
+    });
+
+    test('documented key order and null forms', () => {
+        const text = serializePartyState(
+            makeEstado({ ubicacion: null, rumbo: null, bodyMd: '' }),
+            NOW_ISO
+        );
+        expect(text).toBe(
+            [
+                '---',
+                'tipo: estado_grupo',
+                `actualizado: ${NOW_ISO}`,
+                'sesion_activa: false',
+                'dia_mundo: 12',
+                'ubicacion: null',
+                'rumbo: null',
+                'creditos: 500',
+                'medidores:',
+                '  viveres: 3',
+                '  combustible: 3',
+                '  nave: 3',
+                '---',
+                '',
+            ].join('\n')
+        );
+    });
+});
+
+// ── Crash mirror + recoverSession ───────────────────────────────────────────
+
+describe('recoverSession', () => {
+    test('round-trips a crashed session from the mirror', () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(200, undefined, CLOCK));
+        actions().log(makeEntry.medidor('nave', 3, 4, undefined, CLOCK));
+
+        const mirror = readSessionMirror(fake.storage);
+        expect(mirror).not.toBeNull();
+        expect(mirror!.snapshot.creditos).toBe(500); // session-START snapshot
+        expect(mirror!.entries).toHaveLength(3);
+
+        // Simulate the crash: fresh store, fresh deps, fresh scan.
+        actions().reset();
+        const fresh = makeDeps();
+        actions().setDeps(fresh.deps);
+        actions().recoverSession(mirror!, makeModel(makeEstado()));
+
+        const s = usePartyStore.getState();
+        expect(s.session.active).toBe(true);
+        expect(s.session.journalPath).toBe('mundo/diario/2026-07-12_s01.md');
+        expect(s.session.entries).toHaveLength(3);
+        expect(s.creditos).toBe(300); // replayed over the mirror snapshot
+        expect(s.medidores.nave).toBe(4);
+        expect(s.bodyMd).toBe(makeEstado().bodyMd); // estado body re-taken from the model
+
+        // Journal reopened with the full serialized content.
+        expect(fresh.opened).toHaveLength(1);
+        expect(fresh.opened[0].path).toBe('mundo/diario/2026-07-12_s01.md');
+        expect(fresh.opened[0].text).toContain('gasto: 200');
+        expect(fresh.opened[0].text).toContain('nave 3->4');
+
+        // The session keeps working after recovery.
+        const entry = actions().log(makeEntry.ganancia(100, undefined, CLOCK));
+        expect(entry).not.toBeNull();
+        expect(usePartyStore.getState().creditos).toBe(400);
+    });
+
+    test('readSessionMirror rejects corrupt payloads', () => {
+        fake.storage.setItem(SESSION_MIRROR_KEY, '{"version":2}');
+        expect(readSessionMirror(fake.storage)).toBeNull();
+        fake.storage.setItem(SESSION_MIRROR_KEY, 'no-json');
+        expect(readSessionMirror(fake.storage)).toBeNull();
+    });
+
+    test('readSessionMirror rejects a journalPath outside mundo/diario/', () => {
+        // A hostile/corrupt path would make recoverSession's journal.open()
+        // throw AFTER the session flipped active — treat it as no mirror.
+        const good = {
+            version: 1,
+            journalPath: 'mundo/diario/2026-07-12_s01.md',
+            sesion: 1,
+            fechaReal: TODAY,
+            diaInicio: 1,
+            startedAt: 1,
+            snapshot: { diaMundo: 1, ubicacion: null, rumbo: null, creditos: 0, medidores: {} },
+            entries: [],
+        };
+        fake.storage.setItem(SESSION_MIRROR_KEY, JSON.stringify(good));
+        expect(readSessionMirror(fake.storage)).not.toBeNull();
+        for (const journalPath of ['mundo/mundo.md', 'mundo/estado/grupo.md', 'diario/x.md']) {
+            fake.storage.setItem(SESSION_MIRROR_KEY, JSON.stringify({ ...good, journalPath }));
+            expect(readSessionMirror(fake.storage)).toBeNull();
+        }
+    });
+});
+
+// ── writeStatus propagation ─────────────────────────────────────────────────
+
+describe('writeStatus', () => {
+    test('estado write failure surfaces denied; retryWrites recovers', async () => {
+        actions().startSession([], TODAY);
+        fake.failEstado.value = true;
+        actions().log(makeEntry.gasto(10, undefined, CLOCK));
+        await settle();
+        expect(usePartyStore.getState().session.writeStatus).toBe('denied');
+
+        fake.failEstado.value = false;
+        actions().retryWrites();
+        await settle();
+        expect(usePartyStore.getState().session.writeStatus).toBe('ok');
+    });
+
+    test('journal denied wins over estado ok', async () => {
+        actions().startSession([], TODAY);
+        await settle();
+        actions().setJournalStatus('denied');
+        expect(usePartyStore.getState().session.writeStatus).toBe('denied');
+        actions().setJournalStatus('ok');
+        expect(usePartyStore.getState().session.writeStatus).toBe('ok');
+    });
+});
+
+// ── hydrate ─────────────────────────────────────────────────────────────────
+
+describe('hydrate', () => {
+    test('loads defaults when estadoGrupo is absent', () => {
+        actions().reset();
+        actions().setDeps(makeDeps().deps);
+        actions().hydrate(makeModel(null));
+        const s = usePartyStore.getState();
+        expect(s.diaMundo).toBe(1);
+        expect(s.creditos).toBe(0);
+        expect(s.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+        expect(s.estadoFilePath).toBeNull();
+    });
+
+    test('is ignored while a session is active', () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(100, undefined, CLOCK));
+        actions().hydrate(makeModel(makeEstado({ creditos: 9999 })));
+        expect(usePartyStore.getState().creditos).toBe(400);
+    });
+});
+
+// ── Journal entry type coverage through the store ───────────────────────────
+
+describe('entry application', () => {
+    test('descanso and dia advance the world day; nota/pista/sabe/evento are inert', () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.descanso(2, undefined, CLOCK));
+        expect(usePartyStore.getState().diaMundo).toBe(14);
+        actions().log(makeEntry.dia(14, 20, undefined, CLOCK));
+        expect(usePartyStore.getState().diaMundo).toBe(20);
+
+        const before = usePartyStore.getState();
+        actions().log(makeEntry.nota('los jugadores sospechan de Kael', CLOCK));
+        actions().log(makeEntry.pista('deuda_kael_zara', 'rumor', 'activa', undefined, CLOCK));
+        actions().log(makeEntry.sabe('sitio_sigma', 'desconocido', 'rumoreado', undefined, CLOCK));
+        actions().log(makeEntry.evento('viaje_frontera', 'v03', undefined, CLOCK));
+        const after = usePartyStore.getState();
+        expect(after.diaMundo).toBe(before.diaMundo);
+        expect(after.creditos).toBe(before.creditos);
+        expect(after.session.entries).toHaveLength(7);
+
+        const journal = fake.journalTexts[fake.journalTexts.length - 1];
+        expect(journal).toContain(`- [${HORA}] nota: los jugadores sospechan de Kael`);
+        expect(journal).toContain(`- [${HORA}] pista: deuda_kael_zara rumor->activa`);
+        expect(journal).toContain(`- [${HORA}] sabe: sitio_sigma desconocido->rumoreado`);
+        expect(journal).toContain(`- [${HORA}] evento: viaje_frontera#v03`);
+    });
+});

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -77,7 +77,7 @@ function makeDeps(): FakeDeps {
 const MANIFEST: WorldManifest = {
     nombre: 'Sector Test',
     calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
-    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustiblePorTramo: 1, viveresCadaDias: 4 },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustibleCadaDias: 4, viveresCadaDias: 4 },
     medidores: ['viveres', 'combustible', 'nave'],
     regiones: [],
 };

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -116,6 +116,8 @@ function makeModel(estadoGrupo: PartyState | null, diario: JournalDay[] = []): W
         estadoGrupo,
         diario,
         musica: { bgm: [], eventPlaylists: [] },
+        tiendas: new Map(),
+        resumen: null,
     };
 }
 

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -118,6 +118,7 @@ function makeModel(estadoGrupo: PartyState | null, diario: JournalDay[] = []): W
         musica: { bgm: [], eventPlaylists: [] },
         tiendas: new Map(),
         resumen: null,
+        guias: [],
     };
 }
 

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -92,6 +92,7 @@ function makeModel(estadoGrupo: PartyState | null, diario: JournalDay[] = []): W
         pnjs: [],
         pistas: [],
         tramas: [],
+        tablas: [],
         problemas: [],
         childrenOf: new Map(),
         estadoGrupo,

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -37,22 +37,30 @@ interface FakeDeps {
     estadoWrites: string[];
     journalTexts: string[];
     opened: { path: string; text: string }[];
+    deletedPaths: string[];
     storage: ReturnType<typeof makeFakeStorage>;
     failEstado: { value: boolean };
     failFlush: { value: boolean };
+    failDelete: { value: boolean };
 }
 
 function makeDeps(): FakeDeps {
     const estadoWrites: string[] = [];
     const journalTexts: string[] = [];
     const opened: { path: string; text: string }[] = [];
+    const deletedPaths: string[] = [];
     const storage = makeFakeStorage();
     const failEstado = { value: false };
     const failFlush = { value: false };
+    const failDelete = { value: false };
     const deps: PartyStoreDeps = {
         writeEstado: async (text: string) => {
             if (failEstado.value) throw new Error('NotAllowedError');
             estadoWrites.push(text);
+        },
+        deleteFile: async (path: string) => {
+            if (failDelete.value) throw new Error('NotAllowedError');
+            deletedPaths.push(path);
         },
         journal: {
             open: (path: string, text: string) => {
@@ -71,7 +79,17 @@ function makeDeps(): FakeDeps {
         debounceMs: 0, // debounce fires on the next macrotask
         mirrorStorage: storage,
     };
-    return { deps, estadoWrites, journalTexts, opened, storage, failEstado, failFlush };
+    return {
+        deps,
+        estadoWrites,
+        journalTexts,
+        opened,
+        deletedPaths,
+        storage,
+        failEstado,
+        failFlush,
+        failDelete,
+    };
 }
 
 const MANIFEST: WorldManifest = {
@@ -359,6 +377,69 @@ describe('endSession', () => {
 });
 
 // ── serializePartyState round-trip ──────────────────────────────────────────
+
+describe('discardSession', () => {
+    beforeEach(() => {
+        // Hydrate with a roster so we can prove it survives the rollback.
+        actions().hydrate(makeModel(makeEstado({ personajes: ['Xiao', 'Chesco'] })));
+    });
+
+    test('deletes the journal, rolls estado back to the snapshot, reverts live fields', async () => {
+        actions().startSession([], TODAY);
+        const journalPath = usePartyStore.getState().session.journalPath!;
+        // Play: spend credits + change a gauge (would persist without discard).
+        actions().log(makeEntry.gasto(200, undefined, CLOCK));
+        actions().log(makeEntry.medidor('combustible', 3, 1, undefined, CLOCK));
+        expect(usePartyStore.getState().creditos).toBe(300);
+
+        const result = await actions().discardSession();
+
+        expect(result).toEqual({ ok: true });
+        // journal deleted (exactly its path)
+        expect(fake.deletedPaths).toEqual([journalPath]);
+        // estado restored to the pre-session snapshot, session closed
+        const estado = fake.estadoWrites[fake.estadoWrites.length - 1];
+        expect(estado).toContain('sesion_activa: false');
+        expect(estado).toContain('creditos: 500'); // back to pre-session
+        expect(estado).toContain('combustible: 3'); // gauge reverted
+        // roster + agent body preserved through the rollback write
+        expect(estado).toContain('personajes:\n  - Xiao\n  - Chesco');
+        expect(estado).toContain('## Inventario');
+        // live fields reverted + session inactive + mirror cleared
+        const st = usePartyStore.getState();
+        expect(st.creditos).toBe(500);
+        expect(st.medidores.combustible).toBe(3);
+        expect(st.session.active).toBe(false);
+        expect(fake.storage.getItem(SESSION_MIRROR_KEY)).toBeNull();
+    });
+
+    test('a subsequent session numbers as if the discarded one never existed', async () => {
+        actions().startSession([], TODAY);
+        await actions().discardSession();
+        const day = actions().startSession([], TODAY);
+        expect(day!.sesion).toBe(1); // not 2 — no leftover journal
+    });
+
+    test('deleteFile failure leaves the session ACTIVE and estado untouched', async () => {
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(200, undefined, CLOCK));
+        const estadoWritesBefore = fake.estadoWrites.length;
+        fake.failDelete.value = true;
+
+        const result = await actions().discardSession();
+
+        expect(result).toEqual({ ok: false });
+        expect(usePartyStore.getState().session.active).toBe(true);
+        expect(usePartyStore.getState().creditos).toBe(300); // NOT rolled back
+        // no rollback estado write happened after the failed delete
+        expect(fake.estadoWrites.length).toBe(estadoWritesBefore);
+    });
+
+    test('no-op with a clear result when no session is active', async () => {
+        expect(await actions().discardSession()).toEqual({ ok: false });
+        expect(fake.deletedPaths).toHaveLength(0);
+    });
+});
 
 describe('serializePartyState', () => {
     const NOW_ISO = '2026-07-12T14:05:00.000Z';

--- a/lib/world/partyStore.test.ts
+++ b/lib/world/partyStore.test.ts
@@ -407,6 +407,7 @@ describe('serializePartyState', () => {
                 '  viveres: 3',
                 '  combustible: 3',
                 '  nave: 3',
+                'personajes: []',
                 '---',
                 '',
             ].join('\n')
@@ -527,6 +528,54 @@ describe('hydrate', () => {
         actions().log(makeEntry.gasto(100, undefined, CLOCK));
         actions().hydrate(makeModel(makeEstado({ creditos: 9999 })));
         expect(usePartyStore.getState().creditos).toBe(400);
+    });
+
+    test('loads the personajes roster from estado', () => {
+        actions().reset();
+        actions().setDeps(makeDeps().deps);
+        actions().hydrate(makeModel(makeEstado({ personajes: ['Xiao', 'Chesco'] })));
+        expect(usePartyStore.getState().personajes).toEqual(['Xiao', 'Chesco']);
+    });
+});
+
+// ── personajes preservation through the session write path ──────────────────
+
+describe('personajes', () => {
+    test('every estado write preserves the hydrated roster (never dropped by log)', async () => {
+        actions().reset();
+        const f = makeDeps();
+        actions().setDeps(f.deps);
+        actions().hydrate(makeModel(makeEstado({ personajes: ['Xiao', 'Chesco'] })));
+
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(200, undefined, CLOCK));
+        await new Promise((r) => setTimeout(r, 5));
+        await actions().flushEstado();
+
+        // The roster the log never touches still round-trips into estado/grupo.md.
+        const estado = f.estadoWrites[f.estadoWrites.length - 1];
+        expect(estado).toContain('personajes:');
+        const { state } = parsePartyState(estado, 'mundo/estado/grupo.md');
+        expect(state.personajes).toEqual(['Xiao', 'Chesco']);
+        // ...and the log still mutated the party numbers as usual.
+        expect(state.creditos).toBe(300);
+    });
+
+    test('recoverSession re-takes the roster from the fresh scan', () => {
+        actions().reset();
+        const f = makeDeps();
+        actions().setDeps(f.deps);
+        actions().hydrate(makeModel(makeEstado({ personajes: ['Xiao'] })));
+        actions().startSession([], TODAY);
+        actions().log(makeEntry.gasto(50, undefined, CLOCK));
+        const mirror = readSessionMirror(f.storage);
+
+        actions().reset();
+        const fresh = makeDeps();
+        actions().setDeps(fresh.deps);
+        // The fresh scan holds the CURRENT roster (file-owned, not in the mirror).
+        actions().recoverSession(mirror!, makeModel(makeEstado({ personajes: ['Xiao', 'Chesco'] })));
+        expect(usePartyStore.getState().personajes).toEqual(['Xiao', 'Chesco']);
     });
 });
 

--- a/lib/world/shops.test.ts
+++ b/lib/world/shops.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun-types" />
 import { test, expect, describe } from 'bun:test';
-import { parseShop } from './shops';
+import type { PlaceEntity, Shop, SystemEntity, WorldEntityBase, WorldModel } from '@/types/world';
+import { affordancesFor, parseShop } from './shops';
 
 const PATH = 'mundo/lugares/porto_verne/tiendas/taller.md';
 
@@ -103,5 +104,108 @@ tipo: tienda
     test('garbage content never throws', () => {
         expect(() => parseShop('not markdown at all {[}', PATH, 'x')).not.toThrow();
         expect(() => parseShop('', PATH, 'x')).not.toThrow();
+    });
+});
+
+// ── affordancesFor: shop/info map-node badge derivation ─────────────────────
+
+/** Minimal PlaceEntity with just the fields affordancesFor reads. */
+function place(id: string, servicios: string[]): PlaceEntity {
+    return {
+        id,
+        tipo: 'estacion',
+        nombre: id,
+        filePath: `mundo/lugares/${id}/lugar.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        servicios,
+        facciones: [],
+        acceso: 'normal',
+    };
+}
+
+/** Minimal SystemEntity (no `servicios` field — the guard must handle it). */
+function system(id: string): SystemEntity {
+    return {
+        id,
+        tipo: 'sistema',
+        nombre: id,
+        filePath: `mundo/sistemas/${id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        coordenadas: { x: 0, y: 0 },
+    };
+}
+
+/** A WorldModel carrying only the two maps affordancesFor reads. */
+function modelWith(
+    entities: WorldEntityBase[],
+    tiendas: Record<string, Shop[]> = {}
+): WorldModel {
+    const entidades = new Map<string, WorldEntityBase>();
+    for (const e of entities) entidades.set(e.id, e);
+    return {
+        entidades,
+        tiendas: new Map(Object.entries(tiendas)),
+    } as unknown as WorldModel;
+}
+
+function shop(id: string): Shop {
+    return { id, nombre: id, etiquetas: [], items: [], body: '', filePath: `x/${id}.md` };
+}
+
+describe('affordancesFor', () => {
+    test('shop from a non-empty tiendas entry', () => {
+        const model = modelWith([place('brasa', [])], { brasa: [shop('s1')] });
+        expect(affordancesFor(model, 'brasa')).toEqual({ shop: true, info: false });
+    });
+
+    test('an empty tiendas array is NOT a shop', () => {
+        const model = modelWith([place('brasa', [])], { brasa: [] });
+        expect(affordancesFor(model, 'brasa')).toEqual({ shop: false, info: false });
+    });
+
+    test('shop from servicios mercado', () => {
+        const model = modelWith([place('mkt', ['mercado'])]);
+        expect(affordancesFor(model, 'mkt')).toEqual({ shop: true, info: false });
+    });
+
+    test('shop from servicios contrabando', () => {
+        const model = modelWith([place('smug', ['contrabando'])]);
+        expect(affordancesFor(model, 'smug')).toEqual({ shop: true, info: false });
+    });
+
+    test('info from servicios informacion', () => {
+        const model = modelWith([place('torre', ['informacion'])]);
+        expect(affordancesFor(model, 'torre')).toEqual({ shop: false, info: true });
+    });
+
+    test('info from servicios ocio', () => {
+        const model = modelWith([place('bar', ['ocio'])]);
+        expect(affordancesFor(model, 'bar')).toEqual({ shop: false, info: true });
+    });
+
+    test('both shop and info when servicios carry each', () => {
+        const model = modelWith([place('hub', ['mercado', 'informacion'])]);
+        expect(affordancesFor(model, 'hub')).toEqual({ shop: true, info: true });
+    });
+
+    test('a bare sistema (no servicios field) yields no affordances', () => {
+        const model = modelWith([system('sis')]);
+        expect(affordancesFor(model, 'sis')).toEqual({ shop: false, info: false });
+    });
+
+    test('a place with irrelevant servicios yields nothing', () => {
+        const model = modelWith([place('field', ['refugio', 'taller'])]);
+        expect(affordancesFor(model, 'field')).toEqual({ shop: false, info: false });
+    });
+
+    test('an unknown id yields no affordances (no crash)', () => {
+        const model = modelWith([]);
+        expect(affordancesFor(model, 'nope')).toEqual({ shop: false, info: false });
     });
 });

--- a/lib/world/shops.test.ts
+++ b/lib/world/shops.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { parseShop } from './shops';
+
+const PATH = 'mundo/lugares/porto_verne/tiendas/taller.md';
+
+describe('parseShop', () => {
+    test('parses frontmatter + prose + table', () => {
+        const content = `---
+tipo: tienda
+nombre: Taller de Bracca
+pnj: bracca
+etiquetas: [taller]
+---
+Bracca repara casi cualquier cosa.
+
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Célula de combustible | 120 | 4 | recargable |
+| Kit de reparación | 60 | - |  |
+`;
+        const { shop, issues } = parseShop(content, PATH, 'taller');
+        expect(issues).toEqual([]);
+        expect(shop.id).toBe('taller');
+        expect(shop.nombre).toBe('Taller de Bracca');
+        expect(shop.pnj).toBe('bracca');
+        expect(shop.etiquetas).toEqual(['taller']);
+        expect(shop.body).toBe('Bracca repara casi cualquier cosa.');
+        expect(shop.items).toEqual([
+            { articulo: 'Célula de combustible', precio: 120, stock: 4, nota: 'recargable' },
+            { articulo: 'Kit de reparación', precio: 60, stock: null },
+        ]);
+    });
+
+    test('empty stock cell is null (unlimited)', () => {
+        const content = `---
+tipo: tienda
+nombre: X
+---
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Agua | 2 |  |  |
+`;
+        const { shop } = parseShop(content, PATH, 'x');
+        expect(shop.items[0].stock).toBeNull();
+    });
+
+    test('columns located by header position, not order', () => {
+        const content = `---
+tipo: tienda
+nombre: X
+---
+| nota | stock | articulo | precio |
+|---|---|---|---|
+| barato | 3 | Pan | 5 |
+`;
+        const { shop } = parseShop(content, PATH, 'x');
+        expect(shop.items[0]).toEqual({ articulo: 'Pan', precio: 5, stock: 3, nota: 'barato' });
+    });
+
+    test('non-integer precio row is skipped with an aviso', () => {
+        const content = `---
+tipo: tienda
+nombre: X
+---
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Bueno | 10 | 1 |  |
+| Malo | 3.5 | 1 |  |
+`;
+        const { shop, issues } = parseShop(content, PATH, 'x');
+        expect(shop.items.map((i) => i.articulo)).toEqual(['Bueno']);
+        expect(issues.length).toBe(1);
+        expect(issues[0].nivel).toBe('aviso');
+    });
+
+    test('no table → empty items, whole body kept, no throw', () => {
+        const content = `---
+tipo: tienda
+nombre: Sin catálogo
+---
+Aún no hay precios listados.
+`;
+        const { shop, issues } = parseShop(content, PATH, 'sin_catalogo');
+        expect(shop.items).toEqual([]);
+        expect(shop.body).toBe('Aún no hay precios listados.');
+        expect(issues).toEqual([]);
+    });
+
+    test('missing nombre falls back to the id; missing pnj stays undefined', () => {
+        const content = `---
+tipo: tienda
+---
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Cosa | 1 | 1 |  |
+`;
+        const { shop } = parseShop(content, PATH, 'mi_tienda');
+        expect(shop.nombre).toBe('mi_tienda');
+        expect(shop.pnj).toBeUndefined();
+    });
+
+    test('garbage content never throws', () => {
+        expect(() => parseShop('not markdown at all {[}', PATH, 'x')).not.toThrow();
+        expect(() => parseShop('', PATH, 'x')).not.toThrow();
+    });
+});

--- a/lib/world/shops.ts
+++ b/lib/world/shops.ts
@@ -12,8 +12,43 @@
  * ValidationIssue so the world always loads (same contract as worldScanner).
  */
 
-import { Shop, ShopItem, ValidationIssue } from '@/types/world';
+import { Shop, ShopItem, ValidationIssue, WorldModel } from '@/types/world';
 import { asString, asStringArray, normalizeKeys, parseFrontmatter } from './frontmatter';
+
+/**
+ * Semantic map-node affordances for the GM's at-a-glance scan: does this place
+ * sell things (SHOP) and/or offer information (INFO)? Derived purely from the
+ * model; the amber leads badge (quest/rumor) is computed separately in the page.
+ */
+export interface NodeAffordances {
+    /** The place has shops, or `servicios` markets goods (mercado/contrabando). */
+    shop: boolean;
+    /** The place offers information/leisure (`servicios` informacion/ocio). */
+    info: boolean;
+}
+
+/** `servicios` values that imply a SHOP affordance (goods for sale). */
+const SHOP_SERVICIOS = new Set(['mercado', 'contrabando']);
+/** `servicios` values that imply an INFO affordance (chatter / rumor sources). */
+const INFO_SERVICIOS = new Set(['informacion', 'ocio']);
+
+/**
+ * Derives the shop/info affordances for a given entity id from the world model.
+ * Only places (PlaceEntity) carry `servicios`; sistemas and other kinds have
+ * none, so they yield no affordances. Callers gate on conocimiento BEFORE
+ * calling this (never reveal shop/info on desconocido/rumoreado nodes).
+ */
+export function affordancesFor(model: WorldModel, id: string): NodeAffordances {
+    const shopsHere = model.tiendas.get(id);
+    const hasShops = shopsHere !== undefined && shopsHere.length > 0;
+    const entity = model.entidades.get(id);
+    // Only PlaceEntity has `servicios`; guard the field for sistemas et al.
+    const rawServicios = (entity as { servicios?: unknown } | undefined)?.servicios;
+    const servicios: string[] = Array.isArray(rawServicios) ? (rawServicios as string[]) : [];
+    const shop = hasShops || servicios.some((s) => SHOP_SERVICIOS.has(s));
+    const info = servicios.some((s) => INFO_SERVICIOS.has(s));
+    return { shop, info };
+}
 
 /** Columns the parser understands, matched by header text (case-insensitive). */
 const KNOWN_COLUMNS = ['articulo', 'precio', 'stock', 'nota'] as const;

--- a/lib/world/shops.ts
+++ b/lib/world/shops.ts
@@ -1,0 +1,169 @@
+/**
+ * Shop parsing (feature — shop system). A shop lives at
+ * `mundo/lugares/<place>/tiendas/<shop_id>.md`:
+ *   - frontmatter: `tipo: tienda`, `nombre:`, `pnj: <id|null>`, `etiquetas: [...]`
+ *   - body: GM prose, then a markdown table with EXACT headers
+ *       | articulo | precio | stock | nota |
+ *     `precio` is an integer, `stock` an integer ("-"/empty = unlimited/null),
+ *     `nota` free text and optional.
+ *
+ * NEVER throws: malformed rows are skipped with an aviso, a missing/garbled
+ * table yields an empty item list, and every problem degrades into a
+ * ValidationIssue so the world always loads (same contract as worldScanner).
+ */
+
+import { Shop, ShopItem, ValidationIssue } from '@/types/world';
+import { asString, asStringArray, normalizeKeys, parseFrontmatter } from './frontmatter';
+
+/** Columns the parser understands, matched by header text (case-insensitive). */
+const KNOWN_COLUMNS = ['articulo', 'precio', 'stock', 'nota'] as const;
+type Column = (typeof KNOWN_COLUMNS)[number];
+
+/** Splits one markdown table line into trimmed cells (drops the edge pipes). */
+function splitRow(line: string): string[] {
+    let inner = line.trim();
+    if (inner.startsWith('|')) inner = inner.slice(1);
+    if (inner.endsWith('|')) inner = inner.slice(0, -1);
+    return inner.split('|').map((cell) => cell.trim());
+}
+
+/** A separator row is all dashes/colons/spaces between pipes (`|---|:--:|`). */
+function isSeparatorRow(cells: string[]): boolean {
+    return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell));
+}
+
+/**
+ * Parses `stock`: an integer, or null for "-"/"" (unlimited). Returns
+ * `undefined` for anything else so the caller can skip the row as malformed.
+ */
+function parseStock(raw: string): number | null | undefined {
+    const value = raw.trim();
+    if (value === '' || value === '-') return null;
+    const num = Number(value);
+    return Number.isInteger(num) ? num : undefined;
+}
+
+/**
+ * Parses the price-table rows after the `|---|` separator into ShopItems.
+ * Columns are located by header position (articulo/precio/stock/nota); a row
+ * with a non-integer precio, a bad stock, or an empty articulo is skipped with
+ * an aviso instead of crashing. Returns [] when no valid table is present.
+ */
+function parseItems(
+    lines: string[],
+    filePath: string,
+    issues: ValidationIssue[]
+): ShopItem[] {
+    // Locate the header row: the first table-looking line whose cells include
+    // an `articulo` column, immediately followed by a separator row.
+    let headerIdx = -1;
+    let columns: (Column | null)[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.includes('|')) continue;
+        const cells = splitRow(line).map((cell) => cell.toLowerCase());
+        if (isSeparatorRow(splitRow(line))) continue;
+        const mapped = cells.map((cell) =>
+            (KNOWN_COLUMNS as readonly string[]).includes(cell) ? (cell as Column) : null
+        );
+        if (!mapped.includes('articulo')) continue;
+        const next = lines[i + 1];
+        if (next === undefined || !isSeparatorRow(splitRow(next))) continue;
+        headerIdx = i;
+        columns = mapped;
+        break;
+    }
+
+    if (headerIdx === -1) return [];
+
+    const col = (name: Column): number => columns.indexOf(name);
+    const articuloIdx = col('articulo');
+    const precioIdx = col('precio');
+    const stockIdx = col('stock');
+    const notaIdx = col('nota');
+
+    const items: ShopItem[] = [];
+    // Rows start two lines after the header (header + separator).
+    for (let i = headerIdx + 2; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim().startsWith('|')) break; // table ended
+        const cells = splitRow(line);
+        if (isSeparatorRow(cells)) continue;
+
+        const articulo = (cells[articuloIdx] ?? '').trim();
+        const precioRaw = precioIdx >= 0 ? (cells[precioIdx] ?? '').trim() : '';
+        const precio = Number(precioRaw);
+        const stock = stockIdx >= 0 ? parseStock(cells[stockIdx] ?? '') : null;
+        const nota = notaIdx >= 0 ? (cells[notaIdx] ?? '').trim() : '';
+
+        if (articulo === '' || !Number.isInteger(precio) || stock === undefined) {
+            issues.push({
+                nivel: 'aviso',
+                archivo: filePath,
+                mensaje: `Fila de tienda mal formada (se omite): "${line.trim()}"`,
+            });
+            continue;
+        }
+
+        items.push({
+            articulo,
+            precio,
+            stock,
+            ...(nota ? { nota } : {}),
+        });
+    }
+
+    return items;
+}
+
+/**
+ * Parses one shop markdown file into a Shop + its ValidationIssues. Never
+ * throws. `id` is the filename without extension; `filePath` is
+ * campaign-relative. The shopkeeper `pnj` is carried through raw — the scanner
+ * validates it resolves against the entity map (this parser has no world view).
+ */
+export function parseShop(
+    content: string,
+    filePath: string,
+    id: string
+): { shop: Shop; issues: ValidationIssue[] } {
+    const issues: ValidationIssue[] = [];
+
+    const parsed = parseFrontmatter(content, filePath);
+    if (parsed.issue) issues.push(parsed.issue);
+    const data = normalizeKeys(parsed.data);
+
+    const nombre = asString(data.nombre) ?? id;
+    // `pnj: null` (or absent) leaves the shop keeper-less.
+    const pnj = asString(data.pnj);
+    const etiquetas = asStringArray(data.etiquetas);
+
+    const bodyLines = parsed.body.split(/\r?\n/);
+    const items = parseItems(bodyLines, filePath, issues);
+    // GM prose = everything above the first table line (best-effort; the panel
+    // shows it as context). Falls back to the whole body when there is no table.
+    const firstTableLine = bodyLines.findIndex(
+        (line, i) =>
+            line.includes('|') &&
+            !isSeparatorRow(splitRow(line)) &&
+            bodyLines[i + 1] !== undefined &&
+            isSeparatorRow(splitRow(bodyLines[i + 1]))
+    );
+    const body =
+        firstTableLine === -1
+            ? parsed.body.trim()
+            : bodyLines.slice(0, firstTableLine).join('\n').trim();
+
+    return {
+        shop: {
+            id,
+            nombre,
+            ...(pnj ? { pnj } : {}),
+            etiquetas,
+            items,
+            body,
+            filePath,
+        },
+        issues,
+    };
+}

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -237,6 +237,13 @@ export interface PartyStoreState {
     rumbo: { destino: string; llegadaDia: number } | null;
     creditos: number;
     medidores: Record<string, number>;
+    /**
+     * Party PC names (roster). Hydrated from estado/grupo.md; NEVER mutated by
+     * the log — but held here so serializePartyState (called from currentPartyState
+     * on every write) round-trips it and a session write never drops the roster.
+     * Feeds the cockpit InitiativeTracker.
+     */
+    personajes: string[];
     /** Agent-owned estado body, preserved byte-for-byte on every write. */
     bodyMd: string;
     /** Path of estado/grupo.md relative to the campaign folder (bookkeeping). */
@@ -313,6 +320,7 @@ function partyInitial() {
         rumbo: defaults.rumbo,
         creditos: defaults.creditos,
         medidores: defaults.medidores,
+        personajes: defaults.personajes,
         bodyMd: defaults.bodyMd,
         estadoFilePath: null as string | null,
         session: { ...SESSION_INITIAL, entries: [] as JournalEntry[] },
@@ -396,6 +404,7 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
             rumbo: s.rumbo === null ? null : { ...s.rumbo },
             creditos: s.creditos,
             medidores: { ...s.medidores },
+            personajes: [...s.personajes],
             bodyMd: s.bodyMd,
             filePath: s.estadoFilePath,
         };
@@ -496,6 +505,7 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
                     rumbo: estado.rumbo === null ? null : { ...estado.rumbo },
                     creditos: estado.creditos,
                     medidores: { ...estado.medidores },
+                    personajes: [...estado.personajes],
                     bodyMd: estado.bodyMd,
                     estadoFilePath: estado.filePath,
                 });
@@ -678,6 +688,9 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
                 estadoStatus = 'ok';
                 set({
                     ...snapshotToFields(snapshot),
+                    // Roster is file-owned (not in the mirror); re-take it from the
+                    // fresh scan so a recovered session still writes it back.
+                    personajes: estado ? [...estado.personajes] : [],
                     bodyMd: estado?.bodyMd ?? '',
                     estadoFilePath: estado?.filePath ?? null,
                     session: {
@@ -749,7 +762,7 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
 // ── uiStore ─────────────────────────────────────────────────────────────────
 
 export type MapTier = 'sector' | 'system';
-export type PanelTab = 'entidad' | 'pistas' | 'diario';
+export type PanelTab = 'entidad' | 'pistas' | 'diario' | 'eventos';
 
 /** Map viewport transform — structurally identical to StarMap's MapViewport. */
 export interface UiViewport {
@@ -866,7 +879,12 @@ export function readPersistedUi(storage: UiStorage | null = sessionStorageOrNull
         const value = p[key];
         if (typeof value === 'string' || value === null) out[key] = value;
     }
-    if (p.panelTab === 'entidad' || p.panelTab === 'pistas' || p.panelTab === 'diario') {
+    if (
+        p.panelTab === 'entidad' ||
+        p.panelTab === 'pistas' ||
+        p.panelTab === 'diario' ||
+        p.panelTab === 'eventos'
+    ) {
         out.panelTab = p.panelTab;
     }
     if (typeof p.mapCollapsed === 'boolean') out.mapCollapsed = p.mapCollapsed;

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -869,7 +869,7 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
 // ── uiStore ─────────────────────────────────────────────────────────────────
 
 export type MapTier = 'sector' | 'system' | 'place';
-export type PanelTab = 'entidad' | 'pistas' | 'diario' | 'eventos';
+export type PanelTab = 'entidad' | 'pistas' | 'hilos' | 'diario' | 'eventos';
 
 /** Map viewport transform — structurally identical to StarMap's MapViewport. */
 export interface UiViewport {
@@ -893,6 +893,12 @@ export interface UiSlice {
     siteListId: string | null;
     selectedEntityId: string | null;
     panelTab: PanelTab;
+    /**
+     * Trama whose narrative web ("Hilos" feature) is painted on the sector
+     * map; null = none. Persisted; a stale id after a re-scan simply paints
+     * nothing (the derivation returns empty nodes) — it never crashes.
+     */
+    focusTramaId: string | null;
     mapCollapsed: boolean;
     showUnknown: boolean;
     /**
@@ -925,6 +931,13 @@ export interface UiState extends UiSlice {
         closeSiteList: () => void;
         selectEntity: (entityId: string | null) => void;
         setPanelTab: (tab: PanelTab) => void;
+        /**
+         * Paint (or clear) a trama's thread web on the sector map. TOGGLE:
+         * calling with the already-focused id clears it. Focusing also drops
+         * to the sector tier so the web is visible (mirrors backToSector:
+         * tier 'sector', clears focusPlaceId/focusSystemId/siteListId).
+         */
+        focusTrama: (tramaId: string | null) => void;
         setMapCollapsed: (collapsed: boolean) => void;
         setShowUnknown: (show: boolean) => void;
         /** Remembers a gesture-committed viewport under its tier key. */
@@ -940,6 +953,7 @@ const UI_INITIAL: UiSlice = {
     siteListId: null,
     selectedEntityId: null,
     panelTab: 'entidad',
+    focusTramaId: null,
     mapCollapsed: false,
     showUnknown: true,
     viewports: {},
@@ -994,7 +1008,13 @@ export function readPersistedUi(storage: UiStorage | null = sessionStorageOrNull
     const p = parsed as Record<string, unknown>;
     const out: Partial<UiSlice> = {};
     if (p.tier === 'sector' || p.tier === 'system' || p.tier === 'place') out.tier = p.tier;
-    for (const key of ['focusSystemId', 'focusPlaceId', 'siteListId', 'selectedEntityId'] as const) {
+    for (const key of [
+        'focusSystemId',
+        'focusPlaceId',
+        'siteListId',
+        'selectedEntityId',
+        'focusTramaId',
+    ] as const) {
         const value = p[key];
         if (typeof value === 'string' || value === null) out[key] = value;
     }
@@ -1006,6 +1026,7 @@ export function readPersistedUi(storage: UiStorage | null = sessionStorageOrNull
     if (
         p.panelTab === 'entidad' ||
         p.panelTab === 'pistas' ||
+        p.panelTab === 'hilos' ||
         p.panelTab === 'diario' ||
         p.panelTab === 'eventos'
     ) {
@@ -1033,6 +1054,7 @@ export function persistUi(state: UiSlice, storage: UiStorage | null = sessionSto
         siteListId: state.siteListId,
         selectedEntityId: state.selectedEntityId,
         panelTab: state.panelTab,
+        focusTramaId: state.focusTramaId,
         mapCollapsed: state.mapCollapsed,
         showUnknown: state.showUnknown,
         viewports: state.viewports,
@@ -1080,6 +1102,22 @@ export const useUiStore = create<UiState>()((set) => ({
         },
         setPanelTab(tab: PanelTab) {
             set({ panelTab: tab });
+        },
+        focusTrama(tramaId: string | null) {
+            set((state) => {
+                // Toggle: re-focusing the same trama clears the web.
+                const next = tramaId !== null && state.focusTramaId === tramaId ? null : tramaId;
+                // Focusing drops to the sector tier so the web is visible
+                // (reuse backToSector's effect); clearing leaves the tier as-is.
+                if (next === null) return { focusTramaId: null };
+                return {
+                    focusTramaId: next,
+                    tier: 'sector',
+                    focusPlaceId: null,
+                    focusSystemId: null,
+                    siteListId: null,
+                };
+            });
         },
         setMapCollapsed(collapsed: boolean) {
             set({ mapCollapsed: collapsed });

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -868,7 +868,7 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
 
 // ── uiStore ─────────────────────────────────────────────────────────────────
 
-export type MapTier = 'sector' | 'system';
+export type MapTier = 'sector' | 'system' | 'place';
 export type PanelTab = 'entidad' | 'pistas' | 'diario' | 'eventos';
 
 /** Map viewport transform — structurally identical to StarMap's MapViewport. */
@@ -888,14 +888,17 @@ export interface UiViewport {
 export interface UiSlice {
     tier: MapTier;
     focusSystemId: string | null;
+    /** Place focused at the 'place' tier (spatial Plano); null at other tiers. */
+    focusPlaceId: string | null;
     siteListId: string | null;
     selectedEntityId: string | null;
     panelTab: PanelTab;
     mapCollapsed: boolean;
     showUnknown: boolean;
     /**
-     * Last gesture-committed map viewport per tier key ('sector' or
-     * 'system:<sistemaId>'). Only gesture ENDS land here (StarMap emits
+     * Last gesture-committed map viewport per tier key ('sector',
+     * 'system:<sistemaId>' or 'place:<placeId>'). Only gesture ENDS land here
+     * (StarMap emits
      * onViewportChange once per finished gesture); mid-gesture transforms
      * stay in StarMap's refs and are ephemeral by design.
      */
@@ -907,8 +910,16 @@ export interface UiState extends UiSlice {
         setTier: (tier: MapTier) => void;
         /** Drill into a sistema: sets the focus AND switches to the 'system' tier. */
         focusSystem: (systemId: string) => void;
+        /**
+         * Drill into a place's spatial Plano: switches to the 'place' tier,
+         * pins both the place and its parent sistema (for the system-tier
+         * backdrop and breadcrumb), and closes any open SiteList.
+         */
+        focusPlace: (placeId: string, systemId: string) => void;
         /** Back out to the sector tier (keeps the last focus for re-entry). */
         backToSector: () => void;
+        /** Back out from the Plano to the system tier (keeps focusSystemId). */
+        backToSystem: () => void;
         /** Open the interior list of a lugar (tier stays where it is). */
         openSiteList: (placeId: string) => void;
         closeSiteList: () => void;
@@ -925,6 +936,7 @@ export interface UiState extends UiSlice {
 const UI_INITIAL: UiSlice = {
     tier: 'sector',
     focusSystemId: null,
+    focusPlaceId: null,
     siteListId: null,
     selectedEntityId: null,
     panelTab: 'entidad',
@@ -981,10 +993,15 @@ export function readPersistedUi(storage: UiStorage | null = sessionStorageOrNull
     if (parsed === null || typeof parsed !== 'object') return {};
     const p = parsed as Record<string, unknown>;
     const out: Partial<UiSlice> = {};
-    if (p.tier === 'sector' || p.tier === 'system') out.tier = p.tier;
-    for (const key of ['focusSystemId', 'siteListId', 'selectedEntityId'] as const) {
+    if (p.tier === 'sector' || p.tier === 'system' || p.tier === 'place') out.tier = p.tier;
+    for (const key of ['focusSystemId', 'focusPlaceId', 'siteListId', 'selectedEntityId'] as const) {
         const value = p[key];
         if (typeof value === 'string' || value === null) out[key] = value;
+    }
+    // A 'place' tier with no focus can't render a Plano — degrade to system
+    // (if a sistema is focused) or sector, so a reload never lands blank.
+    if (out.tier === 'place' && !out.focusPlaceId) {
+        out.tier = out.focusSystemId ? 'system' : 'sector';
     }
     if (
         p.panelTab === 'entidad' ||
@@ -1012,6 +1029,7 @@ export function persistUi(state: UiSlice, storage: UiStorage | null = sessionSto
     const slice: UiSlice = {
         tier: state.tier,
         focusSystemId: state.focusSystemId,
+        focusPlaceId: state.focusPlaceId,
         siteListId: state.siteListId,
         selectedEntityId: state.selectedEntityId,
         panelTab: state.panelTab,
@@ -1035,10 +1053,21 @@ export const useUiStore = create<UiState>()((set) => ({
             set({ tier });
         },
         focusSystem(systemId: string) {
-            set({ tier: 'system', focusSystemId: systemId, siteListId: null });
+            set({ tier: 'system', focusSystemId: systemId, focusPlaceId: null, siteListId: null });
+        },
+        focusPlace(placeId: string, systemId: string) {
+            set({
+                tier: 'place',
+                focusPlaceId: placeId,
+                focusSystemId: systemId,
+                siteListId: null,
+            });
         },
         backToSector() {
-            set({ tier: 'sector', siteListId: null });
+            set({ tier: 'sector', focusPlaceId: null, siteListId: null });
+        },
+        backToSystem() {
+            set({ tier: 'system', focusPlaceId: null, siteListId: null });
         },
         openSiteList(placeId: string) {
             set({ siteListId: placeId });

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -2,15 +2,30 @@
  * World-mode zustand stores (plan Part B).
  *
  * worldStore — immutable-after-scan world model + scan lifecycle.
+ * partyStore — live file-backed party state + session recorder (M3).
  * uiStore — map tier/focus/selection/panel UI state.
  *
- * Headless on purpose: no React imports, so both stores are bun-testable via
- * useXxxStore.getState() without a DOM.
+ * Headless on purpose: no React imports, so all stores are bun-testable via
+ * useXxxStore.getState() without a DOM. The partyStore additionally takes its
+ * side effects (estado write, journal writer, clock, mirror storage) as
+ * injected deps — the page provides bound closures; tests provide fakes.
  */
 
 import { create } from 'zustand';
-import { WorldModel } from '@/types/world';
+import {
+    JournalDay,
+    JournalEntry,
+    JournalEntryType,
+    PartySnapshot,
+    PartyState,
+    SessionRuntime,
+    WorldModel,
+} from '@/types/world';
 import { FileSystemManager } from '@/lib/fileSystem';
+import { ENTITY_DIRS, WORLD_DIR } from './constants';
+import { applyEntryToSnapshot, makeEntry, serializeJournal } from './logEntries';
+import { nextJournalFile } from './journalWriter';
+import { defaultPartyState, serializePartyState } from './partyState';
 import { scanWorldFolder } from './worldScanner';
 
 // ── worldStore ──────────────────────────────────────────────────────────────
@@ -83,6 +98,653 @@ export const useWorldStore = create<WorldState>()((set, get) => ({
         },
     },
 }));
+
+// ── partyStore ──────────────────────────────────────────────────────────────
+
+export type WriteStatus = SessionRuntime['writeStatus'];
+
+/**
+ * Journal writer surface the store depends on — matches the JournalWriter
+ * class in lib/world/journalWriter.ts one-to-one (the page passes the
+ * instance or bound closures). Full-rewrite semantics: `rewrite` replaces the
+ * whole file (append == undo == same path) through the writer's own
+ * serialized queue. NOTE: `flush` follows the JournalWriter contract — it
+ * resolves (never rejects) even when a write was denied; the outcome is
+ * observed through `onStatus`.
+ */
+export interface PartyStoreJournal {
+    /** Claim/create the session's journal file and write its initial full text. */
+    open: (filePath: string, text: string) => void;
+    /** Queue a full rewrite of the journal with the given text. */
+    rewrite: (text: string) => void;
+    /** Resolves when the write queue is idle (persisted OR stalled denied). */
+    flush: () => Promise<void>;
+    /** Retry after a denied write (permission regained). */
+    retryNow: () => void;
+    /** Optional status feed; the store subscribes on setDeps. */
+    onStatus?: (cb: (status: WriteStatus) => void) => void;
+}
+
+/** Minimal Storage surface for the crash mirror (injectable for bun tests). */
+export type MirrorStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export interface PartyStoreDeps {
+    /**
+     * Bound closure that writes `mundo/estado/grupo.md` (the binding side —
+     * worldWriter — enforces the diario/+estado/ write surface).
+     */
+    writeEstado: (text: string) => Promise<void>;
+    journal: PartyStoreJournal;
+    now: () => Date;
+    /** Estado write debounce in ms; default DEFAULT_ESTADO_DEBOUNCE_MS. */
+    debounceMs?: number;
+    /** Crash-mirror storage; defaults to window.sessionStorage (no-op when absent). */
+    mirrorStorage?: MirrorStorage;
+}
+
+export const DEFAULT_ESTADO_DEBOUNCE_MS = 2000;
+
+/**
+ * Crash mirror persisted to sessionStorage on every session mutation.
+ *
+ * DECISION (M3 reconciliation): the mirror carries the session-start
+ * `snapshot` IN the mirror itself — recovery replays `entries` over
+ * `snapshot`, NOT over the estado file (which may hold a newer
+ * debounce-written mid-session state, so replaying over it would
+ * double-apply entries). This is THE canonical crash mirror (key
+ * `world.session.mirror.v1`); the snapshot-less helpers that briefly lived
+ * in lib/world/journalWriter.ts were deleted — the journal writer mirrors
+ * nothing.
+ */
+export interface SessionMirror {
+    version: 1;
+    journalPath: string;
+    sesion: number;
+    fechaReal: string;
+    diaInicio: number | null;
+    /** Epoch ms when the session started. */
+    startedAt: number;
+    /** Party state at session start — the replay base. */
+    snapshot: PartySnapshot;
+    entries: JournalEntry[];
+}
+
+export const SESSION_MIRROR_KEY = 'world.session.mirror.v1';
+
+function defaultMirrorStorage(): MirrorStorage | null {
+    if (typeof window === 'undefined') return null;
+    try {
+        return window.sessionStorage;
+    } catch {
+        return null; // storage blocked (e.g. privacy mode) — mirror disabled
+    }
+}
+
+/** Reads (and validates) the crash mirror; null when absent/corrupt/SSR. */
+export function readSessionMirror(storage?: MirrorStorage | null): SessionMirror | null {
+    const st = storage ?? defaultMirrorStorage();
+    if (!st) return null;
+    try {
+        const raw = st.getItem(SESSION_MIRROR_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as SessionMirror;
+        if (
+            parsed === null ||
+            typeof parsed !== 'object' ||
+            parsed.version !== 1 ||
+            typeof parsed.journalPath !== 'string' ||
+            typeof parsed.startedAt !== 'number' ||
+            typeof parsed.snapshot !== 'object' ||
+            parsed.snapshot === null ||
+            !Array.isArray(parsed.entries)
+        ) {
+            return null;
+        }
+        // A journalPath outside the app's write surface is a corrupt/hostile
+        // mirror: recovering it would make JournalWriter.open() throw AFTER
+        // the session flipped active. Treat it as no mirror.
+        if (!parsed.journalPath.startsWith(`${WORLD_DIR}/${ENTITY_DIRS.diario}/`)) {
+            return null;
+        }
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+export function clearSessionMirror(storage?: MirrorStorage | null): void {
+    const st = storage ?? defaultMirrorStorage();
+    if (!st) return;
+    try {
+        st.removeItem(SESSION_MIRROR_KEY);
+    } catch {
+        // best effort
+    }
+}
+
+/** End-of-session recap returned by endSession() for the closing toast. */
+export interface SessionSummary {
+    durationMs: number;
+    counts: Partial<Record<JournalEntryType, number>>;
+    /** Sum of ganancia minus gasto payloads over the whole session. */
+    netCreditos: number;
+}
+
+export interface PartyStoreState {
+    // Live party fields (PartySnapshot shape, mutated only through log/undo/replay)
+    diaMundo: number;
+    ubicacion: string | null;
+    rumbo: { destino: string; llegadaDia: number } | null;
+    creditos: number;
+    medidores: Record<string, number>;
+    /** Agent-owned estado body, preserved byte-for-byte on every write. */
+    bodyMd: string;
+    /** Path of estado/grupo.md relative to the campaign folder (bookkeeping). */
+    estadoFilePath: string | null;
+    session: SessionRuntime;
+    actions: {
+        /** Injects side-effect deps (page: bound closures; tests: fakes). */
+        setDeps: (deps: PartyStoreDeps) => void;
+        /** Loads estadoGrupo (or defaults) into the live fields. No-op mid-session. */
+        hydrate: (model: WorldModel) => void;
+        /**
+         * Opens a session: next journal file from `diario` + `today`
+         * (YYYY-MM-DD), inicio entry, snapshot, journal open, mirror,
+         * debounced estado write with sesion_activa true. Returns the new
+         * JournalDay (null when already active / deps missing).
+         */
+        startSession: (diario: JournalDay[], today: string) => JournalDay | null;
+        /**
+         * THE single mutation entry point: applies the entry to the live
+         * fields, appends it, rewrites the journal, refreshes the mirror and
+         * schedules the debounced estado write. Returns the entry for the
+         * toast; null (+console.warn) when no session is active.
+         */
+        log: (entry: JournalEntry) => JournalEntry | null;
+        /**
+         * Drops the last entry (never the inicio) and recomputes the live
+         * fields by replaying the remaining entries over the session-start
+         * snapshot. Returns the removed entry, or null when nothing undoable.
+         */
+        undoLast: () => JournalEntry | null;
+        /**
+         * Appends fin, sets dia_fin, flushes the journal, forces the estado
+         * write with sesion_activa false, clears the mirror and deactivates.
+         * If the journal flush fails the session STAYS active (writeStatus
+         * denied, mirror kept) and null is returned — retry after retryWrites.
+         */
+        endSession: () => Promise<SessionSummary | null>;
+        /**
+         * Rebuilds an active session from a crash mirror: live fields =
+         * mirror.entries replayed over mirror.snapshot (see SessionMirror
+         * doc); estado body/path re-taken from the fresh model; journal
+         * reopened with the full serialized content.
+         */
+        recoverSession: (mirror: SessionMirror, model: WorldModel) => void;
+        /** Forces any pending debounced estado write now; resolves when settled. */
+        flushEstado: () => Promise<void>;
+        /**
+         * Registers pagehide/visibilitychange listeners that flush the
+         * debounced estado write; returns the cleanup. SSR-safe no-op.
+         */
+        bindLifecycleFlush: () => () => void;
+        /** Feed for the journal writer's status (page binds this as onStatus). */
+        setJournalStatus: (status: WriteStatus) => void;
+        /** Retries denied writes: journal retryNow + estado re-write. */
+        retryWrites: () => void;
+        reset: () => void;
+    };
+}
+
+const SESSION_INITIAL: SessionRuntime = {
+    active: false,
+    journalPath: null,
+    startedAt: null,
+    entries: [],
+    snapshot: null,
+    writeStatus: 'ok',
+};
+
+function partyInitial() {
+    const defaults = defaultPartyState();
+    return {
+        diaMundo: defaults.diaMundo,
+        ubicacion: defaults.ubicacion,
+        rumbo: defaults.rumbo,
+        creditos: defaults.creditos,
+        medidores: defaults.medidores,
+        bodyMd: defaults.bodyMd,
+        estadoFilePath: null as string | null,
+        session: { ...SESSION_INITIAL, entries: [] as JournalEntry[] },
+    };
+}
+
+function cloneSnapshot(snapshot: PartySnapshot): PartySnapshot {
+    return {
+        diaMundo: snapshot.diaMundo,
+        ubicacion: snapshot.ubicacion,
+        rumbo: snapshot.rumbo === null ? null : { ...snapshot.rumbo },
+        creditos: snapshot.creditos,
+        medidores: { ...snapshot.medidores },
+    };
+}
+
+function summarize(entries: JournalEntry[], durationMs: number): SessionSummary {
+    const counts: Partial<Record<JournalEntryType, number>> = {};
+    let netCreditos = 0;
+    for (const entry of entries) {
+        counts[entry.tipo] = (counts[entry.tipo] ?? 0) + 1;
+        const cantidad = Number(entry.payload.trim());
+        if (!Number.isFinite(cantidad)) continue;
+        if (entry.tipo === 'ganancia') netCreditos += cantidad;
+        if (entry.tipo === 'gasto') netCreditos -= cantidad;
+    }
+    return { durationMs: Math.max(0, durationMs), counts, netCreditos };
+}
+
+export const usePartyStore = create<PartyStoreState>()((set, get) => {
+    // Non-reactive session machinery lives in the closure, not in state.
+    let deps: PartyStoreDeps | null = null;
+    let journalDay: JournalDay | null = null;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let journalStatus: WriteStatus = 'ok';
+    let estadoStatus: WriteStatus = 'ok';
+    /** Serializes estado writes; never left rejected. */
+    let estadoChain: Promise<void> = Promise.resolve();
+
+    function combineStatus(a: WriteStatus, b: WriteStatus): WriteStatus {
+        if (a === 'denied' || b === 'denied') return 'denied'; // denied wins over pending
+        if (a === 'pending' || b === 'pending') return 'pending';
+        return 'ok';
+    }
+
+    function pushStatus() {
+        const writeStatus = combineStatus(journalStatus, estadoStatus);
+        const { session } = get();
+        if (session.writeStatus === writeStatus) return;
+        set({ session: { ...session, writeStatus } });
+    }
+
+    function liveSnapshot(): PartySnapshot {
+        const s = get();
+        return cloneSnapshot({
+            diaMundo: s.diaMundo,
+            ubicacion: s.ubicacion,
+            rumbo: s.rumbo,
+            creditos: s.creditos,
+            medidores: s.medidores,
+        });
+    }
+
+    function snapshotToFields(snapshot: PartySnapshot) {
+        const copy = cloneSnapshot(snapshot);
+        return {
+            diaMundo: copy.diaMundo,
+            ubicacion: copy.ubicacion,
+            rumbo: copy.rumbo,
+            creditos: copy.creditos,
+            medidores: copy.medidores,
+        };
+    }
+
+    function currentPartyState(): PartyState {
+        const s = get();
+        return {
+            sesionActiva: s.session.active,
+            diaMundo: s.diaMundo,
+            ubicacion: s.ubicacion,
+            rumbo: s.rumbo === null ? null : { ...s.rumbo },
+            creditos: s.creditos,
+            medidores: { ...s.medidores },
+            bodyMd: s.bodyMd,
+            filePath: s.estadoFilePath,
+        };
+    }
+
+    // ── Crash mirror ────────────────────────────────────────────────────
+
+    function mirrorStorage(): MirrorStorage | null {
+        return deps?.mirrorStorage ?? defaultMirrorStorage();
+    }
+
+    function writeMirror() {
+        const storage = mirrorStorage();
+        if (!storage || journalDay === null) return;
+        const { session } = get();
+        if (!session.active || session.snapshot === null || session.startedAt === null) return;
+        const mirror: SessionMirror = {
+            version: 1,
+            journalPath: journalDay.filePath,
+            sesion: journalDay.sesion,
+            fechaReal: journalDay.fechaReal,
+            diaInicio: journalDay.diaInicio,
+            startedAt: session.startedAt,
+            snapshot: session.snapshot,
+            entries: session.entries,
+        };
+        try {
+            storage.setItem(SESSION_MIRROR_KEY, JSON.stringify(mirror));
+        } catch (error) {
+            console.warn('[world] no se pudo escribir el espejo de sesión', error);
+        }
+    }
+
+    // ── Debounced estado write ──────────────────────────────────────────
+
+    function performEstadoWrite(): Promise<void> {
+        const d = deps;
+        if (d === null) return Promise.resolve();
+        estadoStatus = 'pending';
+        pushStatus();
+        estadoChain = estadoChain
+            .then(() => d.writeEstado(serializePartyState(currentPartyState(), d.now().toISOString())))
+            .then(
+                () => {
+                    estadoStatus = 'ok';
+                    pushStatus();
+                },
+                (error) => {
+                    console.warn('[world] fallo al escribir estado/grupo.md', error);
+                    estadoStatus = 'denied';
+                    pushStatus();
+                }
+            );
+        return estadoChain;
+    }
+
+    function scheduleEstadoWrite() {
+        const d = deps;
+        if (d === null) return;
+        if (debounceTimer !== null) clearTimeout(debounceTimer);
+        estadoStatus = 'pending';
+        pushStatus();
+        debounceTimer = setTimeout(() => {
+            debounceTimer = null;
+            void performEstadoWrite();
+        }, d.debounceMs ?? DEFAULT_ESTADO_DEBOUNCE_MS);
+    }
+
+    function flushEstadoNow(): Promise<void> {
+        if (debounceTimer !== null) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+            return performEstadoWrite();
+        }
+        return estadoChain;
+    }
+
+    return {
+        ...partyInitial(),
+        actions: {
+            setDeps(next: PartyStoreDeps) {
+                deps = next;
+                next.journal.onStatus?.((status) => {
+                    journalStatus = status;
+                    pushStatus();
+                });
+            },
+
+            hydrate(model: WorldModel) {
+                if (get().session.active) {
+                    console.warn('[world] hydrate ignorado: hay una sesión activa');
+                    return;
+                }
+                const estado = model.estadoGrupo ?? defaultPartyState();
+                set({
+                    diaMundo: estado.diaMundo,
+                    ubicacion: estado.ubicacion,
+                    rumbo: estado.rumbo === null ? null : { ...estado.rumbo },
+                    creditos: estado.creditos,
+                    medidores: { ...estado.medidores },
+                    bodyMd: estado.bodyMd,
+                    estadoFilePath: estado.filePath,
+                });
+            },
+
+            startSession(diario: JournalDay[], today: string): JournalDay | null {
+                const s = get();
+                if (s.session.active) {
+                    console.warn('[world] startSession ignorado: ya hay una sesión activa');
+                    return null;
+                }
+                if (deps === null) {
+                    console.warn('[world] startSession ignorado: faltan las dependencias (setDeps)');
+                    return null;
+                }
+                const inicio = makeEntry.inicio(s.diaMundo, s.ubicacion, deps.now);
+                const snapshot = liveSnapshot();
+                const { fileName, sesion } = nextJournalFile(diario, today);
+                journalDay = {
+                    filePath: `${WORLD_DIR}/${ENTITY_DIRS.diario}/${fileName}`,
+                    sesion,
+                    fechaReal: today,
+                    diaInicio: s.diaMundo,
+                    diaFin: null,
+                    procesado: false,
+                    entradas: [inicio],
+                };
+                journalStatus = 'ok';
+                estadoStatus = 'ok';
+                set({
+                    session: {
+                        active: true,
+                        journalPath: journalDay.filePath,
+                        startedAt: deps.now().getTime(),
+                        entries: [inicio],
+                        snapshot,
+                        writeStatus: 'ok',
+                    },
+                });
+                writeMirror();
+                deps.journal.open(journalDay.filePath, serializeJournal(journalDay, journalDay.entradas));
+                scheduleEstadoWrite(); // sesion_activa: true reaches disk within the debounce
+                return journalDay;
+            },
+
+            log(entry: JournalEntry): JournalEntry | null {
+                const s = get();
+                if (!s.session.active || deps === null || journalDay === null) {
+                    console.warn('[world] log ignorado: no hay sesión activa');
+                    return null;
+                }
+                const next = applyEntryToSnapshot(liveSnapshot(), entry);
+                const entries = [...s.session.entries, entry];
+                journalDay = { ...journalDay, entradas: entries };
+                set({
+                    ...snapshotToFields(next),
+                    session: { ...s.session, entries },
+                });
+                writeMirror();
+                deps.journal.rewrite(serializeJournal(journalDay, journalDay.entradas));
+                scheduleEstadoWrite();
+                return entry;
+            },
+
+            undoLast(): JournalEntry | null {
+                const s = get();
+                if (!s.session.active || deps === null || journalDay === null) {
+                    console.warn('[world] undo ignorado: no hay sesión activa');
+                    return null;
+                }
+                if (s.session.entries.length <= 1) {
+                    console.warn('[world] undo ignorado: la entrada de inicio no se puede deshacer');
+                    return null;
+                }
+                const removed = s.session.entries[s.session.entries.length - 1];
+                const entries = s.session.entries.slice(0, -1);
+                let snapshot = cloneSnapshot(s.session.snapshot!);
+                for (const past of entries) {
+                    snapshot = applyEntryToSnapshot(snapshot, past);
+                }
+                journalDay = { ...journalDay, entradas: entries };
+                set({
+                    ...snapshotToFields(snapshot),
+                    session: { ...s.session, entries },
+                });
+                writeMirror();
+                deps.journal.rewrite(serializeJournal(journalDay, journalDay.entradas));
+                scheduleEstadoWrite();
+                return removed;
+            },
+
+            async endSession(): Promise<SessionSummary | null> {
+                const s = get();
+                if (!s.session.active || deps === null || journalDay === null) {
+                    console.warn('[world] endSession ignorado: no hay sesión activa');
+                    return null;
+                }
+                const d = deps;
+                // Reuse the fin from a previous failed close instead of duplicating it.
+                // If the GM logged more entries after a failed close, the old fin is
+                // stranded mid-journal — drop it: a fin must only ever be the final entry.
+                let entries = s.session.entries;
+                if (entries[entries.length - 1]?.tipo !== 'fin') {
+                    entries = [
+                        ...entries.filter((e) => e.tipo !== 'fin'),
+                        makeEntry.fin(s.diaMundo, s.ubicacion, d.now),
+                    ];
+                }
+                journalDay = { ...journalDay, diaFin: s.diaMundo, entradas: entries };
+                set({ session: { ...s.session, entries } });
+                writeMirror();
+                d.journal.rewrite(serializeJournal(journalDay, journalDay.entradas));
+                try {
+                    await d.journal.flush();
+                } catch (error) {
+                    // Defensive: JournalWriter.flush never rejects, but a
+                    // custom binding might.
+                    console.warn('[world] no se pudo confirmar el diario al cerrar la sesión', error);
+                    journalStatus = 'denied';
+                    pushStatus();
+                    return null;
+                }
+                if (journalStatus === 'denied') {
+                    // JournalWriter.flush resolves even on denial (status via
+                    // onStatus). Journal is the recovery log: without it on
+                    // disk we neither deactivate nor drop the mirror. The GM
+                    // retries via retryWrites and closes again.
+                    console.warn('[world] cierre pospuesto: el diario no se pudo escribir');
+                    return null;
+                }
+                const startedAt = s.session.startedAt ?? d.now().getTime();
+                const summary = summarize(entries, d.now().getTime() - startedAt);
+                if (debounceTimer !== null) {
+                    clearTimeout(debounceTimer);
+                    debounceTimer = null;
+                }
+                // Deactivate BEFORE the forced write so sesion_activa: false lands.
+                set({
+                    session: {
+                        active: false,
+                        journalPath: null,
+                        startedAt: null,
+                        entries: [],
+                        snapshot: null,
+                        writeStatus: combineStatus(journalStatus, estadoStatus),
+                    },
+                });
+                // Even if this write is denied the journal is safe on disk; the
+                // stale sesion_activa lock is flagged to the GM by PROTOCOLO.
+                await performEstadoWrite();
+                clearSessionMirror(mirrorStorage());
+                journalDay = null;
+                return summary;
+            },
+
+            recoverSession(mirror: SessionMirror, model: WorldModel) {
+                if (get().session.active) {
+                    console.warn('[world] recoverSession ignorado: ya hay una sesión activa');
+                    return;
+                }
+                if (deps === null) {
+                    console.warn('[world] recoverSession ignorado: faltan las dependencias (setDeps)');
+                    return;
+                }
+                const estado = model.estadoGrupo;
+                let snapshot = cloneSnapshot(mirror.snapshot);
+                for (const entry of mirror.entries) {
+                    snapshot = applyEntryToSnapshot(snapshot, entry);
+                }
+                journalDay = {
+                    filePath: mirror.journalPath,
+                    sesion: mirror.sesion,
+                    fechaReal: mirror.fechaReal,
+                    diaInicio: mirror.diaInicio,
+                    diaFin: null,
+                    procesado: false,
+                    entradas: [...mirror.entries],
+                };
+                journalStatus = 'ok';
+                estadoStatus = 'ok';
+                set({
+                    ...snapshotToFields(snapshot),
+                    bodyMd: estado?.bodyMd ?? '',
+                    estadoFilePath: estado?.filePath ?? null,
+                    session: {
+                        active: true,
+                        journalPath: mirror.journalPath,
+                        startedAt: mirror.startedAt,
+                        entries: [...mirror.entries],
+                        snapshot: cloneSnapshot(mirror.snapshot),
+                        writeStatus: 'ok',
+                    },
+                });
+                writeMirror();
+                // Reopen + resync: the file content is rewritten to match memory.
+                deps.journal.open(journalDay.filePath, serializeJournal(journalDay, journalDay.entradas));
+                scheduleEstadoWrite();
+            },
+
+            flushEstado(): Promise<void> {
+                return flushEstadoNow();
+            },
+
+            bindLifecycleFlush(): () => void {
+                if (typeof window === 'undefined' || typeof document === 'undefined') {
+                    return () => {};
+                }
+                const onPageHide = () => {
+                    void flushEstadoNow();
+                };
+                const onVisibilityChange = () => {
+                    if (document.visibilityState === 'hidden') void flushEstadoNow();
+                };
+                window.addEventListener('pagehide', onPageHide);
+                document.addEventListener('visibilitychange', onVisibilityChange);
+                return () => {
+                    window.removeEventListener('pagehide', onPageHide);
+                    document.removeEventListener('visibilitychange', onVisibilityChange);
+                };
+            },
+
+            setJournalStatus(status: WriteStatus) {
+                journalStatus = status;
+                pushStatus();
+            },
+
+            retryWrites() {
+                deps?.journal.retryNow();
+                if (estadoStatus === 'denied') void performEstadoWrite();
+            },
+
+            reset() {
+                if (debounceTimer !== null) {
+                    clearTimeout(debounceTimer);
+                    debounceTimer = null;
+                }
+                // NOTE: the crash mirror is intentionally NOT cleared — reset
+                // simulates/handles an in-app teardown, and the mirror must
+                // survive until endSession or an explicit clearSessionMirror.
+                deps = null;
+                journalDay = null;
+                journalStatus = 'ok';
+                estadoStatus = 'ok';
+                estadoChain = Promise.resolve();
+                set({ ...partyInitial() });
+            },
+        },
+    };
+});
 
 // ── uiStore ─────────────────────────────────────────────────────────────────
 

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -94,6 +94,8 @@ export interface UiState {
     tier: MapTier;
     /** Sistema focused at the 'system' tier. */
     focusSystemId: string | null;
+    /** Lugar whose SiteList (non-spatial tier 3) is open; null = closed. */
+    siteListId: string | null;
     selectedEntityId: string | null;
     panelTab: PanelTab;
     mapCollapsed: boolean;
@@ -105,6 +107,9 @@ export interface UiState {
         focusSystem: (systemId: string) => void;
         /** Back out to the sector tier (keeps the last focus for re-entry). */
         backToSector: () => void;
+        /** Open the interior list of a lugar (tier stays where it is). */
+        openSiteList: (placeId: string) => void;
+        closeSiteList: () => void;
         selectEntity: (entityId: string | null) => void;
         setPanelTab: (tab: PanelTab) => void;
         setMapCollapsed: (collapsed: boolean) => void;
@@ -116,6 +121,7 @@ export interface UiState {
 const UI_INITIAL = {
     tier: 'sector' as MapTier,
     focusSystemId: null,
+    siteListId: null,
     selectedEntityId: null,
     panelTab: 'entidad' as PanelTab,
     mapCollapsed: false,
@@ -129,10 +135,16 @@ export const useUiStore = create<UiState>()((set) => ({
             set({ tier });
         },
         focusSystem(systemId: string) {
-            set({ tier: 'system', focusSystemId: systemId });
+            set({ tier: 'system', focusSystemId: systemId, siteListId: null });
         },
         backToSector() {
-            set({ tier: 'sector' });
+            set({ tier: 'sector', siteListId: null });
+        },
+        openSiteList(placeId: string) {
+            set({ siteListId: placeId });
+        },
+        closeSiteList() {
+            set({ siteListId: null });
         },
         selectEntity(entityId: string | null) {
             set({ selectedEntityId: entityId });

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -1,0 +1,153 @@
+/**
+ * World-mode zustand stores (plan Part B).
+ *
+ * worldStore — immutable-after-scan world model + scan lifecycle.
+ * uiStore — map tier/focus/selection/panel UI state.
+ *
+ * Headless on purpose: no React imports, so both stores are bun-testable via
+ * useXxxStore.getState() without a DOM.
+ */
+
+import { create } from 'zustand';
+import { WorldModel } from '@/types/world';
+import { FileSystemManager } from '@/lib/fileSystem';
+import { scanWorldFolder } from './worldScanner';
+
+// ── worldStore ──────────────────────────────────────────────────────────────
+
+export type WorldStatus = 'idle' | 'scanning' | 'ready' | 'error';
+
+export interface ScanProgress {
+    done: number;
+    total: number;
+}
+
+export interface WorldState {
+    status: WorldStatus;
+    scanProgress: ScanProgress;
+    /** Immutable after scan; null until a scan succeeds. */
+    model: WorldModel | null;
+    /** Bound to the campaign folder handle at scan time; used for later file reads. */
+    fs: FileSystemManager | null;
+    /** Spanish user-facing message when status === 'error'. */
+    error: string | null;
+    actions: {
+        /** Scans `mundo/` under the campaign folder handle into the store. */
+        scan: (handle: FileSystemDirectoryHandle) => Promise<void>;
+        reset: () => void;
+    };
+}
+
+const WORLD_INITIAL = {
+    status: 'idle' as WorldStatus,
+    scanProgress: { done: 0, total: 0 },
+    model: null,
+    fs: null,
+    error: null,
+};
+
+export const useWorldStore = create<WorldState>()((set, get) => ({
+    ...WORLD_INITIAL,
+    actions: {
+        async scan(handle: FileSystemDirectoryHandle) {
+            if (get().status === 'scanning') return;
+
+            const fs = new FileSystemManager();
+            fs.setDirectoryHandle(handle);
+            set({
+                status: 'scanning',
+                scanProgress: { done: 0, total: 0 },
+                model: null,
+                fs,
+                error: null,
+            });
+
+            try {
+                const model = await scanWorldFolder(handle, (done, total) => {
+                    set({ scanProgress: { done, total } });
+                });
+                set({ status: 'ready', model, error: null });
+            } catch (error) {
+                // scanWorldFolder degrades content problems into model.problemas;
+                // this guards against infrastructure failures only.
+                const detail = error instanceof Error ? error.message : String(error);
+                set({
+                    status: 'error',
+                    model: null,
+                    error: `No se pudo abrir el mundo: ${detail}`,
+                });
+            }
+        },
+        reset() {
+            set({ ...WORLD_INITIAL });
+        },
+    },
+}));
+
+// ── uiStore ─────────────────────────────────────────────────────────────────
+
+export type MapTier = 'sector' | 'system';
+export type PanelTab = 'entidad' | 'pistas' | 'diario';
+
+export interface UiState {
+    /** Starmap semantic-zoom tier. */
+    tier: MapTier;
+    /** Sistema focused at the 'system' tier. */
+    focusSystemId: string | null;
+    selectedEntityId: string | null;
+    panelTab: PanelTab;
+    mapCollapsed: boolean;
+    /** Show desconocido entities as ghosts (toggle off for screen-share). */
+    showUnknown: boolean;
+    actions: {
+        setTier: (tier: MapTier) => void;
+        /** Drill into a sistema: sets the focus AND switches to the 'system' tier. */
+        focusSystem: (systemId: string) => void;
+        /** Back out to the sector tier (keeps the last focus for re-entry). */
+        backToSector: () => void;
+        selectEntity: (entityId: string | null) => void;
+        setPanelTab: (tab: PanelTab) => void;
+        setMapCollapsed: (collapsed: boolean) => void;
+        setShowUnknown: (show: boolean) => void;
+        reset: () => void;
+    };
+}
+
+const UI_INITIAL = {
+    tier: 'sector' as MapTier,
+    focusSystemId: null,
+    selectedEntityId: null,
+    panelTab: 'entidad' as PanelTab,
+    mapCollapsed: false,
+    showUnknown: true,
+};
+
+export const useUiStore = create<UiState>()((set) => ({
+    ...UI_INITIAL,
+    actions: {
+        setTier(tier: MapTier) {
+            set({ tier });
+        },
+        focusSystem(systemId: string) {
+            set({ tier: 'system', focusSystemId: systemId });
+        },
+        backToSector() {
+            set({ tier: 'sector' });
+        },
+        selectEntity(entityId: string | null) {
+            set({ selectedEntityId: entityId });
+        },
+        setPanelTab(tab: PanelTab) {
+            set({ panelTab: tab });
+        },
+        setMapCollapsed(collapsed: boolean) {
+            set({ mapCollapsed: collapsed });
+        },
+        setShowUnknown(show: boolean) {
+            set({ showUnknown: show });
+        },
+        reset() {
+            set({ ...UI_INITIAL });
+        },
+    },
+}));

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -751,18 +751,38 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
 export type MapTier = 'sector' | 'system';
 export type PanelTab = 'entidad' | 'pistas' | 'diario';
 
-export interface UiState {
-    /** Starmap semantic-zoom tier. */
+/** Map viewport transform — structurally identical to StarMap's MapViewport. */
+export interface UiViewport {
+    x: number;
+    y: number;
+    k: number;
+}
+
+/**
+ * The persisted subset of UiState (everything except actions). M5 polish:
+ * mirrored to sessionStorage on every change so a reload lands where the GM
+ * was. Stale ids after a re-scan degrade exactly like stale store ids do
+ * (invalid focus -> sector tier, missing selection -> empty panel), so no
+ * model-side validation is needed here.
+ */
+export interface UiSlice {
     tier: MapTier;
-    /** Sistema focused at the 'system' tier. */
     focusSystemId: string | null;
-    /** Lugar whose SiteList (non-spatial tier 3) is open; null = closed. */
     siteListId: string | null;
     selectedEntityId: string | null;
     panelTab: PanelTab;
     mapCollapsed: boolean;
-    /** Show desconocido entities as ghosts (toggle off for screen-share). */
     showUnknown: boolean;
+    /**
+     * Last gesture-committed map viewport per tier key ('sector' or
+     * 'system:<sistemaId>'). Only gesture ENDS land here (StarMap emits
+     * onViewportChange once per finished gesture); mid-gesture transforms
+     * stay in StarMap's refs and are ephemeral by design.
+     */
+    viewports: Record<string, UiViewport>;
+}
+
+export interface UiState extends UiSlice {
     actions: {
         setTier: (tier: MapTier) => void;
         /** Drill into a sistema: sets the focus AND switches to the 'system' tier. */
@@ -776,22 +796,115 @@ export interface UiState {
         setPanelTab: (tab: PanelTab) => void;
         setMapCollapsed: (collapsed: boolean) => void;
         setShowUnknown: (show: boolean) => void;
+        /** Remembers a gesture-committed viewport under its tier key. */
+        rememberViewport: (key: string, viewport: UiViewport) => void;
         reset: () => void;
     };
 }
 
-const UI_INITIAL = {
-    tier: 'sector' as MapTier,
+const UI_INITIAL: UiSlice = {
+    tier: 'sector',
     focusSystemId: null,
     siteListId: null,
     selectedEntityId: null,
-    panelTab: 'entidad' as PanelTab,
+    panelTab: 'entidad',
     mapCollapsed: false,
     showUnknown: true,
+    viewports: {},
 };
+
+/** sessionStorage key of the persisted UI slice. */
+export const UI_PERSIST_KEY = 'world.ui.v1';
+
+/** Minimal Storage surface the persistence needs (injectable for bun tests). */
+export type UiStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+function sessionStorageOrNull(): UiStorage | null {
+    if (typeof window === 'undefined') return null;
+    try {
+        return window.sessionStorage;
+    } catch {
+        return null; // storage blocked (e.g. privacy mode) — persistence disabled
+    }
+}
+
+function isUiViewport(value: unknown): value is UiViewport {
+    if (value === null || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.x === 'number' &&
+        Number.isFinite(v.x) &&
+        typeof v.y === 'number' &&
+        Number.isFinite(v.y) &&
+        typeof v.k === 'number' &&
+        Number.isFinite(v.k) &&
+        v.k > 0
+    );
+}
+
+/**
+ * Reads the persisted UI slice, validating FIELD BY FIELD: a corrupt or
+ * out-of-vocabulary field falls back to its default while the valid ones
+ * still restore (same degrade-don't-fail stance as the world scanner).
+ * Returns {} when absent/corrupt/SSR.
+ */
+export function readPersistedUi(storage: UiStorage | null = sessionStorageOrNull()): Partial<UiSlice> {
+    if (!storage) return {};
+    let parsed: unknown;
+    try {
+        const raw = storage.getItem(UI_PERSIST_KEY);
+        if (!raw) return {};
+        parsed = JSON.parse(raw);
+    } catch {
+        return {};
+    }
+    if (parsed === null || typeof parsed !== 'object') return {};
+    const p = parsed as Record<string, unknown>;
+    const out: Partial<UiSlice> = {};
+    if (p.tier === 'sector' || p.tier === 'system') out.tier = p.tier;
+    for (const key of ['focusSystemId', 'siteListId', 'selectedEntityId'] as const) {
+        const value = p[key];
+        if (typeof value === 'string' || value === null) out[key] = value;
+    }
+    if (p.panelTab === 'entidad' || p.panelTab === 'pistas' || p.panelTab === 'diario') {
+        out.panelTab = p.panelTab;
+    }
+    if (typeof p.mapCollapsed === 'boolean') out.mapCollapsed = p.mapCollapsed;
+    if (typeof p.showUnknown === 'boolean') out.showUnknown = p.showUnknown;
+    if (p.viewports !== null && typeof p.viewports === 'object') {
+        const viewports: Record<string, UiViewport> = {};
+        for (const [key, value] of Object.entries(p.viewports as Record<string, unknown>)) {
+            if (isUiViewport(value)) viewports[key] = { x: value.x, y: value.y, k: value.k };
+        }
+        out.viewports = viewports;
+    }
+    return out;
+}
+
+/** Writes the UI slice to storage (best effort — quota/privacy errors swallowed). */
+export function persistUi(state: UiSlice, storage: UiStorage | null = sessionStorageOrNull()): void {
+    if (!storage) return;
+    const slice: UiSlice = {
+        tier: state.tier,
+        focusSystemId: state.focusSystemId,
+        siteListId: state.siteListId,
+        selectedEntityId: state.selectedEntityId,
+        panelTab: state.panelTab,
+        mapCollapsed: state.mapCollapsed,
+        showUnknown: state.showUnknown,
+        viewports: state.viewports,
+    };
+    try {
+        storage.setItem(UI_PERSIST_KEY, JSON.stringify(slice));
+    } catch {
+        // best effort
+    }
+}
 
 export const useUiStore = create<UiState>()((set) => ({
     ...UI_INITIAL,
+    // Restore the persisted slice at creation (SSR/bun: no window -> defaults).
+    ...readPersistedUi(),
     actions: {
         setTier(tier: MapTier) {
             set({ tier });
@@ -820,8 +933,20 @@ export const useUiStore = create<UiState>()((set) => ({
         setShowUnknown(show: boolean) {
             set({ showUnknown: show });
         },
+        rememberViewport(key: string, viewport: UiViewport) {
+            set((state) => ({
+                viewports: { ...state.viewports, [key]: { ...viewport } },
+            }));
+        },
         reset() {
             set({ ...UI_INITIAL });
         },
     },
 }));
+
+// Mirror every UI change into sessionStorage (a tiny slice — cheaper and less
+// invasive than the zustand persist middleware, and bun-testable through the
+// exported readPersistedUi/persistUi pair). No window (SSR/bun) -> no-op.
+if (typeof window !== 'undefined') {
+    useUiStore.subscribe((state) => persistUi(state));
+}

--- a/lib/world/stores.ts
+++ b/lib/world/stores.ts
@@ -134,6 +134,12 @@ export interface PartyStoreDeps {
      * worldWriter — enforces the diario/+estado/ write surface).
      */
     writeEstado: (text: string) => Promise<void>;
+    /**
+     * Deletes a file relative to the campaign folder. Used by discardSession
+     * to drop a TEST session's journal (page binds it to fsm.deleteFile). The
+     * store enforces the mundo/diario/ surface before calling it.
+     */
+    deleteFile: (path: string) => Promise<void>;
     journal: PartyStoreJournal;
     now: () => Date;
     /** Estado write debounce in ms; default DEFAULT_ESTADO_DEBOUNCE_MS. */
@@ -281,6 +287,29 @@ export interface PartyStoreState {
          * denied, mirror kept) and null is returned — retry after retryWrites.
          */
         endSession: () => Promise<SessionSummary | null>;
+        /**
+         * DISCARD (test session): deletes the session journal and ROLLS BACK
+         * estado to the session-start snapshot, then deactivates — the opposite
+         * of endSession's SAVE. Because the journal is written incrementally and
+         * estado is debounce-written DURING play, both are already on disk by the
+         * time the GM ends, so discard must actively undo them.
+         *
+         *   - Guard: only while session.active (else {ok:false}).
+         *   - Deletes session.journalPath (enforces the mundo/diario/ surface;
+         *     a path outside it, or a delete that throws, returns {ok:false}
+         *     WITHOUT touching anything so the GM can retry — the session stays
+         *     active and estado is left as-is).
+         *   - Cancels the pending debounced estado write FIRST (so a queued
+         *     mid-session write cannot land after the rollback), then forces an
+         *     estado write equal to the snapshot with sesion_activa:false and the
+         *     unchanged roster/body preserved.
+         *   - Clears the crash mirror, reverts the LIVE party fields to the
+         *     snapshot (so the UI reverts immediately) and deactivates.
+         *
+         * The page then re-scans so in-memory knowledge/pista bumps vanish and
+         * the diario reloads without the deleted file.
+         */
+        discardSession: () => Promise<{ ok: boolean }>;
         /**
          * Rebuilds an active session from a crash mirror: live fields =
          * mirror.entries replayed over mirror.snapshot (see SessionMirror
@@ -659,6 +688,84 @@ export const usePartyStore = create<PartyStoreState>()((set, get) => {
                 clearSessionMirror(mirrorStorage());
                 journalDay = null;
                 return summary;
+            },
+
+            async discardSession(): Promise<{ ok: boolean }> {
+                const s = get();
+                if (!s.session.active || deps === null || s.session.snapshot === null) {
+                    console.warn('[world] discardSession ignorado: no hay sesión activa');
+                    return { ok: false };
+                }
+                const d = deps;
+                const snapshot = cloneSnapshot(s.session.snapshot);
+                const journalPath = s.session.journalPath;
+                // Surface guard: only ever delete inside mundo/diario/. A path
+                // outside it is corrupt state — refuse without touching anything.
+                const diarioPrefix = `${WORLD_DIR}/${ENTITY_DIRS.diario}/`;
+                if (journalPath === null || !journalPath.startsWith(diarioPrefix)) {
+                    console.warn('[world] discardSession ignorado: journalPath fuera de mundo/diario/');
+                    return { ok: false };
+                }
+                // Delete the journal. On any failure stay ACTIVE and untouched so
+                // the GM can retry (estado is not rolled back either).
+                try {
+                    await d.deleteFile(journalPath);
+                } catch (error) {
+                    console.warn('[world] no se pudo borrar el diario de la sesión de prueba', error);
+                    return { ok: false };
+                }
+                // Cancel the pending debounced estado write FIRST so a queued
+                // mid-session write cannot land after the rollback below.
+                if (debounceTimer !== null) {
+                    clearTimeout(debounceTimer);
+                    debounceTimer = null;
+                }
+                // Roll estado back to the session-start snapshot (sesion_activa
+                // false), preserving the roster + agent body the log never edits.
+                const restored: PartyState = {
+                    sesionActiva: false,
+                    diaMundo: snapshot.diaMundo,
+                    ubicacion: snapshot.ubicacion,
+                    rumbo: snapshot.rumbo === null ? null : { ...snapshot.rumbo },
+                    creditos: snapshot.creditos,
+                    medidores: { ...snapshot.medidores },
+                    personajes: [...s.personajes],
+                    bodyMd: s.bodyMd,
+                    filePath: s.estadoFilePath,
+                };
+                estadoStatus = 'pending';
+                pushStatus();
+                estadoChain = estadoChain.then(() =>
+                    d.writeEstado(serializePartyState(restored, d.now().toISOString()))
+                );
+                try {
+                    await estadoChain;
+                    estadoStatus = 'ok';
+                } catch (error) {
+                    // Journal is already gone; a denied estado write leaves the
+                    // pre-session state on disk (nothing was ever overwritten by
+                    // the discard). Surface denied but still deactivate — the
+                    // test session is over regardless.
+                    console.warn('[world] fallo al restaurar estado tras descartar', error);
+                    estadoStatus = 'denied';
+                }
+                estadoChain = estadoChain.catch(() => {});
+                clearSessionMirror(mirrorStorage());
+                journalDay = null;
+                journalStatus = 'ok';
+                // Revert the LIVE party fields + deactivate so the UI reverts now.
+                set({
+                    ...snapshotToFields(snapshot),
+                    session: {
+                        active: false,
+                        journalPath: null,
+                        startedAt: null,
+                        entries: [],
+                        snapshot: null,
+                        writeStatus: estadoStatus,
+                    },
+                });
+                return { ok: true };
             },
 
             recoverSession(mirror: SessionMirror, model: WorldModel) {

--- a/lib/world/supportDocCategory.test.ts
+++ b/lib/world/supportDocCategory.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  categorizeSupportDoc,
+  SUPPORT_DOC_CATEGORY_LABEL,
+  SUPPORT_DOC_CATEGORY_ORDER,
+} from './supportDocCategory';
+
+describe('categorizeSupportDoc', () => {
+  it('reads characters/ as personajes', () => {
+    expect(categorizeSupportDoc('mundo/lugares/porto_verne/characters/kael_voss.md')).toBe(
+      'personajes'
+    );
+  });
+
+  it('reads threats/ as amenazas', () => {
+    expect(categorizeSupportDoc('mundo/lugares/porto_verne/threats/dron_aduanas.md')).toBe(
+      'amenazas'
+    );
+  });
+
+  it('reads maps/ markdown as mapas', () => {
+    expect(categorizeSupportDoc('mundo/lugares/porto_verne/maps/plano_ascii.md')).toBe('mapas');
+  });
+
+  it('falls back to otros for anything else', () => {
+    expect(categorizeSupportDoc('mundo/lugares/porto_verne/plan/acto2.md')).toBe('otros');
+    expect(categorizeSupportDoc('notas.md')).toBe('otros');
+  });
+
+  it('matches the folder as a whole segment, case-insensitively', () => {
+    expect(categorizeSupportDoc('X/Characters/a.md')).toBe('personajes');
+    // A substring that is not its own segment must NOT match.
+    expect(categorizeSupportDoc('mundo/lugares/mapas_del_sur/notas.md')).toBe('otros');
+  });
+
+  it('exposes a label for every ordered category', () => {
+    for (const cat of SUPPORT_DOC_CATEGORY_ORDER) {
+      expect(SUPPORT_DOC_CATEGORY_LABEL[cat]).toBeTruthy();
+    }
+  });
+});

--- a/lib/world/supportDocCategory.ts
+++ b/lib/world/supportDocCategory.ts
@@ -1,0 +1,39 @@
+/**
+ * Categorises an ActRunner support doc by the subfolder its FileReference.path
+ * comes from, so the runner can group the "Fichas" dropdown into readable
+ * sections. World support docs arrive prefixed
+ * `mundo/lugares/<id>/<subfolder>/<file>.md` (see lib/world/worldScanner +
+ * lib/sessionScanner collectPathSupportContent), so the segment we key off is
+ * `characters/`, `threats/`, or `maps/` anywhere in the path. Everything else
+ * (e.g. flat `plan/` acts split into parts) falls back to "Otros".
+ */
+export type SupportDocCategory = 'personajes' | 'amenazas' | 'mapas' | 'otros';
+
+/** The fixed display order of the grouped sections in the dropdown. */
+export const SUPPORT_DOC_CATEGORY_ORDER: readonly SupportDocCategory[] = [
+  'personajes',
+  'amenazas',
+  'mapas',
+  'otros',
+] as const;
+
+export const SUPPORT_DOC_CATEGORY_LABEL: Record<SupportDocCategory, string> = {
+  personajes: 'Personajes',
+  amenazas: 'Amenazas',
+  mapas: 'Mapas (ASCII)',
+  otros: 'Otros',
+};
+
+/**
+ * Infers the section for a support doc from its path. Matches the folder
+ * segment case-insensitively and only as a whole path segment (`/characters/`
+ * or a leading `characters/`) so a place literally named `.../characters.../`
+ * file can't be misread.
+ */
+export function categorizeSupportDoc(path: string): SupportDocCategory {
+  const segments = path.toLowerCase().split('/');
+  if (segments.includes('characters')) return 'personajes';
+  if (segments.includes('threats')) return 'amenazas';
+  if (segments.includes('maps')) return 'mapas';
+  return 'otros';
+}

--- a/lib/world/threads.test.ts
+++ b/lib/world/threads.test.ts
@@ -1,0 +1,185 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import {
+    Lead,
+    PlaceEntity,
+    SystemEntity,
+    Trama,
+    WorldEntityBase,
+    WorldManifest,
+    WorldModel,
+} from '@/types/world';
+import { WORLD_SCALE } from './constants';
+import { tramaThreadNodes } from './threads';
+
+// ── Hand-built minimal model ────────────────────────────────────────────────
+// sistema_a {x:0,y:0}
+//   └── porto (en: sistema_a)
+// sistema_b {x:6,y:3}
+//   └── brasa (en: sistema_b)
+// node_deep {x:14,y:-14} (deep space, own coords)
+// sistema_nc {x:2,y:2}  (NO coordenadas — coord-less root, skipped)
+
+function base(id: string, tipo: string): WorldEntityBase {
+    return {
+        id,
+        tipo,
+        nombre: id,
+        filePath: `mundo/${tipo}/${id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+    };
+}
+
+function sistema(id: string, coords: { x: number; y: number } | undefined): SystemEntity {
+    // coords deliberately optional to exercise the coord-less skip path.
+    return {
+        ...base(id, 'sistema'),
+        tipo: 'sistema',
+        coordenadas: coords as { x: number; y: number },
+    };
+}
+
+function lugar(id: string, opts: { en?: string; coordenadas?: { x: number; y: number } } = {}): PlaceEntity {
+    return {
+        ...base(id, 'estacion'),
+        en: opts.en,
+        coordenadas: opts.coordenadas,
+        servicios: [],
+        facciones: [],
+        acceso: 'normal',
+    };
+}
+
+function pista(id: string, opts: { trama?: string; donde?: string } = {}): Lead {
+    return {
+        ...base(id, 'pista'),
+        estadoPista: 'activa',
+        trama: opts.trama,
+        donde: opts.donde,
+        requisitos: [],
+        accionable: false,
+    };
+}
+
+const MANIFEST: WorldManifest = {
+    nombre: 'Sector Test',
+    calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustibleCadaDias: 4, viveresCadaDias: 4 },
+    medidores: [],
+    regiones: [],
+};
+
+function makeModel(tramas: Trama[]): WorldModel {
+    const sistemas = [
+        sistema('sistema_a', { x: 0, y: 0 }),
+        sistema('sistema_b', { x: 6, y: 3 }),
+        sistema('sistema_nc', undefined), // coord-less root
+    ];
+    const lugares = [
+        lugar('porto', { en: 'sistema_a' }),
+        lugar('brasa', { en: 'sistema_b' }),
+        lugar('sin_sistema', { en: 'sistema_nc' }),
+        lugar('node_deep', { coordenadas: { x: 14, y: -14 } }),
+    ];
+    const pistas = tramas.flatMap((t) => t.pistas);
+    const entidades = new Map<string, WorldEntityBase>(
+        [...sistemas, ...lugares].map((e) => [e.id, e])
+    );
+    const childrenOf = new Map<string, string[]>();
+    for (const l of lugares) {
+        if (l.en === undefined) continue;
+        const arr = childrenOf.get(l.en) ?? [];
+        arr.push(l.id);
+        childrenOf.set(l.en, arr);
+    }
+    return {
+        manifest: MANIFEST,
+        entidades,
+        sistemas,
+        lugares,
+        facciones: [],
+        pnjs: [],
+        pistas,
+        tramas,
+        tablas: [],
+        problemas: [],
+        childrenOf,
+        estadoGrupo: null,
+        diario: [],
+        musica: { bgm: [], eventPlaylists: [] },
+        tiendas: new Map(),
+        resumen: null,
+    };
+}
+
+function trama(id: string, opts: { lugaresClave?: string[]; pistas?: Lead[] } = {}): Trama {
+    return {
+        ...base(id, 'trama'),
+        rol: 'principal',
+        estadoTrama: 'activa',
+        lugaresClave: opts.lugaresClave ?? [],
+        facciones: [],
+        pistas: opts.pistas ?? [],
+    };
+}
+
+describe('tramaThreadNodes', () => {
+    test('resolves lugaresClave + pistas.donde to deduped sector nodes (coords × WORLD_SCALE)', () => {
+        const t = trama('web', {
+            // porto -> sistema_a {0,0}; node_deep {14,-14} (deep-space root)
+            lugaresClave: ['porto', 'node_deep'],
+            // brasa -> sistema_b {6,3}
+            pistas: [pista('p1', { trama: 'web', donde: 'brasa' })],
+        });
+        const model = makeModel([t]);
+        const { nodes, places } = tramaThreadNodes(model, 'web');
+
+        expect(places).toEqual(['porto', 'node_deep', 'brasa']);
+        // Three distinct sector roots, in the collection order.
+        expect(nodes.map((n) => n.id)).toEqual(['sistema_a', 'node_deep', 'sistema_b']);
+        expect(nodes).toContainEqual({ id: 'sistema_a', x: 0, y: 0 });
+        expect(nodes).toContainEqual({ id: 'node_deep', x: 14 * WORLD_SCALE, y: -14 * WORLD_SCALE });
+        expect(nodes).toContainEqual({ id: 'sistema_b', x: 6 * WORLD_SCALE, y: 3 * WORLD_SCALE });
+    });
+
+    test('dedupes roots when several places share one sector', () => {
+        const t = trama('web', {
+            // porto AND its pista both roll up to sistema_a -> one node.
+            lugaresClave: ['porto'],
+            pistas: [pista('p1', { trama: 'web', donde: 'porto' })],
+        });
+        const model = makeModel([t]);
+        const { nodes } = tramaThreadNodes(model, 'web');
+        expect(nodes.map((n) => n.id)).toEqual(['sistema_a']);
+    });
+
+    test('drops pistas with donde absent and coord-less roots', () => {
+        const t = trama('web', {
+            // sin_sistema -> sistema_nc (no coordenadas) -> skipped.
+            lugaresClave: ['sin_sistema', 'porto'],
+            pistas: [
+                pista('p1', { trama: 'web' }), // donde absent -> dropped
+                pista('p2', { trama: 'web', donde: 'brasa' }),
+            ],
+        });
+        const model = makeModel([t]);
+        const { nodes, places } = tramaThreadNodes(model, 'web');
+        // donde-absent pista never contributes a place.
+        expect(places).toEqual(['sin_sistema', 'porto', 'brasa']);
+        // sistema_nc has no coords -> only porto + brasa's sistemas render.
+        expect(nodes.map((n) => n.id).sort()).toEqual(['sistema_a', 'sistema_b']);
+    });
+
+    test('unknown trama returns empty nodes and places, never throws', () => {
+        const model = makeModel([trama('web')]);
+        expect(tramaThreadNodes(model, 'no_existe')).toEqual({ nodes: [], places: [] });
+    });
+
+    test('empty trama (no places) returns empty nodes', () => {
+        const model = makeModel([trama('web')]);
+        expect(tramaThreadNodes(model, 'web')).toEqual({ nodes: [], places: [] });
+    });
+});

--- a/lib/world/threads.test.ts
+++ b/lib/world/threads.test.ts
@@ -112,6 +112,7 @@ function makeModel(tramas: Trama[]): WorldModel {
         musica: { bgm: [], eventPlaylists: [] },
         tiendas: new Map(),
         resumen: null,
+        guias: [],
     };
 }
 

--- a/lib/world/threads.ts
+++ b/lib/world/threads.ts
@@ -1,0 +1,70 @@
+/**
+ * Story-threads ("Hilos") map geometry (feature — Hilos de historia).
+ *
+ * A trama (story arc) touches a set of lugares (its `lugaresClave` plus the
+ * `donde` of its child pistas). tramaThreadNodes resolves each of those places
+ * to its SECTOR-tier root node (via sectorNodeFor, walking the `en:` chain),
+ * dedupes the roots, and returns their map-pixel positions so ThreadLayer can
+ * paint the narrative web on the sector map.
+ *
+ * Pure over a WorldModel — no store/DOM access, bun-testable. Never throws: a
+ * stale/unknown/empty trama simply yields an empty node list.
+ */
+
+import type { PlaceEntity, Trama, WorldModel } from '@/types/world';
+import { WORLD_SCALE } from './constants';
+import { sectorNodeFor } from './worldNav';
+
+/** Rol accent colors shared by the Hilos tab and the map ThreadLayer. */
+export const TRAMA_ROL_COLOR: Record<Trama['rol'], string> = {
+    principal: '#f59e0b', // amber-500
+    secundaria: '#0ea5e9', // sky-500
+    ambiental: '#8b5cf6', // violet-500
+};
+
+/** One thread endpoint: a sector-tier root node id + its map-pixel position. */
+export interface ThreadNode {
+    id: string;
+    x: number;
+    y: number;
+}
+
+export interface TramaThreadNodes {
+    /** Deduped sector-root nodes with coordinates, in map pixels. */
+    nodes: ThreadNode[];
+    /** The trama's raw place ids (lugaresClave ++ pistas.donde), pre-resolution. */
+    places: string[];
+}
+
+/**
+ * Sector-map nodes a trama's narrative web connects.
+ *
+ * Collects the trama's place ids (lugaresClave ++ each child pista's `donde`,
+ * dropping absent ones), maps each to its sector-tier root via sectorNodeFor,
+ * dedupes the roots, and emits {id, x, y} in map pixels (coord × WORLD_SCALE)
+ * for every root that carries `coordenadas`. Roots without coords (or dangling
+ * chains) are skipped. Returns empty `nodes` for an unknown/empty trama.
+ */
+export function tramaThreadNodes(model: WorldModel, tramaId: string): TramaThreadNodes {
+    const trama = model.tramas.find((t) => t.id === tramaId);
+    if (!trama) return { nodes: [], places: [] };
+
+    const places: string[] = [
+        ...trama.lugaresClave,
+        ...trama.pistas.map((p) => p.donde).filter((d): d is string => Boolean(d)),
+    ];
+
+    const nodes: ThreadNode[] = [];
+    const seenRoots = new Set<string>();
+    for (const placeId of places) {
+        const rootId = sectorNodeFor(model, placeId);
+        if (rootId === null || seenRoots.has(rootId)) continue;
+        seenRoots.add(rootId);
+        const root = model.entidades.get(rootId) as Partial<PlaceEntity> | undefined;
+        const coords = root?.coordenadas;
+        if (!coords) continue; // system-less / coord-less root — nothing to place
+        nodes.push({ id: rootId, x: coords.x * WORLD_SCALE, y: coords.y * WORLD_SCALE });
+    }
+
+    return { nodes, places };
+}

--- a/lib/world/threatStatblock.test.ts
+++ b/lib/world/threatStatblock.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'bun:test';
+import { hasStatblock, parseThreatStatblock } from './threatStatblock';
+
+// The snippets below mirror the REAL threat fichas verbatim (heading + fenced
+// stat block), e.g.
+//   mundo/lugares/jardin_que_exhala/threats/depredador_jardin.md
+//   mundo/lugares/jardin_que_exhala/threats/brote_esporas.md
+//   mundo/lugares/coro_de_vidrio/threats/guardian_de_cristal.md
+// Labels are Spanish "CA"/"PV" (not AC/HP), inside a ``` fence, with the level
+// on the name line ("CRIATURA 3" / "PELIGRO / ENJAMBRE 2").
+
+const DEPREDADOR = `# DEPREDADOR DEL JARDÍN
+## Amenaza — Fauna alfa territorial (Nodo B, set-piece Acto 3)
+
+Mole de tejido vegetal y músculo que PLANEA con membranas-raíz.
+
+---
+
+\`\`\`
+DEPREDADOR DEL JARDÍN                            CRIATURA 3
+GRANDE BESTIA (PLANTA)
+Perception +11 (olfato/vibración; ciego a color, ve calor)
+Str +5, Dex +2, Con +4, Int -3, Wis +3, Cha +0
+
+AC 19; Fort +12, Ref +6, Will +8
+(REFLEJOS REBAJADOS a propósito)
+HP 58
+Debilidad: fuego 5 (clave para Chesco)
+
+Speed 25 pies, planeo 35 pies
+
+ATAQUES
+Cuerpo a cuerpo [1 acción] mordisco-capullo +12 (alcance 10 pies), Daño 2d8+4 perforante
+Cuerpo a cuerpo [1 acción] zarpa-raíz +12 (agile, alcance 10 pies), Daño 1d10+5 contundente
+\`\`\`
+`;
+
+const BROTE = `# BROTE DE ESPORAS HOSTILES
+## Amenaza — Peligro ambiental + enjambre (Nodo B, Actos 2-3)
+
+Nube viva de esporas que el bioma "suelta" como defensa.
+
+---
+
+\`\`\`
+BROTE DE ESPORAS HOSTILES                        PELIGRO / ENJAMBRE 2
+GRANDE PLANTA (ENJAMBRE)
+Perception +8 (sin vista; siente movimiento/calor)
+Str -2, Dex +3, Con +3, Int -5, Wis +2, Cha -4
+
+AC 16; Fort +9, Ref +6, Will +6
+HP 30
+Debilidad: fuego 6 (clave — Chesco lo borra), daño de área 5
+\`\`\`
+`;
+
+const GUARDIAN = `# GUARDIÁN DE CRISTAL
+## Enemigo del Nodo A — Constructo resonante (set-piece Acto 3)
+
+Una figura humanoide tallada en cristal resonante.
+
+---
+
+\`\`\`
+GUARDIÁN DE CRISTAL                              CRIATURA 3
+MEDIANO CONSTRUCTO PREDECESSOR
+Perception +10 (vista por vibración)
+
+Str +4, Dex +1, Con +4, Int -3, Wis +2, Cha +0
+
+AC 21 (alta — degradar con área/fuego/pulsos);
+Fort +11, Ref +6 (REBAJADO), Will +8
+HP 50
+Debilidades: fuego 5, sónico 5
+\`\`\`
+`;
+
+// A ficha that uses the canonical CA/PV labels and tolerated punctuation
+// ("CA: 19", "PV 58 (") — the exact tolerance the prompt calls out.
+const CANONICAL_CA_PV = `**Sabueso de Vidrio**
+
+CA: 21; Fort +11, Ref +6
+PV 44 (constructo, sin sangrado)
+`;
+
+// A RESKIN ficha (the real Custodio de Ecos): a prose line ABOVE the fence
+// describes the BASE creature's "AC 18 / HP 45" stats, then the actual fenced
+// stat block carries the reskin's real "AC 19 / HP 48". The parser must prefer
+// the fenced stats, not the earliest document-wide occurrence.
+const RESKIN_BASE_IN_PROSE = `# CUSTODIO DE ECOS
+## Enemigo del Nodo A — Constructo controlador (set-piece Acto 2b)
+
+BASE ALIEN CORE: Hardlight Mascot (Criatura 3, Alien Core p.88; AC 18 / HP 45 / Fort +7 / Ref +10 / Will +11; pixel blast +12, kick 2d6+2 force, Taunt 4d6 mental DC 19). Reskin a constructo de luz-sonido.
+
+---
+
+\`\`\`
+CUSTODIO DE ECOS                                 CRIATURA 3
+MEDIANO CONSTRUCTO PREDECESSOR
+Perception +12
+
+Str +2, Dex +1, Con +4, Int -2, Wis +4, Cha +1
+
+AC 19 (alta — degradar con área/fuego/empujes);
+Fort +11, Ref +6 (REBAJADO), Will +8
+HP 48
+Debilidades: fuego 5, daño de área 5
+\`\`\`
+`;
+
+// A threat doc with NO statblock: prose only. hasStatblock -> false.
+const NO_STATBLOCK = `# Dron de aduanas
+
+Escanea el casco al acoplar. Nivel 1. Un peligro narrativo, sin ficha de combate.
+`;
+
+describe('parseThreatStatblock', () => {
+  it('parses the real Depredador ficha (CA 19 / PV 58 / CRIATURA 3)', () => {
+    const s = parseThreatStatblock(DEPREDADOR);
+    expect(s.ca).toBe(19);
+    expect(s.pv).toBe(58);
+    expect(s.nivel).toBe(3);
+    // Name comes from the first heading, softened from ALL CAPS.
+    expect(s.nombre).toBe('Depredador Del Jardín');
+    // A couple of attack lines are captured verbatim.
+    expect(s.ataques?.[0]).toContain('mordisco-capullo +12');
+    expect(s.ataques?.[0]).toContain('2d8+4');
+  });
+
+  it('parses the real Brote ficha (CA 16 / PV 30 / PELIGRO 2)', () => {
+    const s = parseThreatStatblock(BROTE);
+    expect(s.ca).toBe(16);
+    expect(s.pv).toBe(30);
+    expect(s.nivel).toBe(2);
+    expect(s.nombre).toBe('Brote De Esporas Hostiles');
+  });
+
+  it('parses the real Guardián ficha (CA 21 / PV 50 / CRIATURA 3)', () => {
+    const s = parseThreatStatblock(GUARDIAN);
+    expect(s.ca).toBe(21);
+    expect(s.pv).toBe(50);
+    expect(s.nivel).toBe(3);
+    expect(s.nombre).toBe('Guardián De Cristal');
+  });
+
+  it('tolerates canonical CA:/PV punctuation and a bold **Nombre**', () => {
+    const s = parseThreatStatblock(CANONICAL_CA_PV);
+    expect(s.ca).toBe(21);
+    expect(s.pv).toBe(44); // "PV 44 (" — trailing paren tolerated
+    expect(s.nombre).toBe('Sabueso de Vidrio'); // mixed case left as-is
+  });
+
+  it('takes the max from a "PV cur/max" form', () => {
+    const s = parseThreatStatblock('# X\nCA 15\nPV 12/40\n');
+    expect(s.pv).toBe(40);
+  });
+
+  it('returns {} for empty / non-string input and never throws', () => {
+    expect(parseThreatStatblock('')).toEqual({});
+    // @ts-expect-error deliberately exercising the runtime guard
+    expect(parseThreatStatblock(undefined)).toEqual({});
+    // @ts-expect-error deliberately exercising the runtime guard
+    expect(parseThreatStatblock(null)).toEqual({});
+  });
+
+  it('prefers the FENCED stats over a base-creature prose line (reskin ficha)', () => {
+    // The Custodio de Ecos: prose says "AC 18 / HP 45" (base creature) ABOVE
+    // the fence; the real fenced stats are AC 19 / HP 48.
+    const s = parseThreatStatblock(RESKIN_BASE_IN_PROSE);
+    expect(s.ca).toBe(19);
+    expect(s.pv).toBe(48);
+    expect(s.nivel).toBe(3);
+    expect(s.nombre).toBe('Custodio De Ecos');
+  });
+
+  it('leaves ca/pv undefined on a prose-only doc', () => {
+    const s = parseThreatStatblock(NO_STATBLOCK);
+    expect(s.ca).toBeUndefined();
+    expect(s.pv).toBeUndefined();
+  });
+});
+
+describe('hasStatblock', () => {
+  it('is true for the real Depredador/Brote/Guardián fichas', () => {
+    expect(hasStatblock(DEPREDADOR)).toBe(true);
+    expect(hasStatblock(BROTE)).toBe(true);
+    expect(hasStatblock(GUARDIAN)).toBe(true);
+    expect(hasStatblock(CANONICAL_CA_PV)).toBe(true);
+  });
+
+  it('is false for a prose-only threat doc (no CA/PV)', () => {
+    expect(hasStatblock(NO_STATBLOCK)).toBe(false);
+  });
+
+  it('is false when only one of CA/PV is present', () => {
+    expect(hasStatblock('# X\nCA 19\n')).toBe(false);
+    expect(hasStatblock('# X\nPV 58\n')).toBe(false);
+  });
+});

--- a/lib/world/threatStatblock.ts
+++ b/lib/world/threatStatblock.ts
@@ -1,0 +1,189 @@
+/**
+ * Parses a threat "ficha" (a threats/*.md support doc) into the handful of
+ * fields the InitiativeTracker needs to prefill a combatant: the creature's
+ * name, its armour class (SF2e "CA"), its hit points ("PV") and, when trivially
+ * present, its level ("CRIATURA 3" / "PELIGRO 2"). It mirrors the style of
+ * extractPCStats in lib/sessionScanner.ts (a small ordered list of tolerant,
+ * case-insensitive regexes over the RAW markdown) so the world runner can offer
+ * a one-tap "Añadir al combate" instead of the GM hand-typing name + HP + AC.
+ *
+ * The real files (mundo/lugares/<id>/threats/<x>.md) put the stat line inside a
+ * markdown code fence, Spanish-labelled: e.g. "AC 19; Fort +12..." — wait, the
+ * canonical label used by these fichas is "CA" (Clase de Armadura) and "PV"
+ * (Puntos de Vida). Some Alien-Core-derived fichas leak the English "AC"/"HP"
+ * labels; we accept BOTH so a mixed doc still parses. Everything is optional and
+ * the parser never throws — a doc with no statblock simply yields {} and
+ * hasStatblock() returns false, which is how the runner decides not to show the
+ * button.
+ */
+
+export interface ThreatStatblock {
+  nombre?: string;
+  ca?: number;
+  pv?: number;
+  nivel?: number;
+  /** A couple of key melee/ranged attack lines, verbatim, when easily found. */
+  ataques?: string[];
+}
+
+/**
+ * Armour class. Canonical Spanish label is "CA"; we also accept the English
+ * "AC" that some reskinned Alien Core fichas keep. Tolerates "CA 19",
+ * "CA: 19", "CA 19;" and "CA 19 (".
+ */
+const CA_PATTERNS: readonly RegExp[] = [
+  /\bCA\s*[:=]?\s*(\d+)/i,
+  /\bAC\s*[:=]?\s*(\d+)/i,
+  /\bClase\s+de\s+Armadura\s*[:=]?\s*(\d+)/i,
+];
+
+/**
+ * Hit points. Canonical "PV"; English "HP" accepted as a fallback. Tolerates
+ * "PV 58", "PV: 58", "PV 58 (" and a "PV 58/58" current/max form (max wins).
+ */
+const PV_PATTERNS: readonly RegExp[] = [
+  /\bPV\s*[:=]?\s*\d+\s*\/\s*(\d+)/i,
+  /\bPV\s*[:=]?\s*(\d+)/i,
+  /\bHP\s*[:=]?\s*\d+\s*\/\s*(\d+)/i,
+  /\bHP\s*[:=]?\s*(\d+)/i,
+  /\bPuntos\s+de\s+Vida\s*[:=]?\s*(\d+)/i,
+];
+
+/**
+ * Level. The fichas write it on the name line of the stat block, e.g.
+ * "DEPREDADOR DEL JARDÍN                CRIATURA 3" or "... PELIGRO / ENJAMBRE 2".
+ * We also accept the Spanish "Nivel 3" prose form.
+ */
+const NIVEL_PATTERNS: readonly RegExp[] = [
+  /\bCRIATURA\s+(\d+)/i,
+  /\bPELIGRO(?:\s*\/\s*ENJAMBRE)?\s+(\d+)/i,
+  /\bNivel\s+(\d+)/i,
+];
+
+/**
+ * Attack lines like "mordisco +12 ... 2d8+4" or "golpe de cristal +12, Daño
+ * 2d8+4". We key off a "+N" to-hit followed later on the line by an "NdM" dice
+ * expression, and keep the trimmed line. Best-effort only; used for a hover
+ * hint, never load-bearing.
+ */
+const ATTACK_LINE = /^.*?\+\d+.*?\b\d+d\d+(?:\s*\+\s*\d+)?.*$/;
+
+function firstMatch(md: string, patterns: readonly RegExp[]): number | undefined {
+  for (const pattern of patterns) {
+    const match = md.match(pattern);
+    if (match && match[1]) {
+      const value = parseInt(match[1], 10);
+      if (!Number.isNaN(value) && value > 0) return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns the concatenated contents of every ``` code fence in the doc, or
+ * undefined when there is no fence. The canonical stat block lives inside the
+ * fence, so we scope CA/PV/nivel matching to it first — otherwise a reskin
+ * ficha that mentions its BASE creature's "AC 18 / HP 45" in prose ABOVE the
+ * fence poisons the result (the Custodio de Ecos parses as CA 18 / PV 45
+ * instead of its real CA 19 / PV 48). Fichas without a fence (e.g. the
+ * canonical CA:/PV: one-liner) fall back to whole-document matching.
+ */
+function fencedBody(md: string): string | undefined {
+  const parts: string[] = [];
+  const fence = /```[^\n]*\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+  while ((match = fence.exec(md)) !== null) {
+    if (match[1]) parts.push(match[1]);
+  }
+  return parts.length > 0 ? parts.join('\n') : undefined;
+}
+
+/**
+ * Scoped numeric match: prefer a hit inside the code fence (the canonical stat
+ * block), and only fall back to the whole document when the fence yields
+ * nothing. This keeps a pre-fence prose line describing a reskin's base
+ * creature from overriding the real fenced stats.
+ */
+function scopedMatch(
+  md: string,
+  fenced: string | undefined,
+  patterns: readonly RegExp[],
+): number | undefined {
+  if (fenced !== undefined) {
+    const inFence = firstMatch(fenced, patterns);
+    if (inFence !== undefined) return inFence;
+  }
+  return firstMatch(md, patterns);
+}
+
+/**
+ * Pulls the creature name from the first markdown heading (`# NOMBRE`) or the
+ * first bold line (`**Nombre**`). Falls back to undefined. Title-cases an
+ * ALL-CAPS heading so "DEPREDADOR DEL JARDÍN" reads as "Depredador Del Jardín"
+ * in the tracker rather than shouting.
+ */
+function extractNombre(md: string): string | undefined {
+  const lines = md.split(/\r?\n/);
+  for (const line of lines) {
+    const heading = line.match(/^#{1,6}\s+(.+?)\s*$/);
+    if (heading && heading[1].trim()) return normaliseName(heading[1].trim());
+    const bold = line.match(/^\s*\*\*(.+?)\*\*\s*$/);
+    if (bold && bold[1].trim()) return normaliseName(bold[1].trim());
+  }
+  return undefined;
+}
+
+/** Softens an all-caps name to Title Case; leaves mixed-case names untouched. */
+function normaliseName(name: string): string {
+  const letters = name.replace(/[^A-Za-zÀ-ÿ]/g, '');
+  const isAllCaps = letters.length > 0 && letters === letters.toUpperCase();
+  if (!isAllCaps) return name;
+  return name
+    .toLocaleLowerCase('es')
+    .replace(/(^|\s|-)([\p{L}])/gu, (_m, sep: string, ch: string) => sep + ch.toLocaleUpperCase('es'));
+}
+
+function extractAtaques(md: string): string[] {
+  const out: string[] = [];
+  for (const raw of md.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (ATTACK_LINE.test(line)) out.push(line);
+    if (out.length >= 3) break;
+  }
+  return out;
+}
+
+/**
+ * Parses a threat ficha's raw markdown into a tolerant ThreatStatblock. Never
+ * throws; every field is optional. `nivel` and `ataques` are only set when
+ * trivially present.
+ */
+export function parseThreatStatblock(markdown: string): ThreatStatblock {
+  if (typeof markdown !== 'string' || markdown.length === 0) return {};
+
+  const fenced = fencedBody(markdown);
+  const ca = scopedMatch(markdown, fenced, CA_PATTERNS);
+  const pv = scopedMatch(markdown, fenced, PV_PATTERNS);
+  const nivel = scopedMatch(markdown, fenced, NIVEL_PATTERNS);
+  const nombre = extractNombre(markdown);
+  const ataques = extractAtaques(markdown);
+
+  const result: ThreatStatblock = {};
+  if (nombre !== undefined) result.nombre = nombre;
+  if (ca !== undefined) result.ca = ca;
+  if (pv !== undefined) result.pv = pv;
+  if (nivel !== undefined) result.nivel = nivel;
+  if (ataques.length > 0) result.ataques = ataques;
+  return result;
+}
+
+/**
+ * Whether a threat doc carries a usable combat statblock. Both CA and PV must
+ * parse — those are the two fields the tracker prefills (defense + maxHP). The
+ * runner shows the "Añadir al combate" button only when this is true.
+ */
+export function hasStatblock(markdown: string): boolean {
+  const parsed = parseThreatStatblock(markdown);
+  return parsed.ca != null && parsed.pv != null;
+}

--- a/lib/world/travel.test.ts
+++ b/lib/world/travel.test.ts
@@ -1,0 +1,405 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import {
+    PlaceEntity,
+    SystemEntity,
+    TravelPlan,
+    WorldEntityBase,
+    WorldManifest,
+    WorldModel,
+} from '@/types/world';
+import {
+    computeTravelPlan,
+    sectorLegEndDay,
+    travelDaySchedule,
+    TravelSnapshot,
+    WARN_COMBUSTIBLE,
+    WARN_VIVERES,
+} from './travel';
+
+// ── Hand-built minimal model ────────────────────────────────────────────────
+// sistema_a (0,0)
+//   └── planet_a1
+//         └── site_a2                       (deep chain)
+// sistema_b (2,3)  — distance √13 ≈ 3.606 -> ceil 4
+//   ├── planet_b1
+//   ├── portal_gate  (acceso: portal)
+//   │     └── portal_inner                  (inherits portal via the chain)
+//   └── ...
+// node_e (5,5)  — deep-space root, distance √50 ≈ 7.071 -> ceil 8
+//   └── pocket_f
+// huerfano (en: fantasma)                   (dangling root)
+// perdido  (no en:, no coords)              (rootless lugar)
+
+function base(id: string, tipo: string): WorldEntityBase {
+    return {
+        id,
+        tipo,
+        nombre: id,
+        filePath: `mundo/${tipo}/${id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+    };
+}
+
+function sistema(id: string, coordenadas: { x: number; y: number }): SystemEntity {
+    return { ...base(id, 'sistema'), tipo: 'sistema', coordenadas };
+}
+
+function lugar(
+    id: string,
+    opts: {
+        en?: string;
+        coordenadas?: { x: number; y: number };
+        acceso?: PlaceEntity['acceso'];
+    } = {}
+): PlaceEntity {
+    return {
+        ...base(id, 'estacion'),
+        en: opts.en,
+        coordenadas: opts.coordenadas,
+        servicios: [],
+        facciones: [],
+        acceso: opts.acceso ?? 'normal',
+    };
+}
+
+const VIAJE_DEFAULTS: WorldManifest['viaje'] = {
+    diasPorUnidad: 1,
+    intrasistemaDias: 1,
+    combustiblePorTramo: 1,
+    viveresCadaDias: 4,
+};
+
+function makeModel(viaje: Partial<WorldManifest['viaje']> = {}): WorldModel {
+    const sistemas = [sistema('sistema_a', { x: 0, y: 0 }), sistema('sistema_b', { x: 2, y: 3 })];
+    const lugares = [
+        lugar('planet_a1', { en: 'sistema_a' }),
+        lugar('site_a2', { en: 'planet_a1' }),
+        lugar('planet_b1', { en: 'sistema_b' }),
+        lugar('portal_gate', { en: 'sistema_b', acceso: 'portal' }),
+        lugar('portal_inner', { en: 'portal_gate' }),
+        lugar('node_e', { coordenadas: { x: 5, y: 5 } }),
+        lugar('pocket_f', { en: 'node_e' }),
+        lugar('huerfano', { en: 'fantasma' }),
+        lugar('perdido'),
+    ];
+    const entidades = new Map<string, WorldEntityBase>(
+        [...sistemas, ...lugares].map((entity) => [entity.id, entity])
+    );
+    return {
+        manifest: {
+            nombre: 'Sector Test',
+            calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
+            viaje: { ...VIAJE_DEFAULTS, ...viaje },
+            medidores: ['viveres', 'combustible', 'nave'],
+            regiones: [],
+        },
+        entidades,
+        sistemas,
+        lugares,
+        facciones: [],
+        pnjs: [],
+        pistas: [],
+        tramas: [],
+        tablas: [],
+        problemas: [],
+        childrenOf: new Map(),
+        estadoGrupo: null,
+        diario: [],
+    };
+}
+
+const model = makeModel();
+
+/** Comfortable snapshot: no warnings unless a test says otherwise. */
+const FULL: TravelSnapshot = { medidores: { viveres: 5, combustible: 5, nave: 5 } };
+
+// ── Degenerate inputs ───────────────────────────────────────────────────────
+
+describe('computeTravelPlan degenerate inputs', () => {
+    test('null when either id is unknown', () => {
+        expect(computeTravelPlan('no_existe', 'planet_b1', model, FULL)).toBeNull();
+        expect(computeTravelPlan('planet_a1', 'no_existe', model, FULL)).toBeNull();
+    });
+
+    test('null when toId === fromId', () => {
+        expect(computeTravelPlan('planet_a1', 'planet_a1', model, FULL)).toBeNull();
+    });
+
+    test('null when a root dangles (en: chain dead-ends)', () => {
+        expect(computeTravelPlan('planet_a1', 'huerfano', model, FULL)).toBeNull();
+        expect(computeTravelPlan('huerfano', 'planet_a1', model, FULL)).toBeNull();
+    });
+
+    test('null when a cross-sector root has no coordinates', () => {
+        expect(computeTravelPlan('planet_a1', 'perdido', model, FULL)).toBeNull();
+        expect(computeTravelPlan('perdido', 'planet_a1', model, FULL)).toBeNull();
+    });
+});
+
+// ── Intra-system ────────────────────────────────────────────────────────────
+
+describe('computeTravelPlan intra-system', () => {
+    test('same root = one flat leg regardless of depth, no fuel, no viveres', () => {
+        expect(computeTravelPlan('planet_a1', 'site_a2', model, FULL)).toEqual({
+            legs: [{ fromId: 'planet_a1', toId: 'site_a2', dias: 1, combustible: 0, viveres: 0 }],
+            totalDias: 1,
+            totalCombustible: 0,
+            totalViveres: 0,
+            warnings: [],
+            portal: false,
+        });
+    });
+
+    test('sistema to its own child is also a flat leg', () => {
+        const plan = computeTravelPlan('sistema_a', 'planet_a1', model, FULL);
+        expect(plan?.legs).toEqual([
+            { fromId: 'sistema_a', toId: 'planet_a1', dias: 1, combustible: 0, viveres: 0 },
+        ]);
+    });
+});
+
+// ── Cross-sector legs ───────────────────────────────────────────────────────
+
+describe('computeTravelPlan cross-sector', () => {
+    test('three legs with ceil on the sector distance (√13 -> 4)', () => {
+        expect(computeTravelPlan('site_a2', 'planet_b1', model, FULL)).toEqual({
+            legs: [
+                { fromId: 'site_a2', toId: 'sistema_a', dias: 1, combustible: 0, viveres: 0 },
+                { fromId: 'sistema_a', toId: 'sistema_b', dias: 4, combustible: 1, viveres: 0 },
+                // viveres = floor(6 / 4) = 1, carried by the last leg
+                { fromId: 'sistema_b', toId: 'planet_b1', dias: 1, combustible: 0, viveres: 1 },
+            ],
+            totalDias: 6,
+            totalCombustible: 1,
+            totalViveres: 1,
+            warnings: [],
+            portal: false,
+        });
+    });
+
+    test('origin IS its root: the up-leg is skipped', () => {
+        const plan = computeTravelPlan('sistema_a', 'planet_b1', model, FULL);
+        expect(plan?.legs).toEqual([
+            { fromId: 'sistema_a', toId: 'sistema_b', dias: 4, combustible: 1, viveres: 0 },
+            { fromId: 'sistema_b', toId: 'planet_b1', dias: 1, combustible: 0, viveres: 1 },
+        ]);
+        expect(plan?.totalDias).toBe(5);
+    });
+
+    test('destination IS its root: the down-leg is skipped, viveres land on the sector leg', () => {
+        const plan = computeTravelPlan('site_a2', 'sistema_b', model, FULL);
+        expect(plan?.legs).toEqual([
+            { fromId: 'site_a2', toId: 'sistema_a', dias: 1, combustible: 0, viveres: 0 },
+            { fromId: 'sistema_a', toId: 'sistema_b', dias: 4, combustible: 1, viveres: 1 },
+        ]);
+    });
+
+    test('root to root: single sector leg carrying fuel and viveres', () => {
+        expect(computeTravelPlan('sistema_a', 'sistema_b', model, FULL)).toEqual({
+            legs: [{ fromId: 'sistema_a', toId: 'sistema_b', dias: 4, combustible: 1, viveres: 1 }],
+            totalDias: 4,
+            totalCombustible: 1,
+            totalViveres: 1,
+            warnings: [],
+            portal: false,
+        });
+    });
+
+    test('deep-space lugar acts as a sector root (√50 -> 8)', () => {
+        const plan = computeTravelPlan('planet_a1', 'pocket_f', model, FULL);
+        expect(plan?.legs).toEqual([
+            { fromId: 'planet_a1', toId: 'sistema_a', dias: 1, combustible: 0, viveres: 0 },
+            { fromId: 'sistema_a', toId: 'node_e', dias: 8, combustible: 1, viveres: 0 },
+            // floor(10 / 4) = 2
+            { fromId: 'node_e', toId: 'pocket_f', dias: 1, combustible: 0, viveres: 2 },
+        ]);
+        expect(plan?.totalDias).toBe(10);
+        expect(plan?.totalViveres).toBe(2);
+    });
+
+    test('diasPorUnidad scales the sector leg before the ceil (√13 × 2 -> 8)', () => {
+        const doubled = makeModel({ diasPorUnidad: 2 });
+        const plan = computeTravelPlan('sistema_a', 'sistema_b', doubled, FULL);
+        expect(plan?.legs[0].dias).toBe(8);
+        expect(plan?.totalDias).toBe(8);
+        // floor(8 / 4) = 2
+        expect(plan?.totalViveres).toBe(2);
+    });
+});
+
+// ── Portal access ───────────────────────────────────────────────────────────
+
+describe('computeTravelPlan portal destinations', () => {
+    const PORTAL_PLAN = {
+        legs: [],
+        totalDias: 0,
+        totalCombustible: 0,
+        totalViveres: 0,
+        warnings: [],
+        portal: true,
+    };
+
+    test('direct portal destination: no legs, portal true', () => {
+        expect(computeTravelPlan('planet_a1', 'portal_gate', model, FULL)).toEqual(PORTAL_PLAN);
+    });
+
+    test('portal inherited through the en: chain', () => {
+        expect(computeTravelPlan('planet_a1', 'portal_inner', model, FULL)).toEqual(PORTAL_PLAN);
+    });
+
+    test('portal wins even from inside the same system', () => {
+        expect(computeTravelPlan('planet_b1', 'portal_inner', model, FULL)).toEqual(PORTAL_PLAN);
+    });
+});
+
+// ── Consumption + warnings ──────────────────────────────────────────────────
+
+describe('computeTravelPlan consumption and warnings', () => {
+    test('short trips round viveres down to zero', () => {
+        // 1 travel day, rations every 4 days -> 0 consumed.
+        const plan = computeTravelPlan('planet_a1', 'site_a2', model, FULL);
+        expect(plan?.totalViveres).toBe(0);
+    });
+
+    test('combustible burns only on the sector leg', () => {
+        const plan = computeTravelPlan('site_a2', 'planet_b1', model, FULL);
+        expect(plan?.legs.map((leg) => leg.combustible)).toEqual([0, 1, 0]);
+        expect(plan?.totalCombustible).toBe(1);
+    });
+
+    test('warnings when the snapshot cannot cover the totals', () => {
+        const broke: TravelSnapshot = { medidores: { viveres: 0, combustible: 0, nave: 5 } };
+        const plan = computeTravelPlan('site_a2', 'planet_b1', model, broke);
+        expect(plan?.warnings).toEqual([WARN_COMBUSTIBLE, WARN_VIVERES]);
+    });
+
+    test('only the short gauge warns; exact-enough passes clean', () => {
+        const lowViveres: TravelSnapshot = { medidores: { viveres: 0, combustible: 1, nave: 5 } };
+        expect(computeTravelPlan('site_a2', 'planet_b1', model, lowViveres)?.warnings).toEqual([
+            WARN_VIVERES,
+        ]);
+
+        const exact: TravelSnapshot = { medidores: { viveres: 1, combustible: 1, nave: 5 } };
+        expect(computeTravelPlan('site_a2', 'planet_b1', model, exact)?.warnings).toEqual([]);
+    });
+
+    test('missing gauges in the snapshot count as 0', () => {
+        const empty: TravelSnapshot = { medidores: {} };
+        const plan = computeTravelPlan('site_a2', 'planet_b1', model, empty);
+        expect(plan?.warnings).toEqual([WARN_COMBUSTIBLE, WARN_VIVERES]);
+    });
+
+    test('exact warning strings (UI + e2e contract)', () => {
+        expect(WARN_COMBUSTIBLE).toBe('Combustible insuficiente');
+        expect(WARN_VIVERES).toBe('Víveres insuficientes');
+    });
+});
+
+// ── travelDaySchedule ───────────────────────────────────────────────────────
+
+function scheduleTotals(days: { combustible: number; viveres: number }[]) {
+    return days.reduce(
+        (acc, day) => ({
+            combustible: acc.combustible + day.combustible,
+            viveres: acc.viveres + day.viveres,
+        }),
+        { combustible: 0, viveres: 0 }
+    );
+}
+
+describe('travelDaySchedule', () => {
+    test('cross-sector default: fuel on the sector leg last day, ration on day 4', () => {
+        // legs 1 + 4 + 1 (site_a2 -> planet_b1), combustible 1 on the sector leg.
+        const plan = computeTravelPlan('site_a2', 'planet_b1', model, FULL)!;
+        const days = travelDaySchedule(plan, model.manifest.viaje.viveresCadaDias);
+        expect(days).toEqual([
+            { combustible: 0, viveres: 0 },
+            { combustible: 0, viveres: 0 },
+            { combustible: 0, viveres: 0 },
+            { combustible: 0, viveres: 1 }, // day 4: viveresCadaDias cadence
+            { combustible: 1, viveres: 0 }, // day 5: last day of the 4-day sector leg
+            { combustible: 0, viveres: 0 },
+        ]);
+    });
+
+    test('per-day amounts always sum to the plan totals', () => {
+        const plan = computeTravelPlan('planet_a1', 'pocket_f', model, FULL)!; // 10 days
+        const days = travelDaySchedule(plan, model.manifest.viaje.viveresCadaDias);
+        expect(days).toHaveLength(plan.totalDias);
+        expect(scheduleTotals(days)).toEqual({
+            combustible: plan.totalCombustible,
+            viveres: plan.totalViveres,
+        });
+        // Rations at days 4 and 8 of the continuous trip.
+        expect(days.map((day) => day.viveres)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0, 0]);
+    });
+
+    test('multi-unit fuel spreads at even boundaries within its leg', () => {
+        const plan: TravelPlan = {
+            legs: [{ fromId: 'a', toId: 'b', dias: 4, combustible: 2, viveres: 0 }],
+            totalDias: 4,
+            totalCombustible: 2,
+            totalViveres: 0,
+            warnings: [],
+            portal: false,
+        };
+        // unit 1 -> ceil(1·4/2) = day 2, unit 2 -> ceil(2·4/2) = day 4.
+        expect(travelDaySchedule(plan, 0).map((day) => day.combustible)).toEqual([0, 1, 0, 1]);
+    });
+
+    test('viveresCadaDias <= 0 charges no rations', () => {
+        const plan = computeTravelPlan('site_a2', 'planet_b1', model, FULL)!;
+        const days = travelDaySchedule(plan, 0);
+        expect(scheduleTotals(days).viveres).toBe(0);
+    });
+
+    test('a 0-day leg with fuel charges on the nearest existing day', () => {
+        const plan: TravelPlan = {
+            legs: [
+                { fromId: 'a', toId: 'b', dias: 1, combustible: 0, viveres: 0 },
+                { fromId: 'b', toId: 'c', dias: 0, combustible: 1, viveres: 0 },
+            ],
+            totalDias: 1,
+            totalCombustible: 1,
+            totalViveres: 0,
+            warnings: [],
+            portal: false,
+        };
+        expect(travelDaySchedule(plan, 4).map((day) => day.combustible)).toEqual([1]);
+    });
+
+    test('a 0-day plan yields an empty schedule', () => {
+        const plan: TravelPlan = {
+            legs: [],
+            totalDias: 0,
+            totalCombustible: 0,
+            totalViveres: 0,
+            warnings: [],
+            portal: true,
+        };
+        expect(travelDaySchedule(plan, 4)).toEqual([]);
+    });
+});
+
+// ── sectorLegEndDay ─────────────────────────────────────────────────────────
+
+describe('sectorLegEndDay', () => {
+    test('cumulative days through the sector leg (pre-leg + sector)', () => {
+        const plan = computeTravelPlan('site_a2', 'planet_b1', model, FULL)!; // 1 + 4 + 1
+        expect(sectorLegEndDay(plan, model)).toBe(5);
+    });
+
+    test('root-to-root: the whole trip is the sector leg', () => {
+        const plan = computeTravelPlan('sistema_a', 'sistema_b', model, FULL)!; // 4
+        expect(sectorLegEndDay(plan, model)).toBe(4);
+    });
+
+    test('intra-system trips have no sector leg -> totalDias', () => {
+        const plan = computeTravelPlan('planet_a1', 'site_a2', model, FULL)!; // 1
+        expect(sectorLegEndDay(plan, model)).toBe(plan.totalDias);
+    });
+});

--- a/lib/world/travel.test.ts
+++ b/lib/world/travel.test.ts
@@ -110,6 +110,7 @@ function makeModel(viaje: Partial<WorldManifest['viaje']> = {}): WorldModel {
         childrenOf: new Map(),
         estadoGrupo: null,
         diario: [],
+        musica: { bgm: [], eventPlaylists: [] },
     };
 }
 

--- a/lib/world/travel.test.ts
+++ b/lib/world/travel.test.ts
@@ -111,6 +111,8 @@ function makeModel(viaje: Partial<WorldManifest['viaje']> = {}): WorldModel {
         estadoGrupo: null,
         diario: [],
         musica: { bgm: [], eventPlaylists: [] },
+        tiendas: new Map(),
+        resumen: null,
     };
 }
 

--- a/lib/world/travel.test.ts
+++ b/lib/world/travel.test.ts
@@ -13,6 +13,7 @@ import {
     sectorLegEndDay,
     travelDaySchedule,
     TravelSnapshot,
+    viveresTicksBetween,
     WARN_COMBUSTIBLE,
     WARN_VIVERES,
 } from './travel';
@@ -69,7 +70,7 @@ function lugar(
 const VIAJE_DEFAULTS: WorldManifest['viaje'] = {
     diasPorUnidad: 1,
     intrasistemaDias: 1,
-    combustiblePorTramo: 1,
+    combustibleCadaDias: 4,
     viveresCadaDias: 4,
 };
 
@@ -114,8 +115,74 @@ function makeModel(viaje: Partial<WorldManifest['viaje']> = {}): WorldModel {
 
 const model = makeModel();
 
-/** Comfortable snapshot: no warnings unless a test says otherwise. */
-const FULL: TravelSnapshot = { medidores: { viveres: 5, combustible: 5, nave: 5 } };
+/**
+ * Comfortable snapshot: no warnings unless a test says otherwise. diaMundo 0
+ * = "phase 0": víveres tick on absolute days 4, 8, 12…
+ */
+const FULL: TravelSnapshot = {
+    medidores: { viveres: 5, combustible: 5, nave: 5 },
+    diaMundo: 0,
+};
+
+function at(diaMundo: number, medidores = FULL.medidores): TravelSnapshot {
+    return { medidores, diaMundo };
+}
+
+// ── viveresTicksBetween ─────────────────────────────────────────────────────
+
+describe('viveresTicksBetween', () => {
+    test('strictly (d0, d1]: the departure day itself never ticks', () => {
+        // From 240 (already a multiple of 4), a 4-day advance ticks ONCE (244).
+        expect(viveresTicksBetween(240, 244, 4)).toBe(1);
+        expect(viveresTicksBetween(240, 241, 4)).toBe(0);
+        expect(viveresTicksBetween(243, 244, 4)).toBe(1);
+        expect(viveresTicksBetween(240, 248, 4)).toBe(2);
+    });
+
+    test('cada <= 0 or non-advance -> 0 (no division by zero, no loop)', () => {
+        expect(viveresTicksBetween(10, 20, 0)).toBe(0);
+        expect(viveresTicksBetween(10, 20, -3)).toBe(0);
+        expect(viveresTicksBetween(20, 20, 4)).toBe(0);
+        expect(viveresTicksBetween(20, 10, 4)).toBe(0);
+    });
+
+    test('cada = 1 ticks daily', () => {
+        expect(viveresTicksBetween(5, 10, 1)).toBe(5);
+    });
+
+    test('negative days use floored division (calendar before the epoch)', () => {
+        // (-5, -1] contains -4 -> 1 tick.
+        expect(viveresTicksBetween(-5, -1, 4)).toBe(1);
+        // (-2, 2] contains 0 -> 1 tick.
+        expect(viveresTicksBetween(-2, 2, 4)).toBe(1);
+    });
+
+    test('property: equals the sum of per-day schedule ticks (random d0/D/cada)', () => {
+        // Deterministic pseudo-random sample, incl. negative departures.
+        const samples: [number, number, number][] = [
+            [0, 10, 4],
+            [3, 21, 4],
+            [-7, 13, 4],
+            [240, 8, 3],
+            [999, 1, 5],
+            [-1, 9, 1],
+            [17, 40, 7],
+        ];
+        for (const [d0, dias, cada] of samples) {
+            const plan: TravelPlan = {
+                legs: [{ fromId: 'a', toId: 'b', dias, combustible: 0, viveres: 0 }],
+                totalDias: dias,
+                totalCombustible: 0,
+                totalViveres: 0,
+                warnings: [],
+                portal: false,
+            };
+            const days = travelDaySchedule(plan, { combustibleCadaDias: 4, viveresCadaDias: cada }, d0);
+            const sum = days.reduce((acc, day) => acc + day.viveres, 0);
+            expect(sum).toBe(viveresTicksBetween(d0, d0 + dias, cada));
+        }
+    });
+});
 
 // ── Degenerate inputs ───────────────────────────────────────────────────────
 
@@ -143,15 +210,21 @@ describe('computeTravelPlan degenerate inputs', () => {
 // ── Intra-system ────────────────────────────────────────────────────────────
 
 describe('computeTravelPlan intra-system', () => {
-    test('same root = one flat leg regardless of depth, no fuel, no viveres', () => {
+    test('same root = one flat leg regardless of depth, no fuel; viveres by phase', () => {
         expect(computeTravelPlan('planet_a1', 'site_a2', model, FULL)).toEqual({
             legs: [{ fromId: 'planet_a1', toId: 'site_a2', dias: 1, combustible: 0, viveres: 0 }],
             totalDias: 1,
             totalCombustible: 0,
-            totalViveres: 0,
+            totalViveres: 0, // (0, 1] crosses no multiple of 4
             warnings: [],
             portal: false,
         });
+    });
+
+    test('the same hop on the eve of a ration day costs 1 víveres (calendar phase)', () => {
+        const plan = computeTravelPlan('planet_a1', 'site_a2', model, at(3));
+        expect(plan?.totalViveres).toBe(1); // (3, 4] crosses day 4
+        expect(plan?.legs[0].viveres).toBe(1);
     });
 
     test('sistema to its own child is also a flat leg', () => {
@@ -165,12 +238,12 @@ describe('computeTravelPlan intra-system', () => {
 // ── Cross-sector legs ───────────────────────────────────────────────────────
 
 describe('computeTravelPlan cross-sector', () => {
-    test('three legs with ceil on the sector distance (√13 -> 4)', () => {
+    test('three legs with ceil on the sector distance (√13 -> 4); fuel = ceil(4/4)', () => {
         expect(computeTravelPlan('site_a2', 'planet_b1', model, FULL)).toEqual({
             legs: [
                 { fromId: 'site_a2', toId: 'sistema_a', dias: 1, combustible: 0, viveres: 0 },
                 { fromId: 'sistema_a', toId: 'sistema_b', dias: 4, combustible: 1, viveres: 0 },
-                // viveres = floor(6 / 4) = 1, carried by the last leg
+                // viveres = ticks in (0, 6] = 1, carried by the last leg
                 { fromId: 'sistema_b', toId: 'planet_b1', dias: 1, combustible: 0, viveres: 1 },
             ],
             totalDias: 6,
@@ -209,15 +282,16 @@ describe('computeTravelPlan cross-sector', () => {
         });
     });
 
-    test('deep-space lugar acts as a sector root (√50 -> 8)', () => {
+    test('deep-space lugar acts as a sector root (√50 -> 8); fuel = ceil(8/4) = 2', () => {
         const plan = computeTravelPlan('planet_a1', 'pocket_f', model, FULL);
         expect(plan?.legs).toEqual([
             { fromId: 'planet_a1', toId: 'sistema_a', dias: 1, combustible: 0, viveres: 0 },
-            { fromId: 'sistema_a', toId: 'node_e', dias: 8, combustible: 1, viveres: 0 },
-            // floor(10 / 4) = 2
+            { fromId: 'sistema_a', toId: 'node_e', dias: 8, combustible: 2, viveres: 0 },
+            // ticks in (0, 10] = days 4 and 8 -> 2
             { fromId: 'node_e', toId: 'pocket_f', dias: 1, combustible: 0, viveres: 2 },
         ]);
         expect(plan?.totalDias).toBe(10);
+        expect(plan?.totalCombustible).toBe(2);
         expect(plan?.totalViveres).toBe(2);
     });
 
@@ -226,8 +300,15 @@ describe('computeTravelPlan cross-sector', () => {
         const plan = computeTravelPlan('sistema_a', 'sistema_b', doubled, FULL);
         expect(plan?.legs[0].dias).toBe(8);
         expect(plan?.totalDias).toBe(8);
-        // floor(8 / 4) = 2
-        expect(plan?.totalViveres).toBe(2);
+        expect(plan?.totalCombustible).toBe(2); // ceil(8/4)
+        expect(plan?.totalViveres).toBe(2); // ticks in (0, 8]
+    });
+
+    test('combustibleCadaDias <= 0 burns no fuel at all', () => {
+        const free = makeModel({ combustibleCadaDias: 0 });
+        const plan = computeTravelPlan('sistema_a', 'sistema_b', free, FULL);
+        expect(plan?.totalCombustible).toBe(0);
+        expect(plan?.legs[0].combustible).toBe(0);
     });
 });
 
@@ -243,7 +324,7 @@ describe('computeTravelPlan portal destinations', () => {
         portal: true,
     };
 
-    test('direct portal destination: no legs, portal true', () => {
+    test('direct portal destination: no legs, portal true, zero consumption', () => {
         expect(computeTravelPlan('planet_a1', 'portal_gate', model, FULL)).toEqual(PORTAL_PLAN);
     });
 
@@ -259,8 +340,8 @@ describe('computeTravelPlan portal destinations', () => {
 // ── Consumption + warnings ──────────────────────────────────────────────────
 
 describe('computeTravelPlan consumption and warnings', () => {
-    test('short trips round viveres down to zero', () => {
-        // 1 travel day, rations every 4 days -> 0 consumed.
+    test('short trips at phase 0 consume no viveres', () => {
+        // 1 travel day from day 0, rations on multiples of 4 -> 0 consumed.
         const plan = computeTravelPlan('planet_a1', 'site_a2', model, FULL);
         expect(plan?.totalViveres).toBe(0);
     });
@@ -272,23 +353,33 @@ describe('computeTravelPlan consumption and warnings', () => {
     });
 
     test('warnings when the snapshot cannot cover the totals', () => {
-        const broke: TravelSnapshot = { medidores: { viveres: 0, combustible: 0, nave: 5 } };
+        const broke = at(0, { viveres: 0, combustible: 0, nave: 5 });
         const plan = computeTravelPlan('site_a2', 'planet_b1', model, broke);
         expect(plan?.warnings).toEqual([WARN_COMBUSTIBLE, WARN_VIVERES]);
     });
 
     test('only the short gauge warns; exact-enough passes clean', () => {
-        const lowViveres: TravelSnapshot = { medidores: { viveres: 0, combustible: 1, nave: 5 } };
+        const lowViveres = at(0, { viveres: 0, combustible: 1, nave: 5 });
         expect(computeTravelPlan('site_a2', 'planet_b1', model, lowViveres)?.warnings).toEqual([
             WARN_VIVERES,
         ]);
 
-        const exact: TravelSnapshot = { medidores: { viveres: 1, combustible: 1, nave: 5 } };
+        const exact = at(0, { viveres: 1, combustible: 1, nave: 5 });
         expect(computeTravelPlan('site_a2', 'planet_b1', model, exact)?.warnings).toEqual([]);
     });
 
+    test('the departure phase can flip the viveres warning on the same route', () => {
+        // 10-day trip: phase 0 -> 2 rations; phase 2 -> ticks at 4, 8, 12 = 3.
+        const two = at(0, { viveres: 2, combustible: 5, nave: 5 });
+        expect(computeTravelPlan('planet_a1', 'pocket_f', model, two)?.warnings).toEqual([]);
+        const twoLater = at(2, { viveres: 2, combustible: 5, nave: 5 });
+        expect(computeTravelPlan('planet_a1', 'pocket_f', model, twoLater)?.warnings).toEqual([
+            WARN_VIVERES,
+        ]);
+    });
+
     test('missing gauges in the snapshot count as 0', () => {
-        const empty: TravelSnapshot = { medidores: {} };
+        const empty = at(0, {});
         const plan = computeTravelPlan('site_a2', 'planet_b1', model, empty);
         expect(plan?.warnings).toEqual([WARN_COMBUSTIBLE, WARN_VIVERES]);
     });
@@ -301,6 +392,8 @@ describe('computeTravelPlan consumption and warnings', () => {
 
 // ── travelDaySchedule ───────────────────────────────────────────────────────
 
+const VIAJE_SCHED = { combustibleCadaDias: 4, viveresCadaDias: 4 };
+
 function scheduleTotals(days: { combustible: number; viveres: number }[]) {
     return days.reduce(
         (acc, day) => ({
@@ -311,49 +404,111 @@ function scheduleTotals(days: { combustible: number; viveres: number }[]) {
     );
 }
 
+/** Hand-built single-leg plan for schedule shape tests. */
+function sectorPlan(dias: number, combustible: number): TravelPlan {
+    return {
+        legs: [{ fromId: 'a', toId: 'b', dias, combustible, viveres: 0 }],
+        totalDias: dias,
+        totalCombustible: combustible,
+        totalViveres: 0,
+        warnings: [],
+        portal: false,
+    };
+}
+
 describe('travelDaySchedule', () => {
-    test('cross-sector default: fuel on the sector leg last day, ration on day 4', () => {
-        // legs 1 + 4 + 1 (site_a2 -> planet_b1), combustible 1 on the sector leg.
+    test('cross-sector default: fuel at the sector-leg cadence boundary, ration on day 4', () => {
+        // legs 1 + 4 + 1 (site_a2 -> planet_b1); sector leg = trip days 2..5,
+        // fuel tick on leg-day 4 = trip day 5.
         const plan = computeTravelPlan('site_a2', 'planet_b1', model, FULL)!;
-        const days = travelDaySchedule(plan, model.manifest.viaje.viveresCadaDias);
+        const days = travelDaySchedule(plan, model.manifest.viaje, 0);
         expect(days).toEqual([
             { combustible: 0, viveres: 0 },
             { combustible: 0, viveres: 0 },
             { combustible: 0, viveres: 0 },
-            { combustible: 0, viveres: 1 }, // day 4: viveresCadaDias cadence
-            { combustible: 1, viveres: 0 }, // day 5: last day of the 4-day sector leg
+            { combustible: 0, viveres: 1 }, // dia_mundo 4: calendar cadence
+            { combustible: 1, viveres: 0 }, // sector leg-day 4
             { combustible: 0, viveres: 0 },
         ]);
     });
 
-    test('per-day amounts always sum to the plan totals', () => {
+    test('per-day amounts always sum to the plan totals (same diaMundo0)', () => {
         const plan = computeTravelPlan('planet_a1', 'pocket_f', model, FULL)!; // 10 days
-        const days = travelDaySchedule(plan, model.manifest.viaje.viveresCadaDias);
+        const days = travelDaySchedule(plan, model.manifest.viaje, 0);
         expect(days).toHaveLength(plan.totalDias);
         expect(scheduleTotals(days)).toEqual({
             combustible: plan.totalCombustible,
             viveres: plan.totalViveres,
         });
-        // Rations at days 4 and 8 of the continuous trip.
+        // Rations on absolute days 4 and 8 of the calendar.
         expect(days.map((day) => day.viveres)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0, 0]);
+        // Fuel inside the 8-day sector leg (trip days 2..9): leg-days 4, 8.
+        expect(days.map((day) => day.combustible)).toEqual([0, 0, 0, 0, 1, 0, 0, 0, 1, 0]);
     });
 
-    test('multi-unit fuel spreads at even boundaries within its leg', () => {
+    test('fuel remainder lands on the leg last day: D=7 -> days 4 and 7', () => {
+        const days = travelDaySchedule(sectorPlan(7, 2), VIAJE_SCHED, 0);
+        expect(days.map((day) => day.combustible)).toEqual([0, 0, 0, 1, 0, 0, 1]);
+    });
+
+    test('no phantom remainder on exact multiples: D=8 -> days 4 and 8', () => {
+        const days = travelDaySchedule(sectorPlan(8, 2), VIAJE_SCHED, 0);
+        expect(days.map((day) => day.combustible)).toEqual([0, 0, 0, 1, 0, 0, 0, 1]);
+    });
+
+    test('short legs charge on arrival: D=3 -> day 3; D=4 -> day 4', () => {
+        expect(travelDaySchedule(sectorPlan(3, 1), VIAJE_SCHED, 0).map((d) => d.combustible)).toEqual([
+            0, 0, 1,
+        ]);
+        expect(travelDaySchedule(sectorPlan(4, 1), VIAJE_SCHED, 0).map((d) => d.combustible)).toEqual([
+            0, 0, 0, 1,
+        ]);
+    });
+
+    test('viveres ticks follow the CALENDAR phase, not the trip start', () => {
+        // 4-day trip from dia_mundo 2: multiples of 4 in (2, 6] = {4} -> trip day 2.
+        const days = travelDaySchedule(sectorPlan(4, 1), VIAJE_SCHED, 2);
+        expect(days.map((day) => day.viveres)).toEqual([0, 1, 0, 0]);
+    });
+
+    test('viveres ticks may land on intra legs of a multi-leg trip', () => {
+        // 1 + 7 + 1 from phase 0: rations on trip days 4 and 8 (both inside
+        // the sector leg here), fuel on sector leg-days 4 and 7 = trip 5 and 8.
         const plan: TravelPlan = {
-            legs: [{ fromId: 'a', toId: 'b', dias: 4, combustible: 2, viveres: 0 }],
-            totalDias: 4,
+            legs: [
+                { fromId: 'a', toId: 'r1', dias: 1, combustible: 0, viveres: 0 },
+                { fromId: 'r1', toId: 'r2', dias: 7, combustible: 2, viveres: 0 },
+                { fromId: 'r2', toId: 'b', dias: 1, combustible: 0, viveres: 0 },
+            ],
+            totalDias: 9,
             totalCombustible: 2,
             totalViveres: 0,
             warnings: [],
             portal: false,
         };
-        // unit 1 -> ceil(1·4/2) = day 2, unit 2 -> ceil(2·4/2) = day 4.
-        expect(travelDaySchedule(plan, 0).map((day) => day.combustible)).toEqual([0, 1, 0, 1]);
+        const days = travelDaySchedule(plan, VIAJE_SCHED, 0);
+        expect(days.map((day) => day.viveres)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+        expect(days.map((day) => day.combustible)).toEqual([0, 0, 0, 0, 1, 0, 0, 1, 0]);
+    });
+
+    test('cada = 1 ticks viveres daily (clamp path exercises every day)', () => {
+        const days = travelDaySchedule(
+            sectorPlan(5, 2),
+            { combustibleCadaDias: 4, viveresCadaDias: 1 },
+            5
+        );
+        expect(days.map((day) => day.viveres)).toEqual([1, 1, 1, 1, 1]);
+    });
+
+    test('hand-built legs off the cadence keep the even spread (totals invariant)', () => {
+        // combustible 2 != ceil(4/4): legacy spread — unit i on ceil(i·D/C).
+        const days = travelDaySchedule(sectorPlan(4, 2), VIAJE_SCHED, 0);
+        expect(days.map((day) => day.combustible)).toEqual([0, 1, 0, 1]);
     });
 
     test('viveresCadaDias <= 0 charges no rations', () => {
         const plan = computeTravelPlan('site_a2', 'planet_b1', model, FULL)!;
-        const days = travelDaySchedule(plan, 0);
+        const days = travelDaySchedule(plan, { combustibleCadaDias: 4, viveresCadaDias: 0 }, 0);
         expect(scheduleTotals(days).viveres).toBe(0);
     });
 
@@ -369,7 +524,7 @@ describe('travelDaySchedule', () => {
             warnings: [],
             portal: false,
         };
-        expect(travelDaySchedule(plan, 4).map((day) => day.combustible)).toEqual([1]);
+        expect(travelDaySchedule(plan, VIAJE_SCHED, 0).map((day) => day.combustible)).toEqual([1]);
     });
 
     test('a 0-day plan yields an empty schedule', () => {
@@ -381,7 +536,18 @@ describe('travelDaySchedule', () => {
             warnings: [],
             portal: true,
         };
-        expect(travelDaySchedule(plan, 4)).toEqual([]);
+        expect(travelDaySchedule(plan, VIAJE_SCHED, 0)).toEqual([]);
+    });
+
+    test('stepping day-by-day equals resolving in one batch (phase-dependent)', () => {
+        for (const d0 of [0, 1, 2, 3, 240, 4127]) {
+            const plan = computeTravelPlan('planet_a1', 'pocket_f', model, at(d0))!;
+            const days = travelDaySchedule(plan, model.manifest.viaje, d0);
+            expect(scheduleTotals(days)).toEqual({
+                combustible: plan.totalCombustible,
+                viveres: plan.totalViveres,
+            });
+        }
     });
 });
 

--- a/lib/world/travel.test.ts
+++ b/lib/world/travel.test.ts
@@ -113,6 +113,7 @@ function makeModel(viaje: Partial<WorldManifest['viaje']> = {}): WorldModel {
         musica: { bgm: [], eventPlaylists: [] },
         tiendas: new Map(),
         resumen: null,
+        guias: [],
     };
 }
 

--- a/lib/world/travel.ts
+++ b/lib/world/travel.ts
@@ -1,5 +1,6 @@
 /**
- * Pure travel-plan math (M4, plan Part B "Travel").
+ * Pure travel-plan math (M4, plan Part B "Travel"; economy redesign — see
+ * CONSUMPTION MODEL below).
  *
  * computeTravelPlan proposes a route + consumption for a trip between two
  * known entities:
@@ -14,16 +15,19 @@
  *     dias = ceil(euclidean(coords) * diasPorUnidad), root -> destination
  *     (skipped when the destination IS the root).
  *
- * Consumption (manifest suggestions — the app proposes, the GM confirms):
- *   - combustible: combustiblePorTramo on the SECTOR leg only; intra-system
- *     legs burn 0.
- *   - viveres: floor(totalDias / viveresCadaDias) for the WHOLE trip,
- *     carried by the LAST leg (a per-leg floor would undercount, e.g.
- *     1+4+1 days at "every 4" is 1 ration, not 0+1+0 recomputed per leg
- *     boundaries — the trip is one continuous stretch of days).
+ * CONSUMPTION MODEL (manifest suggestions — the app proposes, the GM
+ * confirms; two clean axes: food = calendar time, fuel = jump distance):
+ *   - combustible: ceil(leg.dias / combustibleCadaDias) per SECTOR leg
+ *     (jump-drive fuel); intra-system legs burn 0 — cheap local moves are
+ *     the sandbox's agency loop. combustibleCadaDias <= 0 -> 0.
+ *   - viveres: CALENDAR-anchored — 1 ration every viveresCadaDias-th
+ *     dia_mundo, so the total for a trip is viveresTicksBetween(d0, d0 +
+ *     totalDias): the same route costs 1 more or less depending on the
+ *     departure-day phase, and the TravelDialog previews the exact number.
+ *     The departure day itself never ticks (strictly (d0, d1]).
  *
- * Everything is pure over the WorldModel + a party gauge snapshot: no store
- * access, bun-testable without a DOM.
+ * Everything is pure over the WorldModel + a party snapshot (gauges +
+ * diaMundo): no store access, bun-testable without a DOM.
  *
  * The stepper-side helpers below (M4 integration) derive the PER-DAY view of
  * a plan:
@@ -33,17 +37,35 @@
  *     region anchoring) switches from the origin to the destination.
  */
 
-import { TravelLeg, TravelPlan, WorldEntityBase, WorldModel } from '@/types/world';
+import { TravelLeg, TravelPlan, WorldEntityBase, WorldManifest, WorldModel } from '@/types/world';
 import { ancestryChain, sectorNodeFor } from './worldNav';
 
-/** Current party gauges the plan's totals are checked against. */
+/** Current party gauges + calendar day the plan's totals are computed against. */
 export interface TravelSnapshot {
     medidores: Record<string, number>;
+    /** Departure dia_mundo — viveres ticks are calendar-anchored on it. */
+    diaMundo: number;
 }
 
 /** Exact warning strings (TravelDialog banners + e2e assert on these). */
 export const WARN_COMBUSTIBLE = 'Combustible insuficiente';
 export const WARN_VIVERES = 'Víveres insuficientes';
+
+/** Floored modulo (negative-safe): mod(-1, 4) === 3. */
+function mod(n: number, m: number): number {
+    return ((n % m) + m) % m;
+}
+
+/**
+ * Víveres ticks consumed when dia_mundo advances from d0 to d1 (exclusive of
+ * d0, inclusive of d1): one tick per multiple of `cada` crossed. dia_mundo is
+ * the only accumulator — no remainder state anywhere. `cada <= 0` or a
+ * non-advance returns 0.
+ */
+export function viveresTicksBetween(d0: number, d1: number, cada: number): number {
+    if (cada <= 0 || d1 <= d0) return 0;
+    return Math.floor(d1 / cada) - Math.floor(d0 / cada);
+}
 
 function isPortal(entity: WorldEntityBase | undefined): boolean {
     return (entity as { acceso?: string } | undefined)?.acceso === 'portal';
@@ -57,6 +79,12 @@ function coordsOf(entity: WorldEntityBase | undefined): { x: number; y: number }
 
 function leg(fromId: string, toId: string, dias: number, combustible: number): TravelLeg {
     return { fromId, toId, dias, combustible, viveres: 0 };
+}
+
+/** Sector-leg fuel: 1 unit per `cada` days of the leg, rounded up. */
+function sectorLegCombustible(dias: number, cada: number): number {
+    if (cada <= 0 || dias <= 0) return 0;
+    return Math.ceil(dias / cada);
 }
 
 /**
@@ -107,7 +135,9 @@ export function computeTravelPlan(
         }
         const distance = Math.hypot(toCoords.x - fromCoords.x, toCoords.y - fromCoords.y);
         const sectorDias = Math.ceil(distance * viaje.diasPorUnidad);
-        legs.push(leg(fromRoot, toRoot, sectorDias, viaje.combustiblePorTramo));
+        legs.push(
+            leg(fromRoot, toRoot, sectorDias, sectorLegCombustible(sectorDias, viaje.combustibleCadaDias))
+        );
         if (toId !== toRoot) {
             legs.push(leg(toRoot, toId, viaje.intrasistemaDias, 0));
         }
@@ -115,8 +145,12 @@ export function computeTravelPlan(
 
     const totalDias = legs.reduce((sum, current) => sum + current.dias, 0);
     const totalCombustible = legs.reduce((sum, current) => sum + current.combustible, 0);
-    const totalViveres =
-        viaje.viveresCadaDias > 0 ? Math.floor(totalDias / viaje.viveresCadaDias) : 0;
+    // Calendar-anchored: phase-dependent on the departure day (module doc).
+    const totalViveres = viveresTicksBetween(
+        party.diaMundo,
+        party.diaMundo + totalDias,
+        viaje.viveresCadaDias
+    );
     legs[legs.length - 1].viveres = totalViveres;
 
     const warnings: string[] = [];
@@ -139,26 +173,51 @@ export interface TravelDayConsumption {
 }
 
 /**
+ * 1-based leg days on which a leg burns fuel.
+ *
+ * When the leg's units equal ceil(dias / cada) — every computeTravelPlan leg —
+ * the burn lands on leg-days cada, 2·cada, … floor(D/cada)·cada plus one
+ * remainder tick on the leg's LAST day when D % cada != 0 (a 7-day jump at
+ * cada 4 burns on days 4 and 7; an 8-day jump on 4 and 8 — no phantom
+ * remainder). Hand-built plans whose units do not match the cadence keep the
+ * legacy even spread (unit i of C on leg-day ceil(i·D/C)) so per-day amounts
+ * still sum exactly to the leg total.
+ */
+function fuelTickDaysForLeg(dias: number, combustible: number, cada: number): number[] {
+    if (combustible <= 0 || dias <= 0) return [];
+    if (cada > 0 && combustible === Math.ceil(dias / cada)) {
+        const days: number[] = [];
+        for (let day = cada; day <= dias; day += cada) days.push(day);
+        if (dias % cada !== 0) days.push(dias);
+        return days;
+    }
+    return Array.from({ length: combustible }, (_, unit) =>
+        Math.ceil(((unit + 1) * dias) / combustible)
+    );
+}
+
+/**
  * Per-day consumption schedule for a plan, length plan.totalDias.
  *
  * DOCUMENTED CONSUMPTION MODEL (the stepper journals from this):
- *   - combustible: each leg's units are spread across THAT leg's days at
- *     evenly spaced boundaries — unit i of C lands on leg-day ceil(i·D/C).
- *     With the default combustible_por_tramo = 1 the single unit lands on the
- *     sector leg's LAST day (the burn is acknowledged on completing the jump).
+ *   - combustible: each leg's units spread inside THAT leg per
+ *     fuelTickDaysForLeg (cadence boundaries + remainder on the last day).
  *     A degenerate 0-day leg charges its units on the nearest existing day.
- *   - víveres: 1 ration on every viveresCadaDias-th day of the WHOLE trip
- *     (days are one continuous stretch, matching computeTravelPlan's
- *     floor(totalDias / viveresCadaDias) total); viveresCadaDias <= 0 = none.
+ *   - víveres: CALENDAR-anchored — travel day d (1-based) ticks iff
+ *     (diaMundo0 + d) is a multiple of viveresCadaDias (floored modulo, so
+ *     negative days behave). Ticks may land on intra-system leg days: the
+ *     cadence tracks dia_mundo, not the leg structure.
  *
  * Per-day amounts therefore sum EXACTLY to plan.totalCombustible /
- * plan.totalViveres — stepping every day equals resolving the rest in one
- * batch. (The per-leg `viveres` bookkeeping on plan.legs is ignored here on
- * purpose: the cadence is trip-global, only the totals must agree.)
+ * plan.totalViveres for plans computed with the same diaMundo0 — stepping
+ * every day equals resolving the rest in one batch. (The per-leg `viveres`
+ * bookkeeping on plan.legs is ignored here on purpose: the cadence is
+ * calendar-global, only the totals must agree.)
  */
 export function travelDaySchedule(
     plan: TravelPlan,
-    viveresCadaDias: number
+    viaje: Pick<WorldManifest['viaje'], 'combustibleCadaDias' | 'viveresCadaDias'>,
+    diaMundo0: number
 ): TravelDayConsumption[] {
     const days: TravelDayConsumption[] = Array.from({ length: Math.max(0, plan.totalDias) }, () => ({
         combustible: 0,
@@ -168,22 +227,23 @@ export function travelDaySchedule(
 
     let offset = 0; // 0-based index of the current leg's first day
     for (const current of plan.legs) {
-        if (current.combustible > 0) {
-            if (current.dias <= 0) {
-                days[Math.min(offset, days.length - 1)].combustible += current.combustible;
-            } else {
-                for (let unit = 1; unit <= current.combustible; unit++) {
-                    const dayInLeg = Math.ceil((unit * current.dias) / current.combustible);
-                    days[Math.min(offset + dayInLeg - 1, days.length - 1)].combustible += 1;
-                }
+        if (current.combustible > 0 && current.dias <= 0) {
+            days[Math.min(offset, days.length - 1)].combustible += current.combustible;
+        } else {
+            for (const dayInLeg of fuelTickDaysForLeg(
+                current.dias,
+                current.combustible,
+                viaje.combustibleCadaDias
+            )) {
+                days[Math.min(offset + dayInLeg - 1, days.length - 1)].combustible += 1;
             }
         }
         offset += Math.max(0, current.dias);
     }
 
-    if (viveresCadaDias > 0) {
-        for (let dia = viveresCadaDias; dia <= days.length; dia += viveresCadaDias) {
-            days[dia - 1].viveres += 1;
+    if (viaje.viveresCadaDias > 0) {
+        for (let dia = 1; dia <= days.length; dia++) {
+            if (mod(diaMundo0 + dia, viaje.viveresCadaDias) === 0) days[dia - 1].viveres += 1;
         }
     }
     return days;

--- a/lib/world/travel.ts
+++ b/lib/world/travel.ts
@@ -1,0 +1,209 @@
+/**
+ * Pure travel-plan math (M4, plan Part B "Travel").
+ *
+ * computeTravelPlan proposes a route + consumption for a trip between two
+ * known entities:
+ *   - `acceso: portal` on the destination or anywhere up its `en:` chain
+ *     means no route is computable (plan Part A) — the plan comes back with
+ *     `portal: true` and no legs; the GM logs the arrival manually.
+ *   - Endpoints resolve to their sector root (worldNav sectorNodeFor): the
+ *     sistema or deep-space lugar that sits at coordinates on the sector map.
+ *   - Same root  -> one flat intra-system leg (manifest intrasistemaDias).
+ *   - Different roots -> up to three legs: origin -> its root (skipped when
+ *     the origin IS the root), root -> root sector leg with
+ *     dias = ceil(euclidean(coords) * diasPorUnidad), root -> destination
+ *     (skipped when the destination IS the root).
+ *
+ * Consumption (manifest suggestions — the app proposes, the GM confirms):
+ *   - combustible: combustiblePorTramo on the SECTOR leg only; intra-system
+ *     legs burn 0.
+ *   - viveres: floor(totalDias / viveresCadaDias) for the WHOLE trip,
+ *     carried by the LAST leg (a per-leg floor would undercount, e.g.
+ *     1+4+1 days at "every 4" is 1 ration, not 0+1+0 recomputed per leg
+ *     boundaries — the trip is one continuous stretch of days).
+ *
+ * Everything is pure over the WorldModel + a party gauge snapshot: no store
+ * access, bun-testable without a DOM.
+ *
+ * The stepper-side helpers below (M4 integration) derive the PER-DAY view of
+ * a plan:
+ *   - travelDaySchedule: which travel day charges which gauge, summing
+ *     exactly to the plan totals (documented on the function).
+ *   - sectorLegEndDay: the 1-based day after which the route context (event
+ *     region anchoring) switches from the origin to the destination.
+ */
+
+import { TravelLeg, TravelPlan, WorldEntityBase, WorldModel } from '@/types/world';
+import { ancestryChain, sectorNodeFor } from './worldNav';
+
+/** Current party gauges the plan's totals are checked against. */
+export interface TravelSnapshot {
+    medidores: Record<string, number>;
+}
+
+/** Exact warning strings (TravelDialog banners + e2e assert on these). */
+export const WARN_COMBUSTIBLE = 'Combustible insuficiente';
+export const WARN_VIVERES = 'Víveres insuficientes';
+
+function isPortal(entity: WorldEntityBase | undefined): boolean {
+    return (entity as { acceso?: string } | undefined)?.acceso === 'portal';
+}
+
+/** Sector coordinates of a root entity (sistema or deep-space lugar). */
+function coordsOf(entity: WorldEntityBase | undefined): { x: number; y: number } | null {
+    const coords = (entity as { coordenadas?: { x: number; y: number } } | undefined)?.coordenadas;
+    return coords ?? null;
+}
+
+function leg(fromId: string, toId: string, dias: number, combustible: number): TravelLeg {
+    return { fromId, toId, dias, combustible, viveres: 0 };
+}
+
+/**
+ * Route + consumption proposal from `fromId` to `toId`, or null when no plan
+ * makes sense: unknown ids, toId === fromId, or a route whose sector root has
+ * no coordinates (dangling `en:` chain / rootless lugar — nothing to measure).
+ */
+export function computeTravelPlan(
+    fromId: string,
+    toId: string,
+    model: WorldModel,
+    party: TravelSnapshot
+): TravelPlan | null {
+    if (fromId === toId) return null;
+    if (!model.entidades.has(fromId) || !model.entidades.has(toId)) return null;
+
+    // Portal access anywhere on the destination's chain: reachable, but not
+    // by a computable route.
+    const destChain = ancestryChain(model, toId);
+    if (destChain.some((id) => isPortal(model.entidades.get(id)))) {
+        return {
+            legs: [],
+            totalDias: 0,
+            totalCombustible: 0,
+            totalViveres: 0,
+            warnings: [],
+            portal: true,
+        };
+    }
+
+    const fromRoot = sectorNodeFor(model, fromId);
+    const toRoot = sectorNodeFor(model, toId);
+    if (fromRoot === null || toRoot === null) return null;
+
+    const { viaje } = model.manifest;
+    const legs: TravelLeg[] = [];
+
+    if (fromRoot === toRoot) {
+        // Intra-system hop: flat cost regardless of depth, no fuel burn.
+        legs.push(leg(fromId, toId, viaje.intrasistemaDias, 0));
+    } else {
+        const fromCoords = coordsOf(model.entidades.get(fromRoot));
+        const toCoords = coordsOf(model.entidades.get(toRoot));
+        if (fromCoords === null || toCoords === null) return null;
+
+        if (fromId !== fromRoot) {
+            legs.push(leg(fromId, fromRoot, viaje.intrasistemaDias, 0));
+        }
+        const distance = Math.hypot(toCoords.x - fromCoords.x, toCoords.y - fromCoords.y);
+        const sectorDias = Math.ceil(distance * viaje.diasPorUnidad);
+        legs.push(leg(fromRoot, toRoot, sectorDias, viaje.combustiblePorTramo));
+        if (toId !== toRoot) {
+            legs.push(leg(toRoot, toId, viaje.intrasistemaDias, 0));
+        }
+    }
+
+    const totalDias = legs.reduce((sum, current) => sum + current.dias, 0);
+    const totalCombustible = legs.reduce((sum, current) => sum + current.combustible, 0);
+    const totalViveres =
+        viaje.viveresCadaDias > 0 ? Math.floor(totalDias / viaje.viveresCadaDias) : 0;
+    legs[legs.length - 1].viveres = totalViveres;
+
+    const warnings: string[] = [];
+    if (totalCombustible > (party.medidores['combustible'] ?? 0)) {
+        warnings.push(WARN_COMBUSTIBLE);
+    }
+    if (totalViveres > (party.medidores['viveres'] ?? 0)) {
+        warnings.push(WARN_VIVERES);
+    }
+
+    return { legs, totalDias, totalCombustible, totalViveres, warnings, portal: false };
+}
+
+// ── Per-day stepper helpers (M4 integration) ────────────────────────────────
+
+/** What one travel day consumes; index d-1 of the schedule = travel day d (1-based). */
+export interface TravelDayConsumption {
+    combustible: number;
+    viveres: number;
+}
+
+/**
+ * Per-day consumption schedule for a plan, length plan.totalDias.
+ *
+ * DOCUMENTED CONSUMPTION MODEL (the stepper journals from this):
+ *   - combustible: each leg's units are spread across THAT leg's days at
+ *     evenly spaced boundaries — unit i of C lands on leg-day ceil(i·D/C).
+ *     With the default combustible_por_tramo = 1 the single unit lands on the
+ *     sector leg's LAST day (the burn is acknowledged on completing the jump).
+ *     A degenerate 0-day leg charges its units on the nearest existing day.
+ *   - víveres: 1 ration on every viveresCadaDias-th day of the WHOLE trip
+ *     (days are one continuous stretch, matching computeTravelPlan's
+ *     floor(totalDias / viveresCadaDias) total); viveresCadaDias <= 0 = none.
+ *
+ * Per-day amounts therefore sum EXACTLY to plan.totalCombustible /
+ * plan.totalViveres — stepping every day equals resolving the rest in one
+ * batch. (The per-leg `viveres` bookkeeping on plan.legs is ignored here on
+ * purpose: the cadence is trip-global, only the totals must agree.)
+ */
+export function travelDaySchedule(
+    plan: TravelPlan,
+    viveresCadaDias: number
+): TravelDayConsumption[] {
+    const days: TravelDayConsumption[] = Array.from({ length: Math.max(0, plan.totalDias) }, () => ({
+        combustible: 0,
+        viveres: 0,
+    }));
+    if (days.length === 0) return days;
+
+    let offset = 0; // 0-based index of the current leg's first day
+    for (const current of plan.legs) {
+        if (current.combustible > 0) {
+            if (current.dias <= 0) {
+                days[Math.min(offset, days.length - 1)].combustible += current.combustible;
+            } else {
+                for (let unit = 1; unit <= current.combustible; unit++) {
+                    const dayInLeg = Math.ceil((unit * current.dias) / current.combustible);
+                    days[Math.min(offset + dayInLeg - 1, days.length - 1)].combustible += 1;
+                }
+            }
+        }
+        offset += Math.max(0, current.dias);
+    }
+
+    if (viveresCadaDias > 0) {
+        for (let dia = viveresCadaDias; dia <= days.length; dia += viveresCadaDias) {
+            days[dia - 1].viveres += 1;
+        }
+    }
+    return days;
+}
+
+/**
+ * Last 1-based travel day of the plan's sector leg (the leg whose endpoints
+ * resolve to DIFFERENT sector roots): while `dia <= sectorLegEndDay` the trip
+ * is still on the origin side, afterwards on the destination side — the
+ * event-draw context anchors on origin/destination accordingly. Plans with no
+ * sector leg (single-root trips) return plan.totalDias: origin and
+ * destination share the root, so the anchor choice is moot.
+ */
+export function sectorLegEndDay(plan: TravelPlan, model: WorldModel): number {
+    let cumulative = 0;
+    for (const current of plan.legs) {
+        cumulative += current.dias;
+        if (sectorNodeFor(model, current.fromId) !== sectorNodeFor(model, current.toId)) {
+            return cumulative;
+        }
+    }
+    return plan.totalDias;
+}

--- a/lib/world/uiPersist.test.ts
+++ b/lib/world/uiPersist.test.ts
@@ -74,6 +74,12 @@ describe('uiStore persistence (persistUi/readPersistedUi)', () => {
         });
     });
 
+    test('eventos is a valid persisted panelTab (feature 1 migration)', () => {
+        const storage = fakeStorage();
+        persistUi({ ...SLICE, panelTab: 'eventos' }, storage);
+        expect(readPersistedUi(storage).panelTab).toBe('eventos');
+    });
+
     test('a throwing storage never propagates', () => {
         const throwing: UiStorage = {
             getItem: () => {

--- a/lib/world/uiPersist.test.ts
+++ b/lib/world/uiPersist.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { UI_PERSIST_KEY, persistUi, readPersistedUi } from './stores';
+import type { UiSlice, UiStorage } from './stores';
+
+/** In-memory Storage stand-in (bun tests run without a DOM). */
+function fakeStorage(initial: Record<string, string> = {}): UiStorage & { data: Record<string, string> } {
+    const data = { ...initial };
+    return {
+        data,
+        getItem: (key: string) => (key in data ? data[key] : null),
+        setItem: (key: string, value: string) => {
+            data[key] = value;
+        },
+    };
+}
+
+const SLICE: UiSlice = {
+    tier: 'system',
+    focusSystemId: 'sistema_verne',
+    siteListId: 'porto_verne',
+    selectedEntityId: 'torre_korinth',
+    panelTab: 'pistas',
+    mapCollapsed: true,
+    showUnknown: false,
+    viewports: {
+        sector: { x: 12.5, y: -30, k: 0.8 },
+        'system:sistema_verne': { x: 400, y: 300, k: 1.5 },
+    },
+};
+
+describe('uiStore persistence (persistUi/readPersistedUi)', () => {
+    test('round-trips the full slice through storage', () => {
+        const storage = fakeStorage();
+        persistUi(SLICE, storage);
+        expect(readPersistedUi(storage)).toEqual(SLICE);
+    });
+
+    test('null storage (SSR) is a no-op on both sides', () => {
+        expect(() => persistUi(SLICE, null)).not.toThrow();
+        expect(readPersistedUi(null)).toEqual({});
+    });
+
+    test('absent or corrupt JSON restores nothing', () => {
+        expect(readPersistedUi(fakeStorage())).toEqual({});
+        expect(readPersistedUi(fakeStorage({ [UI_PERSIST_KEY]: '{nope' }))).toEqual({});
+        expect(readPersistedUi(fakeStorage({ [UI_PERSIST_KEY]: '"str"' }))).toEqual({});
+    });
+
+    test('invalid fields drop individually while valid ones restore', () => {
+        const storage = fakeStorage({
+            [UI_PERSIST_KEY]: JSON.stringify({
+                tier: 'galaxy', // out of vocabulary -> dropped
+                focusSystemId: 42, // wrong type -> dropped
+                siteListId: null,
+                selectedEntityId: 'porto_verne',
+                panelTab: 'diario',
+                mapCollapsed: 'yes', // wrong type -> dropped
+                showUnknown: false,
+                viewports: {
+                    sector: { x: 1, y: 2, k: 1 },
+                    bad_nan: { x: Number.NaN, y: 0, k: 1 },
+                    bad_zero_k: { x: 0, y: 0, k: 0 },
+                    bad_shape: 'nope',
+                },
+            }),
+        });
+        expect(readPersistedUi(storage)).toEqual({
+            siteListId: null,
+            selectedEntityId: 'porto_verne',
+            panelTab: 'diario',
+            showUnknown: false,
+            viewports: { sector: { x: 1, y: 2, k: 1 } },
+        });
+    });
+
+    test('a throwing storage never propagates', () => {
+        const throwing: UiStorage = {
+            getItem: () => {
+                throw new Error('blocked');
+            },
+            setItem: () => {
+                throw new Error('quota');
+            },
+        };
+        expect(() => persistUi(SLICE, throwing)).not.toThrow();
+        expect(readPersistedUi(throwing)).toEqual({});
+    });
+});

--- a/lib/world/uiPersist.test.ts
+++ b/lib/world/uiPersist.test.ts
@@ -18,6 +18,7 @@ function fakeStorage(initial: Record<string, string> = {}): UiStorage & { data: 
 const SLICE: UiSlice = {
     tier: 'system',
     focusSystemId: 'sistema_verne',
+    focusPlaceId: null,
     siteListId: 'porto_verne',
     selectedEntityId: 'torre_korinth',
     panelTab: 'pistas',
@@ -78,6 +79,60 @@ describe('uiStore persistence (persistUi/readPersistedUi)', () => {
         const storage = fakeStorage();
         persistUi({ ...SLICE, panelTab: 'eventos' }, storage);
         expect(readPersistedUi(storage).panelTab).toBe('eventos');
+    });
+
+    test('round-trips a valid place tier with its focusPlaceId', () => {
+        const storage = fakeStorage();
+        const placeSlice: UiSlice = {
+            ...SLICE,
+            tier: 'place',
+            focusSystemId: 'sistema_verne',
+            focusPlaceId: 'porto_verne',
+            siteListId: null,
+        };
+        persistUi(placeSlice, storage);
+        const out = readPersistedUi(storage);
+        expect(out.tier).toBe('place');
+        expect(out.focusPlaceId).toBe('porto_verne');
+        expect(out.focusSystemId).toBe('sistema_verne');
+    });
+
+    test('a place tier with no focusPlaceId degrades to system (backdrop sistema valid)', () => {
+        const storage = fakeStorage({
+            [UI_PERSIST_KEY]: JSON.stringify({
+                tier: 'place',
+                focusSystemId: 'sistema_verne',
+                focusPlaceId: null,
+            }),
+        });
+        const out = readPersistedUi(storage);
+        expect(out.tier).toBe('system');
+        expect(out.focusPlaceId).toBeNull();
+        expect(out.focusSystemId).toBe('sistema_verne');
+    });
+
+    test('a place tier with neither focus degrades all the way to sector', () => {
+        const storage = fakeStorage({
+            [UI_PERSIST_KEY]: JSON.stringify({
+                tier: 'place',
+                focusSystemId: null,
+                focusPlaceId: null,
+            }),
+        });
+        expect(readPersistedUi(storage).tier).toBe('sector');
+    });
+
+    test('a place tier whose focusPlaceId is the wrong type degrades (id dropped first)', () => {
+        const storage = fakeStorage({
+            [UI_PERSIST_KEY]: JSON.stringify({
+                tier: 'place',
+                focusSystemId: 'sistema_verne',
+                focusPlaceId: 42, // wrong type -> dropped -> then degrade
+            }),
+        });
+        const out = readPersistedUi(storage);
+        expect(out.tier).toBe('system');
+        expect('focusPlaceId' in out).toBe(false);
     });
 
     test('a throwing storage never propagates', () => {

--- a/lib/world/uiPersist.test.ts
+++ b/lib/world/uiPersist.test.ts
@@ -22,6 +22,7 @@ const SLICE: UiSlice = {
     siteListId: 'porto_verne',
     selectedEntityId: 'torre_korinth',
     panelTab: 'pistas',
+    focusTramaId: 'deudas',
     mapCollapsed: true,
     showUnknown: false,
     viewports: {
@@ -79,6 +80,22 @@ describe('uiStore persistence (persistUi/readPersistedUi)', () => {
         const storage = fakeStorage();
         persistUi({ ...SLICE, panelTab: 'eventos' }, storage);
         expect(readPersistedUi(storage).panelTab).toBe('eventos');
+    });
+
+    test('hilos is a valid persisted panelTab (Hilos feature)', () => {
+        const storage = fakeStorage();
+        persistUi({ ...SLICE, panelTab: 'hilos' }, storage);
+        expect(readPersistedUi(storage).panelTab).toBe('hilos');
+    });
+
+    test('focusTramaId round-trips and drops a wrong-typed value', () => {
+        const storage = fakeStorage();
+        persistUi(SLICE, storage);
+        expect(readPersistedUi(storage).focusTramaId).toBe('deudas');
+        const bad = fakeStorage({
+            [UI_PERSIST_KEY]: JSON.stringify({ focusTramaId: 42 }),
+        });
+        expect('focusTramaId' in readPersistedUi(bad)).toBe(false);
     });
 
     test('round-trips a valid place tier with its focusPlaceId', () => {

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -93,6 +93,7 @@ function makeModel(): WorldModel {
         problemas: [],
         childrenOf: new Map(),
         estadoGrupo: null,
+        diario: [],
     };
 }
 

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -60,7 +60,7 @@ function faccion(id: string): FactionEntity {
 const MANIFEST: WorldManifest = {
     nombre: 'Sector Test',
     calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
-    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustiblePorTramo: 1, viveresCadaDias: 4 },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustibleCadaDias: 4, viveresCadaDias: 4 },
     medidores: ['viveres', 'combustible', 'nave'],
     regiones: [],
 };

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -95,6 +95,7 @@ function makeModel(): WorldModel {
         childrenOf: new Map(),
         estadoGrupo: null,
         diario: [],
+        musica: { bgm: [], eventPlaylists: [] },
     };
 }
 

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -90,6 +90,7 @@ function makeModel(): WorldModel {
         pnjs: [],
         pistas: [],
         tramas: [],
+        tablas: [],
         problemas: [],
         childrenOf: new Map(),
         estadoGrupo: null,

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -1,0 +1,220 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import {
+    FactionEntity,
+    PlaceEntity,
+    SystemEntity,
+    WorldEntityBase,
+    WorldManifest,
+    WorldModel,
+} from '@/types/world';
+import { ancestryChain, childNodeWithin, sectorNodeFor, tierTargetFor } from './worldNav';
+
+// ── Hand-built minimal model ────────────────────────────────────────────────
+// sistema_a
+//   └── planet_b (orbita 1)
+//         └── site_c
+//               └── room_d          (site inside a site)
+// node_e (deep space, own coords)
+//   └── pocket_f
+// huerfano_g (en: fantasma — dangling parent)
+// bucle_h <-> bucle_i               (en: cycle)
+// faccion_x                         (non-spatial)
+
+function base(id: string, tipo: string): WorldEntityBase {
+    return {
+        id,
+        tipo,
+        nombre: id,
+        filePath: `mundo/${tipo}/${id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+    };
+}
+
+function sistema(id: string): SystemEntity {
+    return { ...base(id, 'sistema'), tipo: 'sistema', coordenadas: { x: 0, y: 0 } };
+}
+
+function lugar(
+    id: string,
+    opts: { en?: string; coordenadas?: { x: number; y: number }; orbita?: number } = {}
+): PlaceEntity {
+    return {
+        ...base(id, 'estacion'),
+        en: opts.en,
+        coordenadas: opts.coordenadas,
+        orbita: opts.orbita,
+        servicios: [],
+        facciones: [],
+        acceso: 'normal',
+    };
+}
+
+function faccion(id: string): FactionEntity {
+    return { ...base(id, 'faccion'), actitud: 'neutral', objetivos: [] };
+}
+
+const MANIFEST: WorldManifest = {
+    nombre: 'Sector Test',
+    calendario: { era: 'dG', anoEpoca: 322, diasPorMes: 30, meses: ['Uno'] },
+    viaje: { diasPorUnidad: 1, intrasistemaDias: 1, combustiblePorTramo: 1, viveresCadaDias: 4 },
+    medidores: ['viveres', 'combustible', 'nave'],
+    regiones: [],
+};
+
+function makeModel(): WorldModel {
+    const sistemas = [sistema('sistema_a')];
+    const lugares = [
+        lugar('planet_b', { en: 'sistema_a', orbita: 1 }),
+        lugar('site_c', { en: 'planet_b' }),
+        lugar('room_d', { en: 'site_c' }),
+        lugar('node_e', { coordenadas: { x: 5, y: 5 } }),
+        lugar('pocket_f', { en: 'node_e' }),
+        lugar('huerfano_g', { en: 'fantasma' }),
+        lugar('bucle_h', { en: 'bucle_i' }),
+        lugar('bucle_i', { en: 'bucle_h' }),
+    ];
+    const facciones = [faccion('faccion_x')];
+    const entidades = new Map<string, WorldEntityBase>(
+        [...sistemas, ...lugares, ...facciones].map((entity) => [entity.id, entity])
+    );
+    return {
+        manifest: MANIFEST,
+        entidades,
+        sistemas,
+        lugares,
+        facciones,
+        pnjs: [],
+        pistas: [],
+        tramas: [],
+        problemas: [],
+        childrenOf: new Map(),
+        estadoGrupo: null,
+    };
+}
+
+const model = makeModel();
+
+// ── ancestryChain ───────────────────────────────────────────────────────────
+
+describe('ancestryChain', () => {
+    test('walks en: up to the root', () => {
+        expect(ancestryChain(model, 'room_d')).toEqual(['room_d', 'site_c', 'planet_b', 'sistema_a']);
+    });
+
+    test('single element for roots', () => {
+        expect(ancestryChain(model, 'sistema_a')).toEqual(['sistema_a']);
+        expect(ancestryChain(model, 'node_e')).toEqual(['node_e']);
+    });
+
+    test('keeps the dangling parent id as the last element', () => {
+        expect(ancestryChain(model, 'huerfano_g')).toEqual(['huerfano_g', 'fantasma']);
+    });
+
+    test('cycle-guarded', () => {
+        expect(ancestryChain(model, 'bucle_h')).toEqual(['bucle_h', 'bucle_i']);
+    });
+});
+
+// ── sectorNodeFor ───────────────────────────────────────────────────────────
+
+describe('sectorNodeFor', () => {
+    test('rolls a deep site up to its sistema', () => {
+        expect(sectorNodeFor(model, 'room_d')).toBe('sistema_a');
+    });
+
+    test('rolls a pocket up to its deep-space root', () => {
+        expect(sectorNodeFor(model, 'pocket_f')).toBe('node_e');
+    });
+
+    test('a sector-tier entity maps to itself', () => {
+        expect(sectorNodeFor(model, 'sistema_a')).toBe('sistema_a');
+        expect(sectorNodeFor(model, 'node_e')).toBe('node_e');
+    });
+
+    test('null when the chain dead-ends on a missing entity', () => {
+        expect(sectorNodeFor(model, 'huerfano_g')).toBeNull();
+        expect(sectorNodeFor(model, 'no_existe')).toBeNull();
+    });
+});
+
+// ── childNodeWithin ─────────────────────────────────────────────────────────
+
+describe('childNodeWithin', () => {
+    test('container itself when ids match', () => {
+        expect(childNodeWithin(model, 'sistema_a', 'sistema_a')).toBe('sistema_a');
+    });
+
+    test('direct child stays itself', () => {
+        expect(childNodeWithin(model, 'planet_b', 'sistema_a')).toBe('planet_b');
+    });
+
+    test('deeper descendants roll up to the direct child', () => {
+        expect(childNodeWithin(model, 'site_c', 'sistema_a')).toBe('planet_b');
+        expect(childNodeWithin(model, 'room_d', 'sistema_a')).toBe('planet_b');
+        expect(childNodeWithin(model, 'room_d', 'planet_b')).toBe('site_c');
+    });
+
+    test('null when the entity is outside the container', () => {
+        expect(childNodeWithin(model, 'pocket_f', 'sistema_a')).toBeNull();
+        expect(childNodeWithin(model, 'sistema_a', 'planet_b')).toBeNull();
+    });
+});
+
+// ── tierTargetFor ───────────────────────────────────────────────────────────
+
+describe('tierTargetFor', () => {
+    test('sistema -> sector tier, selected only', () => {
+        expect(tierTargetFor(model, 'sistema_a')).toEqual({
+            tier: 'sector',
+            focusSystemId: null,
+            siteListId: null,
+        });
+    });
+
+    test('direct child of a sistema -> system tier, no site list', () => {
+        expect(tierTargetFor(model, 'planet_b')).toEqual({
+            tier: 'system',
+            focusSystemId: 'sistema_a',
+            siteListId: null,
+        });
+    });
+
+    test('site -> system tier + its direct parent site list', () => {
+        expect(tierTargetFor(model, 'site_c')).toEqual({
+            tier: 'system',
+            focusSystemId: 'sistema_a',
+            siteListId: 'planet_b',
+        });
+        expect(tierTargetFor(model, 'room_d')).toEqual({
+            tier: 'system',
+            focusSystemId: 'sistema_a',
+            siteListId: 'site_c',
+        });
+    });
+
+    test('deep-space place -> sector tier', () => {
+        expect(tierTargetFor(model, 'node_e')).toEqual({
+            tier: 'sector',
+            focusSystemId: null,
+            siteListId: null,
+        });
+    });
+
+    test('entity inside a deep-space place -> sector tier + parent site list', () => {
+        expect(tierTargetFor(model, 'pocket_f')).toEqual({
+            tier: 'sector',
+            focusSystemId: null,
+            siteListId: 'node_e',
+        });
+    });
+
+    test('null for non-spatial entities, dangling chains and unknown ids', () => {
+        expect(tierTargetFor(model, 'faccion_x')).toBeNull();
+        expect(tierTargetFor(model, 'huerfano_g')).toBeNull();
+        expect(tierTargetFor(model, 'no_existe')).toBeNull();
+    });
+});

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -96,6 +96,8 @@ function makeModel(): WorldModel {
         estadoGrupo: null,
         diario: [],
         musica: { bgm: [], eventPlaylists: [] },
+        tiendas: new Map(),
+        resumen: null,
     };
 }
 

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -8,7 +8,13 @@ import {
     WorldManifest,
     WorldModel,
 } from '@/types/world';
-import { ancestryChain, childNodeWithin, sectorNodeFor, tierTargetFor } from './worldNav';
+import {
+    ancestryChain,
+    childNodeWithin,
+    placeHasPlano,
+    sectorNodeFor,
+    tierTargetFor,
+} from './worldNav';
 
 // ── Hand-built minimal model ────────────────────────────────────────────────
 // sistema_a
@@ -40,13 +46,19 @@ function sistema(id: string): SystemEntity {
 
 function lugar(
     id: string,
-    opts: { en?: string; coordenadas?: { x: number; y: number }; orbita?: number } = {}
+    opts: {
+        en?: string;
+        coordenadas?: { x: number; y: number };
+        orbita?: number;
+        poi?: { x: number; y: number };
+    } = {}
 ): PlaceEntity {
     return {
         ...base(id, 'estacion'),
         en: opts.en,
         coordenadas: opts.coordenadas,
         orbita: opts.orbita,
+        poi: opts.poi,
         servicios: [],
         facciones: [],
         acceso: 'normal',
@@ -76,11 +88,24 @@ function makeModel(): WorldModel {
         lugar('huerfano_g', { en: 'fantasma' }),
         lugar('bucle_h', { en: 'bucle_i' }),
         lugar('bucle_i', { en: 'bucle_h' }),
+        // plano_p is a direct child of sistema_a with poi-coord children ->
+        // it qualifies for a spatial Plano. poi_q1 carries poi; poi_q2 does not.
+        lugar('plano_p', { en: 'sistema_a', orbita: 2 }),
+        lugar('poi_q1', { en: 'plano_p', poi: { x: 30, y: 70 } }),
+        lugar('poi_q2', { en: 'plano_p' }),
     ];
     const facciones = [faccion('faccion_x')];
     const entidades = new Map<string, WorldEntityBase>(
         [...sistemas, ...lugares, ...facciones].map((entity) => [entity.id, entity])
     );
+    // childrenOf: inverse of `en:` (placeHasPlano reads it).
+    const childrenOf = new Map<string, string[]>();
+    for (const l of lugares) {
+        if (l.en === undefined) continue;
+        const arr = childrenOf.get(l.en) ?? [];
+        arr.push(l.id);
+        childrenOf.set(l.en, arr);
+    }
     return {
         manifest: MANIFEST,
         entidades,
@@ -92,7 +117,7 @@ function makeModel(): WorldModel {
         tramas: [],
         tablas: [],
         problemas: [],
-        childrenOf: new Map(),
+        childrenOf,
         estadoGrupo: null,
         diario: [],
         musica: { bgm: [], eventPlaylists: [] },
@@ -176,6 +201,7 @@ describe('tierTargetFor', () => {
         expect(tierTargetFor(model, 'sistema_a')).toEqual({
             tier: 'sector',
             focusSystemId: null,
+            focusPlaceId: null,
             siteListId: null,
         });
     });
@@ -184,6 +210,7 @@ describe('tierTargetFor', () => {
         expect(tierTargetFor(model, 'planet_b')).toEqual({
             tier: 'system',
             focusSystemId: 'sistema_a',
+            focusPlaceId: null,
             siteListId: null,
         });
     });
@@ -192,11 +219,13 @@ describe('tierTargetFor', () => {
         expect(tierTargetFor(model, 'site_c')).toEqual({
             tier: 'system',
             focusSystemId: 'sistema_a',
+            focusPlaceId: null,
             siteListId: 'planet_b',
         });
         expect(tierTargetFor(model, 'room_d')).toEqual({
             tier: 'system',
             focusSystemId: 'sistema_a',
+            focusPlaceId: null,
             siteListId: 'site_c',
         });
     });
@@ -205,6 +234,7 @@ describe('tierTargetFor', () => {
         expect(tierTargetFor(model, 'node_e')).toEqual({
             tier: 'sector',
             focusSystemId: null,
+            focusPlaceId: null,
             siteListId: null,
         });
     });
@@ -213,7 +243,36 @@ describe('tierTargetFor', () => {
         expect(tierTargetFor(model, 'pocket_f')).toEqual({
             tier: 'sector',
             focusSystemId: null,
+            focusPlaceId: null,
             siteListId: 'node_e',
+        });
+    });
+
+    test('a plano-eligible place itself -> system tier (drill-in opens the Plano)', () => {
+        // plano_p sits directly in sistema_a; its OWN placement is the system
+        // view — only its POI children land on the place tier.
+        expect(tierTargetFor(model, 'plano_p')).toEqual({
+            tier: 'system',
+            focusSystemId: 'sistema_a',
+            focusPlaceId: null,
+            siteListId: null,
+        });
+    });
+
+    test('a POI (parent has a Plano) -> place tier focused on the parent place', () => {
+        expect(tierTargetFor(model, 'poi_q1')).toEqual({
+            tier: 'place',
+            focusSystemId: 'sistema_a',
+            focusPlaceId: 'plano_p',
+            siteListId: null,
+        });
+        // An unplaced child of a plano-eligible place STILL routes to the place
+        // tier (it renders on the dashed "sin ubicar" ring, not a SiteList).
+        expect(tierTargetFor(model, 'poi_q2')).toEqual({
+            tier: 'place',
+            focusSystemId: 'sistema_a',
+            focusPlaceId: 'plano_p',
+            siteListId: null,
         });
     });
 
@@ -221,5 +280,23 @@ describe('tierTargetFor', () => {
         expect(tierTargetFor(model, 'faccion_x')).toBeNull();
         expect(tierTargetFor(model, 'huerfano_g')).toBeNull();
         expect(tierTargetFor(model, 'no_existe')).toBeNull();
+    });
+});
+
+// ── placeHasPlano ────────────────────────────────────────────────────────────
+
+describe('placeHasPlano', () => {
+    test('true when a direct child carries poi coords', () => {
+        expect(placeHasPlano(model, 'plano_p')).toBe(true);
+    });
+
+    test('false when children exist but none carry poi (SiteList fallback)', () => {
+        // planet_b -> site_c (no poi) -> keeps the non-spatial SiteList.
+        expect(placeHasPlano(model, 'planet_b')).toBe(false);
+    });
+
+    test('false for a childless place and unknown ids', () => {
+        expect(placeHasPlano(model, 'room_d')).toBe(false);
+        expect(placeHasPlano(model, 'no_existe')).toBe(false);
     });
 });

--- a/lib/world/worldNav.test.ts
+++ b/lib/world/worldNav.test.ts
@@ -123,6 +123,7 @@ function makeModel(): WorldModel {
         musica: { bgm: [], eventPlaylists: [] },
         tiendas: new Map(),
         resumen: null,
+        guias: [],
     };
 }
 

--- a/lib/world/worldNav.ts
+++ b/lib/world/worldNav.ts
@@ -1,29 +1,46 @@
 /**
  * Pure navigation helpers for the world map tiers (M2).
  *
- * The map has two spatial tiers (sector, system) plus a non-spatial third one
- * (SiteList). These helpers answer, for any entity id, "where does it live on
- * the map?" — used by search selection, ?e= deep links, the party-bar
- * breadcrumb and the party-marker roll-up. All pure over a WorldModel: no
- * store access, bun-testable without a DOM.
+ * The map has three spatial tiers (sector, system, place-Plano) plus a
+ * non-spatial fallback (SiteList). These helpers answer, for any entity id,
+ * "where does it live on the map?" — used by search selection, ?e= deep links,
+ * the party-bar breadcrumb and the party-marker roll-up. All pure over a
+ * WorldModel: no store access, bun-testable without a DOM.
  */
 
 import { PlaceEntity, WorldEntityBase, WorldModel } from '@/types/world';
 
-export type WorldTier = 'sector' | 'system';
+export type WorldTier = 'sector' | 'system' | 'place';
 
 /** Where an entity lives on the map: which tier to show and what to open. */
 export interface TierTarget {
     tier: WorldTier;
-    /** Sistema to focus when tier === 'system'; null at the sector tier. */
+    /** Sistema to focus when tier === 'system' or 'place'; null otherwise. */
     focusSystemId: string | null;
-    /** Direct parent whose SiteList (tier 3) contains the entity, if any. */
+    /** Place whose spatial Plano (tier 3) to focus when tier === 'place'; null otherwise. */
+    focusPlaceId: string | null;
+    /** Direct parent whose SiteList (non-spatial fallback) contains the entity, if any. */
     siteListId: string | null;
 }
 
 function isPlace(entity: WorldEntityBase | undefined): entity is PlaceEntity {
     // Every scanned lugar carries `servicios` (buildLugar defaults it to []).
     return entity !== undefined && 'servicios' in entity;
+}
+
+/**
+ * A place qualifies for a spatial Plano when at least one of its direct
+ * children carries local `poi:{x,y}` coords. Such a place renders as PlaceView
+ * (POIs on a floor-plan); a place with children but no poi ones stays a
+ * SiteList. Uses childrenOf so it matches what the map actually renders.
+ */
+export function placeHasPlano(model: WorldModel, placeId: string): boolean {
+    const childIds = model.childrenOf.get(placeId);
+    if (!childIds) return false;
+    return childIds.some((id) => {
+        const child = model.entidades.get(id);
+        return isPlace(child) && child.poi !== undefined;
+    });
 }
 
 /** [id, parent, grandparent, ...] following `en:` up to the root (cycle-guarded). */
@@ -74,6 +91,8 @@ export function childNodeWithin(
  *   - sistema            -> sector tier, selected (drill-in is a separate act)
  *   - deep-space lugar   -> sector tier
  *   - lugar in a sistema -> system tier focused on the root sistema
+ *   - POI (parent has a Plano) -> place tier focused on its parent place, so
+ *     search/deep-link opens the spatial Plano with the POI selected
  *   - deeper site        -> additionally opens its direct parent's SiteList
  * Null for non-spatial entities (facciones, pnjs, pistas, tramas) and for
  * places whose `en:` chain dangles — selection still works, the map stays put.
@@ -83,7 +102,7 @@ export function tierTargetFor(model: WorldModel, entityId: string): TierTarget |
     if (!entity) return null;
 
     if (entity.tipo === 'sistema') {
-        return { tier: 'sector', focusSystemId: null, siteListId: null };
+        return { tier: 'sector', focusSystemId: null, focusPlaceId: null, siteListId: null };
     }
     if (!isPlace(entity)) return null;
 
@@ -92,15 +111,28 @@ export function tierTargetFor(model: WorldModel, entityId: string): TierTarget |
     const root = model.entidades.get(rootId);
     if (!root) return null; // dangling `en:` — no reliable map placement
 
-    const parentListId = chain.length > 1 ? chain[1] : null;
+    const parentId = chain.length > 1 ? chain[1] : null;
+
+    // A POI: its direct parent renders a spatial Plano. Land on that Plano
+    // (place tier) so the POI shows selected on the floor-plan. The Plano's
+    // backdrop sistema is the ancestor sistema (rootId when it is a sistema).
+    if (parentId !== null && placeHasPlano(model, parentId)) {
+        return {
+            tier: 'place',
+            focusSystemId: root.tipo === 'sistema' ? rootId : null,
+            focusPlaceId: parentId,
+            siteListId: null,
+        };
+    }
 
     if (root.tipo === 'sistema') {
         return {
             tier: 'system',
             focusSystemId: rootId,
+            focusPlaceId: null,
             // Direct children sit on the system view itself; deeper sites open
             // their direct parent's list so the row highlights.
-            siteListId: parentListId === rootId ? null : parentListId,
+            siteListId: parentId === rootId ? null : parentId,
         };
     }
 
@@ -109,6 +141,7 @@ export function tierTargetFor(model: WorldModel, entityId: string): TierTarget |
     return {
         tier: 'sector',
         focusSystemId: null,
-        siteListId: entityId === rootId ? null : parentListId,
+        focusPlaceId: null,
+        siteListId: entityId === rootId ? null : parentId,
     };
 }

--- a/lib/world/worldNav.ts
+++ b/lib/world/worldNav.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure navigation helpers for the world map tiers (M2).
+ *
+ * The map has two spatial tiers (sector, system) plus a non-spatial third one
+ * (SiteList). These helpers answer, for any entity id, "where does it live on
+ * the map?" — used by search selection, ?e= deep links, the party-bar
+ * breadcrumb and the party-marker roll-up. All pure over a WorldModel: no
+ * store access, bun-testable without a DOM.
+ */
+
+import { PlaceEntity, WorldEntityBase, WorldModel } from '@/types/world';
+
+export type WorldTier = 'sector' | 'system';
+
+/** Where an entity lives on the map: which tier to show and what to open. */
+export interface TierTarget {
+    tier: WorldTier;
+    /** Sistema to focus when tier === 'system'; null at the sector tier. */
+    focusSystemId: string | null;
+    /** Direct parent whose SiteList (tier 3) contains the entity, if any. */
+    siteListId: string | null;
+}
+
+function isPlace(entity: WorldEntityBase | undefined): entity is PlaceEntity {
+    // Every scanned lugar carries `servicios` (buildLugar defaults it to []).
+    return entity !== undefined && 'servicios' in entity;
+}
+
+/** [id, parent, grandparent, ...] following `en:` up to the root (cycle-guarded). */
+export function ancestryChain(model: WorldModel, startId: string): string[] {
+    const chain: string[] = [];
+    const seen = new Set<string>();
+    let id: string | undefined = startId;
+    while (id !== undefined && !seen.has(id)) {
+        seen.add(id);
+        chain.push(id);
+        const entity = model.entidades.get(id) as Partial<PlaceEntity> | undefined;
+        id = entity?.en;
+    }
+    return chain;
+}
+
+/**
+ * Sector-tier node representing an entity: the root of its `en:` chain
+ * (a sistema or a deep-space lugar). Null when the chain dead-ends on a
+ * missing entity (dangling ref) — there is nothing to mark on the map.
+ */
+export function sectorNodeFor(model: WorldModel, entityId: string): string | null {
+    const chain = ancestryChain(model, entityId);
+    const rootId = chain[chain.length - 1];
+    return rootId !== undefined && model.entidades.has(rootId) ? rootId : null;
+}
+
+/**
+ * Node representing `entityId` inside `containerId`'s view: the container
+ * itself when they match, otherwise the container's DIRECT child on the
+ * entity's ancestry chain (e.g. the party at a site rolls up to the site's
+ * station at the system tier). Null when the entity is not inside the
+ * container.
+ */
+export function childNodeWithin(
+    model: WorldModel,
+    entityId: string,
+    containerId: string
+): string | null {
+    if (entityId === containerId) return containerId;
+    const chain = ancestryChain(model, entityId);
+    const index = chain.indexOf(containerId);
+    return index > 0 ? chain[index - 1] : null;
+}
+
+/**
+ * Map placement for an entity (search/deep-link navigation):
+ *   - sistema            -> sector tier, selected (drill-in is a separate act)
+ *   - deep-space lugar   -> sector tier
+ *   - lugar in a sistema -> system tier focused on the root sistema
+ *   - deeper site        -> additionally opens its direct parent's SiteList
+ * Null for non-spatial entities (facciones, pnjs, pistas, tramas) and for
+ * places whose `en:` chain dangles — selection still works, the map stays put.
+ */
+export function tierTargetFor(model: WorldModel, entityId: string): TierTarget | null {
+    const entity = model.entidades.get(entityId);
+    if (!entity) return null;
+
+    if (entity.tipo === 'sistema') {
+        return { tier: 'sector', focusSystemId: null, siteListId: null };
+    }
+    if (!isPlace(entity)) return null;
+
+    const chain = ancestryChain(model, entityId);
+    const rootId = chain[chain.length - 1];
+    const root = model.entidades.get(rootId);
+    if (!root) return null; // dangling `en:` — no reliable map placement
+
+    const parentListId = chain.length > 1 ? chain[1] : null;
+
+    if (root.tipo === 'sistema') {
+        return {
+            tier: 'system',
+            focusSystemId: rootId,
+            // Direct children sit on the system view itself; deeper sites open
+            // their direct parent's list so the row highlights.
+            siteListId: parentListId === rootId ? null : parentListId,
+        };
+    }
+
+    // Deep-space root (own coords, no `en:`) — sector tier; interior entities
+    // open their direct parent's SiteList on top of it.
+    return {
+        tier: 'sector',
+        focusSystemId: null,
+        siteListId: entityId === rootId ? null : parentListId,
+    };
+}

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 import { test, expect, describe, beforeEach } from 'bun:test';
-import { makeHandle, FileTree } from '@/lib/testUtils/mockFs';
+import { makeHandle, FileTree, MockDirectoryHandle } from '@/lib/testUtils/mockFs';
 import { hasWorld, scanWorldFolder } from './worldScanner';
 import { useWorldStore, useUiStore } from './stores';
 import { Lead, PlaceEntity, Trama } from '@/types/world';
@@ -250,8 +250,8 @@ describe('scanWorldFolder — happy path', () => {
         });
 
         // 1 manifest + 1 estado/grupo.md + 2 sistemas + 1 faccion + 1 pnj + 2 pistas
-        // + 1 trama + 3 lugares + 1 carpeta
-        const total = 13;
+        // + 1 trama + 3 lugares + 1 carpeta + 1 diario
+        const total = 14;
         expect(calls.length).toBeGreaterThan(0);
         expect(calls[0]).toEqual([1, total]);
         expect(calls[calls.length - 1]).toEqual([total, total]);
@@ -554,6 +554,245 @@ describe('scanWorldFolder — estado del grupo', () => {
         ).toBe(false);
         expect(model.estadoGrupo!.ubicacion).toBe('porto_verne');
         expect(model.estadoGrupo!.rumbo).toEqual({ destino: 'sistema_kovar', llegadaDia: 12 });
+    });
+
+    test('read failure on an existing grupo.md is an error with the cause, not absence', async () => {
+        const handle = makeHandle('campaign', {
+            mundo: {
+                'mundo.md': FULL_MANIFEST,
+                estado: { 'grupo.md': '---\ncreditos: 5\n---\n' },
+            },
+        });
+        const root = handle as unknown as MockDirectoryHandle;
+        const mundo = await root.getDirectoryHandle('mundo');
+        const estado = await mundo.getDirectoryHandle('estado');
+        const grupo = await estado.getFileHandle('grupo.md');
+        grupo.getFile = async () => {
+            throw new Error('NotReadableError: fallo de disco');
+        };
+
+        const model = await scanWorldFolder(handle);
+
+        expect(model.estadoGrupo).toBeNull();
+        const issues = model.problemas.filter((p) => p.archivo === 'mundo/estado/grupo.md');
+        expect(issues).toHaveLength(1);
+        expect(issues[0].nivel).toBe('error');
+        expect(issues[0].mensaje).toContain('No se pudo leer');
+        expect(issues[0].mensaje).toContain('NotReadableError: fallo de disco');
+    });
+});
+
+// ── diario/ → model.diario + journal overlay (M3) ───────────────────────────
+
+describe('scanWorldFolder — diario', () => {
+    const DIARIO_BASE = {
+        'mundo.md': FULL_MANIFEST,
+        sistemas: {
+            'sys.md': '---\ncoordenadas: {x: 0, y: 0}\nconocimiento: visitado\n---\n',
+        },
+        lugares: {
+            'planeta_x.md': '---\nen: sys\nconocimiento: desconocido\n---\n',
+            'base_y.md': '---\nen: planeta_x\nconocimiento: desconocido\n---\n',
+        },
+    };
+
+    function journalFile(fields: {
+        sesion: number;
+        fecha: string;
+        procesado: boolean;
+        lines?: string[];
+    }): string {
+        const body = (fields.lines ?? []).join('\n');
+        return `---\ntipo: diario\nsesion: ${fields.sesion}\nfecha_real: ${fields.fecha}\ndia_inicio: 1\ndia_fin: null\nprocesado: ${fields.procesado}\n---\n\n${body}\n`;
+    }
+
+    test('parses diario files into model.diario sorted by fecha/sesion', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    diario: {
+                        // Names deliberately out of chronological order.
+                        'a_2026-07-10_s02.md': journalFile({
+                            sesion: 2,
+                            fecha: '2026-07-10',
+                            procesado: true,
+                            lines: ['- [20:00] gasto: 100 | taxi orbital'],
+                        }),
+                        'z_2026-07-01_s01.md': journalFile({
+                            sesion: 1,
+                            fecha: '2026-07-01',
+                            procesado: true,
+                        }),
+                    },
+                },
+            })
+        );
+
+        expect(model.diario.map((d) => d.sesion)).toEqual([1, 2]);
+        expect(model.diario[1].fechaReal).toBe('2026-07-10');
+        expect(model.diario[1].procesado).toBe(true);
+        expect(model.diario[1].entradas).toEqual([
+            { hora: '20:00', tipo: 'gasto', payload: '100', comentario: 'taxi orbital' },
+        ]);
+        // journals never become entities
+        expect(model.entidades.size).toBe(3);
+    });
+
+    test('unprocessed sabe bumps knowledge, never lowers it', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    diario: {
+                        '2026-07-01_s01.md': journalFile({
+                            sesion: 1,
+                            fecha: '2026-07-01',
+                            procesado: false,
+                            lines: [
+                                '- [20:00] sabe: planeta_x desconocido->rumoreado',
+                                '- [20:05] sabe: sys visitado->conocido',
+                                '- [20:10] sabe: no_existe desconocido->conocido',
+                                '- [20:15] sabe: base_y basura',
+                            ],
+                        }),
+                    },
+                },
+            })
+        );
+
+        expect(model.entidades.get('planeta_x')!.conocimiento).toBe('rumoreado');
+        // never lowered: sys stays visitado despite the logged ->conocido
+        expect(model.entidades.get('sys')!.conocimiento).toBe('visitado');
+        // unknown ids and bad payloads are skipped silently
+        expect(model.entidades.get('base_y')!.conocimiento).toBe('desconocido');
+    });
+
+    test('procesado: true journals do NOT overlay', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    diario: {
+                        '2026-07-01_s01.md': journalFile({
+                            sesion: 1,
+                            fecha: '2026-07-01',
+                            procesado: true,
+                            lines: ['- [20:00] sabe: planeta_x desconocido->rumoreado'],
+                        }),
+                    },
+                },
+            })
+        );
+
+        expect(model.entidades.get('planeta_x')!.conocimiento).toBe('desconocido');
+    });
+
+    test('unprocessed llegada: destination visitado, ancestors at least conocido', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    diario: {
+                        '2026-07-01_s01.md': journalFile({
+                            sesion: 1,
+                            fecha: '2026-07-01',
+                            procesado: false,
+                            lines: ['- [21:00] llegada: base_y | dia 5'],
+                        }),
+                    },
+                },
+            })
+        );
+
+        expect(model.entidades.get('base_y')!.conocimiento).toBe('visitado');
+        expect(model.entidades.get('planeta_x')!.conocimiento).toBe('conocido');
+        // already above conocido — never lowered
+        expect(model.entidades.get('sys')!.conocimiento).toBe('visitado');
+    });
+
+    test('overlay runs before accionable derivation and orphan avisos', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    pistas: {
+                        'p_x.md': '---\nestado: activa\ndonde: planeta_x\n---\n',
+                    },
+                    diario: {
+                        '2026-07-01_s01.md': journalFile({
+                            sesion: 1,
+                            fecha: '2026-07-01',
+                            procesado: false,
+                            lines: ['- [21:00] llegada: base_y | dia 5'],
+                        }),
+                    },
+                },
+            })
+        );
+
+        // planeta_x became conocido via the journal, so the lead is actionable
+        expect((model.entidades.get('p_x') as Lead).accionable).toBe(true);
+        expect(
+            model.problemas.some((p) => p.mensaje.includes('lugar desconocido'))
+        ).toBe(false);
+        // and base_y (now visitado) is no longer an orphan candidate
+        expect(
+            model.problemas.some((p) => p.archivo === 'mundo/lugares/base_y.md')
+        ).toBe(false);
+    });
+
+    test('stale aviso: unprocessed diario older than the newest one', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    diario: {
+                        '2026-07-01_s01.md': journalFile({
+                            sesion: 1,
+                            fecha: '2026-07-01',
+                            procesado: false,
+                        }),
+                        '2026-07-10_s02.md': journalFile({
+                            sesion: 2,
+                            fecha: '2026-07-10',
+                            procesado: false,
+                        }),
+                    },
+                },
+            })
+        );
+
+        const stale = model.problemas.filter((p) =>
+            p.mensaje.includes('Diario sin procesar')
+        );
+        // only the OLD unprocessed journal warns; the newest one is the
+        // normal "last session awaiting maintenance" state
+        expect(stale).toHaveLength(1);
+        expect(stale[0].nivel).toBe('aviso');
+        expect(stale[0].archivo).toBe('mundo/diario/2026-07-01_s01.md');
+    });
+
+    test('tolerant parsing: missing frontmatter falls back to the filename', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    ...DIARIO_BASE,
+                    diario: {
+                        '2026-07-12_s08.md': '- [18:02] inicio: dia 4128 @ base_y\ngarbage line\n',
+                    },
+                },
+            })
+        );
+
+        expect(model.diario).toHaveLength(1);
+        const day = model.diario[0];
+        expect(day.sesion).toBe(8);
+        expect(day.fechaReal).toBe('2026-07-12');
+        expect(day.procesado).toBe(false);
+        expect(day.diaInicio).toBeNull();
+        expect(day.entradas).toHaveLength(1);
+        expect(day.entradas[0].tipo).toBe('inicio');
     });
 });
 

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -1466,6 +1466,49 @@ describe('scanWorldFolder — resumen', () => {
     });
 });
 
+// ── GM guías (GUIA_FILES allowlist) → model.guias ───────────────────────────
+
+describe('scanWorldFolder — guias', () => {
+    test('collects present guía files, first-heading preferred over the fallback titulo', async () => {
+        const tree = happyTree();
+        // _RUN_OF_SHOW.md has a leading heading -> that heading wins the title.
+        (tree.mundo as FileTree)['_RUN_OF_SHOW.md'] =
+            '# Guion de la sesión\n\nEscena 1: el muelle.';
+        // _REPARTO_DE_MANANA.md has NO heading -> falls back to the mapping titulo.
+        (tree.mundo as FileTree)['_REPARTO_DE_MANANA.md'] = 'Xiao, Chesco, Kael Voss.';
+        const model = await scanWorldFolder(makeHandle('campaign', tree));
+
+        expect(model.guias).toHaveLength(2);
+        // Allowlist order: _RUN_OF_SHOW before _REPARTO_DE_MANANA.
+        expect(model.guias[0]).toEqual({
+            id: '_RUN_OF_SHOW',
+            titulo: 'Guion de la sesión',
+            content: '# Guion de la sesión\n\nEscena 1: el muelle.',
+        });
+        expect(model.guias[1]).toEqual({
+            id: '_REPARTO_DE_MANANA',
+            titulo: 'Reparto de hoy',
+            content: 'Xiao, Chesco, Kael Voss.',
+        });
+        // Guías are never entities.
+        expect(model.entidades.has('_RUN_OF_SHOW')).toBe(false);
+    });
+
+    test('skips absent allowlisted files (mixed present/absent)', async () => {
+        const tree = happyTree();
+        (tree.mundo as FileTree)['_MAPA_DE_HILOS.md'] = '# Hilos\n\nContrabando -> Brasa.';
+        const model = await scanWorldFolder(makeHandle('campaign', tree));
+
+        expect(model.guias.map((g) => g.id)).toEqual(['_MAPA_DE_HILOS']);
+    });
+
+    test('empty array and NO aviso when no guía files are present', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+        expect(model.guias).toEqual([]);
+        expect(model.problemas.some((p) => p.archivo.includes('RUN_OF_SHOW'))).toBe(false);
+    });
+});
+
 // ── Stores (headless zustand) ───────────────────────────────────────────────
 
 describe('worldStore', () => {

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -80,7 +80,16 @@ function happyTree(): FileTree {
                 'la_red_despierta.md':
                     '---\nrol: principal\nestado: activa\nreloj: {actual: 1, max: 6}\nlugares_clave: [porto_verne, nodo_sigma]\nfacciones: [consorcio_tetrad]\n---\n',
             },
-            eventos: { 'viaje_frontera.md': '---\ncontexto: viaje\n---\n## v01\n' },
+            eventos: {
+                'viaje_frontera.md':
+                    '---\ncontexto: viaje\nregiones: [frontera]\nsesgos:\n' +
+                    '  - {si: combustible<=1, etiquetas: [averia], peso: 2}\n---\n' +
+                    '## v01 — Baliza de socorro {peso=3; si=region:frontera; etiquetas=recurso}\n\n' +
+                    ':::leer\nUna baliza parpadea en el vacio.\n:::\n\n' +
+                    ':::efecto\n- ganancia: 400 | chatarra\n- medidor: combustible -1\n:::\n\n' +
+                    '## v02 — Fallo de motor {etiquetas=averia}\n\n:::gm\nTirada de nave CD 17.\n:::\n',
+                '_borrador_eventos.md': '---\ncontexto: viaje\n---\n',
+            },
             estado: { 'grupo.md': '---\ncreditos: 100\n---\n' },
             diario: { '2026-07-12_s08.md': '---\nsesion: 8\n---\n' },
         },
@@ -122,7 +131,7 @@ describe('scanWorldFolder — happy path', () => {
         expect(model.tramas.map((t) => t.id)).toEqual(['la_red_despierta']);
         expect(model.entidades.size).toBe(11);
 
-        // eventos/estado/diario contents never become entities in M1
+        // eventos/estado/diario contents never become entities
         expect(model.entidades.has('viaje_frontera')).toBe(false);
         expect(model.entidades.has('grupo')).toBe(false);
 
@@ -207,6 +216,49 @@ describe('scanWorldFolder — happy path', () => {
         expect(planet.playable).toBeUndefined();
     });
 
+    test('parses eventos/ into model.tablas (M4), outside the entity map', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        expect(model.tablas).toHaveLength(1); // _borrador_eventos.md ignored
+        const tabla = model.tablas[0];
+        expect(tabla.id).toBe('viaje_frontera');
+        expect(tabla.filePath).toBe('mundo/eventos/viaje_frontera.md');
+        expect(tabla.contexto).toBe('viaje');
+        expect(tabla.regiones).toEqual(['frontera']);
+        expect(tabla.sesgos).toEqual([{ si: 'combustible<=1', etiquetas: ['averia'], peso: 2 }]);
+
+        expect(tabla.eventos.map((e) => e.id)).toEqual(['v01', 'v02']);
+        const v01 = tabla.eventos[0];
+        expect(v01.titulo).toBe('Baliza de socorro');
+        expect(v01.peso).toBe(3);
+        expect(v01.si).toEqual(['region:frontera']);
+        expect(v01.etiquetas).toEqual(['recurso']);
+        expect(v01.efectos).toEqual([
+            { key: 'ganancia', value: '400 | chatarra' },
+            { key: 'medidor', value: 'combustible -1' },
+        ]);
+        // :::efecto stripped from the cuerpo; the other ::: blocks stay.
+        expect(v01.cuerpo).toContain(':::leer');
+        expect(v01.cuerpo).not.toContain('efecto');
+        expect(tabla.eventos[1].peso).toBe(1);
+    });
+
+    test('eventos/ issues surface in model.problemas', async () => {
+        const tree = happyTree();
+        ((tree.mundo as FileTree).eventos as FileTree)['tabla_rota.md'] =
+            '---\ncontexto: viaje\n---\n## x01 — Sabotaje {si=cuando quiera el GM}\n\n## sin encabezado valido\n';
+        const model = await scanWorldFolder(makeHandle('campaign', tree));
+
+        expect(model.tablas).toHaveLength(2);
+        const rota = model.tablas.find((t) => t.id === 'tabla_rota')!;
+        expect(rota.eventos).toHaveLength(1); // bad si keeps the event; bad heading drops it
+        const avisos = model.problemas.filter((p) => p.archivo === 'mundo/eventos/tabla_rota.md');
+        expect(avisos).toHaveLength(2);
+        expect(avisos.every((p) => p.nivel === 'aviso')).toBe(true);
+        expect(avisos.some((p) => p.mensaje.includes('Condición no interpretable'))).toBe(true);
+        expect(avisos.some((p) => p.mensaje.includes('Encabezado de evento'))).toBe(true);
+    });
+
     test('childrenOf: sistemas + deep-space roots, en-chains as children', async () => {
         const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
 
@@ -250,8 +302,8 @@ describe('scanWorldFolder — happy path', () => {
         });
 
         // 1 manifest + 1 estado/grupo.md + 2 sistemas + 1 faccion + 1 pnj + 2 pistas
-        // + 1 trama + 3 lugares + 1 carpeta + 1 diario
-        const total = 14;
+        // + 1 trama + 3 lugares + 1 carpeta + 1 tabla de eventos + 1 diario
+        const total = 15;
         expect(calls.length).toBeGreaterThan(0);
         expect(calls[0]).toEqual([1, total]);
         expect(calls[calls.length - 1]).toEqual([total, total]);
@@ -430,7 +482,10 @@ describe('scanWorldFolder — accionable + manifest defaults', () => {
                 pistas: {
                     'p_activa.md': '---\nestado: activa\ndonde: sitio_conocido\n---\n',
                     'p_oculta.md': '---\nestado: activa\ndonde: sitio_oculto\n---\n',
-                    'p_manual.md': '---\nestado: en_curso\nrequisitos: [combustible<=2]\n---\n',
+                    'p_falsa.md': '---\nestado: en_curso\nrequisitos: ["combustible<=2"]\n---\n',
+                    'p_manual.md':
+                        '---\nestado: en_curso\nrequisitos: ["manual: decide el GM"]\n---\n',
+                    'p_rota.md': '---\nestado: en_curso\nrequisitos: [si el GM quiere]\n---\n',
                     'p_rumor.md': '---\nestado: rumor\n---\n',
                     'p_resuelta.md': '---\nestado: resuelta\ndonde: sitio_conocido\n---\n',
                 },
@@ -444,9 +499,26 @@ describe('scanWorldFolder — accionable + manifest defaults', () => {
 
         expect(accionableOf('p_activa')).toBe(true); // activa @ conocido
         expect(accionableOf('p_oculta')).toBe(false); // donde desconocido
-        expect(accionableOf('p_manual')).toBe('manual'); // requisitos -> según GM (evalCondition llega en M4)
+        // Sin estado/grupo.md las condiciones evalúan contra los defaults
+        // (combustible 3): 3 <= 2 es false — ya no degrada a 'manual' (M4).
+        expect(accionableOf('p_falsa')).toBe(false);
+        expect(accionableOf('p_manual')).toBe('manual'); // requisito manual: -> según GM
+        expect(accionableOf('p_rota')).toBe('manual'); // condición no interpretable
         expect(accionableOf('p_rumor')).toBe(false); // estado rumor
         expect(accionableOf('p_resuelta')).toBe(false); // estado terminal
+    });
+
+    test('aviso: requisito no interpretable', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', derivationsTree()));
+
+        const avisos = model.problemas.filter(
+            (p) => p.nivel === 'aviso' && p.mensaje.includes('Requisito no interpretable')
+        );
+        expect(avisos).toHaveLength(1);
+        expect(avisos[0].archivo).toBe('mundo/pistas/p_rota.md');
+        expect(avisos[0].mensaje).toContain('si el GM quiere');
+        // manual: entries are for the GM by design — never an aviso
+        expect(model.problemas.some((p) => p.archivo === 'mundo/pistas/p_manual.md')).toBe(false);
     });
 
     test('aviso: pista activa at a desconocido place', async () => {
@@ -484,6 +556,93 @@ describe('scanWorldFolder — accionable + manifest defaults', () => {
         expect(model.manifest.medidores).toEqual(['viveres', 'combustible', 'nave']);
         expect(model.manifest.regiones).toEqual([]);
         expect(model.manifest.calendario.diasPorMes).toBe(30);
+    });
+});
+
+// ── Requisitos evaluados contra estado/grupo.md (M4) ────────────────────────
+
+describe('scanWorldFolder — requisitos con estado del grupo', () => {
+    function requisitosTree(pistas: Record<string, string>): FileTree {
+        return {
+            mundo: {
+                'mundo.md': FULL_MANIFEST, // regiones: [nucleo, frontera]
+                sistemas: {
+                    'sys_f.md':
+                        '---\ncoordenadas: {x: 0, y: 0}\nregion: frontera\nconocimiento: visitado\n---\n',
+                },
+                lugares: {
+                    'base_f.md':
+                        '---\nen: sys_f\nconocimiento: visitado\netiquetas: [pirata]\n---\n',
+                },
+                pistas,
+                estado: {
+                    'grupo.md':
+                        '---\ndia_mundo: 4200\nubicacion: base_f\ncreditos: 1000\n' +
+                        'medidores: {viveres: 3, combustible: 1, nave: 2}\n---\n',
+                },
+            },
+        };
+    }
+
+    test('condiciones ciertas -> true; falsas -> false; manual gana a false', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                requisitosTree({
+                    'p_ok.md':
+                        '---\nestado: activa\nrequisitos: ["creditos>=800", "region:frontera", "combustible<=1"]\n---\n',
+                    'p_conjuncion.md':
+                        '---\nestado: activa\nrequisitos: ["etiqueta:pirata&dia>=100"]\n---\n',
+                    'p_pobre.md': '---\nestado: activa\nrequisitos: ["creditos>=2000"]\n---\n',
+                    'p_mixta.md':
+                        '---\nestado: activa\nrequisitos: ["creditos>=2000", "manual: decide el GM"]\n---\n',
+                    'p_medidor_raro.md':
+                        '---\nestado: activa\nrequisitos: ["oxigeno<=2"]\n---\n',
+                })
+            )
+        );
+        const accionableOf = (id: string) => (model.entidades.get(id) as Lead).accionable;
+
+        expect(accionableOf('p_ok')).toBe(true);
+        expect(accionableOf('p_conjuncion')).toBe(true); // etiquetas del lugar actual + dia_mundo
+        expect(accionableOf('p_pobre')).toBe(false);
+        expect(accionableOf('p_mixta')).toBe('manual'); // manual/null dominan sobre false
+        expect(accionableOf('p_medidor_raro')).toBe('manual'); // medidor desconocido -> null
+        // sintaxis correcta: el medidor desconocido NO es un aviso de requisito
+        expect(
+            model.problemas.some((p) => p.mensaje.includes('Requisito no interpretable'))
+        ).toBe(false);
+    });
+});
+
+// ── Aviso: nombre de medidor con espacios (TODO del verificador M3) ─────────
+
+describe('scanWorldFolder — medidores del manifiesto', () => {
+    test('aviso cuando un nombre de medidor contiene espacios', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md':
+                        '---\nnombre: Mini\nmedidores: [viveres, celda de energia, nave]\n---\n',
+                },
+            })
+        );
+
+        expect(model.manifest.medidores).toEqual(['viveres', 'celda de energia', 'nave']);
+        const avisos = model.problemas.filter((p) =>
+            p.mensaje.includes('Nombre de medidor con espacios')
+        );
+        expect(avisos).toHaveLength(1);
+        expect(avisos[0].nivel).toBe('aviso');
+        expect(avisos[0].archivo).toBe('mundo/mundo.md');
+        expect(avisos[0].mensaje).toContain('"celda de energia"');
+    });
+
+    test('sin aviso para nombres sin espacios', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+        expect(
+            model.problemas.some((p) => p.mensaje.includes('Nombre de medidor'))
+        ).toBe(false);
     });
 });
 

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -50,6 +50,13 @@ function happyTree(): FileTree {
                     '---\ntipo: estacion\nen: kovar_iii\nconocimiento: rumoreado\nfacciones:\n  - {faccion: consorcio_tetrad, nivel: dominante}\n---\n',
                 'nodo_sigma.md':
                     '---\ntipo: nodo\ncoordenadas: {x: 55, y: 60}\nconocimiento: rumoreado\nacceso: portal\n---\n',
+                // POI child of porto_verne (Plano tier): valid local poi coords.
+                'bar_graviton.md':
+                    '---\ntipo: estructura\nnombre: Bar Graviton\nen: porto_verne\nconocimiento: visitado\npoi: {x: 50, y: 48}\n---\n',
+                // POI-shaped file with a MALFORMED poi: must parse to poi=undefined
+                // silently (poi is optional — no aviso, no error).
+                'muelle_roto.md':
+                    '---\ntipo: estructura\nnombre: Muelle Roto\nen: porto_verne\nconocimiento: conocido\npoi: {x: hola}\n---\n',
                 '_apuntes.md': '---\ntipo: nodo\n---\n',
                 BOCETOS: { 'idea.md': 'boceto suelto' },
                 porto_verne: {
@@ -120,8 +127,10 @@ describe('scanWorldFolder — happy path', () => {
 
         expect(model.sistemas.map((s) => s.id).sort()).toEqual(['sistema_kovar', 'sistema_verne']);
         expect(model.lugares.map((l) => l.id).sort()).toEqual([
+            'bar_graviton',
             'estacion_thal',
             'kovar_iii',
+            'muelle_roto',
             'nodo_sigma',
             'porto_verne',
         ]);
@@ -129,7 +138,7 @@ describe('scanWorldFolder — happy path', () => {
         expect(model.pnjs.map((p) => p.id)).toEqual(['kael_zara']);
         expect(model.pistas.map((p) => p.id).sort()).toEqual(['deuda_kael', 'rumor_sigma']);
         expect(model.tramas.map((t) => t.id)).toEqual(['la_red_despierta']);
-        expect(model.entidades.size).toBe(11);
+        expect(model.entidades.size).toBe(13);
 
         // eventos/estado/diario contents never become entities
         expect(model.entidades.has('viaje_frontera')).toBe(false);
@@ -183,6 +192,23 @@ describe('scanWorldFolder — happy path', () => {
         expect(trama.estadoTrama).toBe('activa');
         expect(trama.reloj).toEqual({ actual: 1, max: 6 });
         expect(trama.lugaresClave).toEqual(['porto_verne', 'nodo_sigma']);
+    });
+
+    test('parses poi: valid coords land on the place; malformed poi is silently dropped', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        const bar = model.entidades.get('bar_graviton') as PlaceEntity;
+        expect(bar.poi).toEqual({ x: 50, y: 48 });
+        expect(bar.en).toBe('porto_verne');
+
+        // Malformed poi -> undefined, and NOT a validation problema (poi is optional).
+        const roto = model.entidades.get('muelle_roto') as PlaceEntity;
+        expect(roto.poi).toBeUndefined();
+        expect(model.problemas.some((p) => p.archivo === 'mundo/lugares/muelle_roto.md')).toBe(false);
+
+        // A lugar without any poi frontmatter has poi undefined.
+        const kovar = model.entidades.get('kovar_iii') as PlaceEntity;
+        expect(kovar.poi).toBeUndefined();
     });
 
     test('only aviso: out-of-vocabulary servicio', async () => {
@@ -306,7 +332,10 @@ describe('scanWorldFolder — happy path', () => {
         expect(model.childrenOf.get('sistema_kovar')).toEqual(['kovar_iii']);
         expect(model.childrenOf.get('kovar_iii')).toEqual(['estacion_thal']);
         expect(model.childrenOf.get('nodo_sigma')).toEqual([]); // deep-space root
-        expect(model.childrenOf.has('porto_verne')).toBe(false); // leaf, not a root
+        // porto_verne now parents two POI children (bar_graviton + muelle_roto),
+        // so it appears in childrenOf (sorted by id: no orbita).
+        expect(model.childrenOf.get('porto_verne')).toEqual(['bar_graviton', 'muelle_roto']);
+        expect(model.childrenOf.has('estacion_thal')).toBe(false); // leaf, not a root
     });
 
     test('region inheritance walks the en-chain to the nearest ancestor', async () => {
@@ -342,8 +371,9 @@ describe('scanWorldFolder — happy path', () => {
         });
 
         // 1 manifest + 1 estado/grupo.md + 2 sistemas + 1 faccion + 1 pnj + 2 pistas
-        // + 1 trama + 3 lugares + 1 carpeta + 1 tabla de eventos + 1 diario
-        const total = 15;
+        // + 1 trama + 5 lugares (incl. bar_graviton + muelle_roto) + 1 carpeta
+        // + 1 tabla de eventos + 1 diario
+        const total = 17;
         expect(calls.length).toBeGreaterThan(0);
         expect(calls[0]).toEqual([1, total]);
         expect(calls[calls.length - 1]).toEqual([total, total]);
@@ -1455,7 +1485,7 @@ describe('worldStore', () => {
         expect(state.status).toBe('ready');
         expect(state.error).toBeNull();
         expect(state.model).not.toBeNull();
-        expect(state.model!.entidades.size).toBe(11);
+        expect(state.model!.entidades.size).toBe(13);
         expect(state.fs).not.toBeNull();
         expect(state.scanProgress.total).toBeGreaterThan(0);
         expect(state.scanProgress.done).toBe(state.scanProgress.total);
@@ -1497,6 +1527,34 @@ describe('uiStore', () => {
         actions.backToSector();
         expect(useUiStore.getState().tier).toBe('sector');
         expect(useUiStore.getState().focusSystemId).toBe('sistema_verne');
+    });
+
+    test('focusPlace opens the Plano; backToSystem keeps the sistema', () => {
+        const { actions } = useUiStore.getState();
+        actions.focusPlace('porto_verne', 'sistema_verne');
+        let state = useUiStore.getState();
+        expect(state.tier).toBe('place');
+        expect(state.focusPlaceId).toBe('porto_verne');
+        expect(state.focusSystemId).toBe('sistema_verne');
+        expect(state.siteListId).toBeNull();
+
+        actions.backToSystem();
+        state = useUiStore.getState();
+        expect(state.tier).toBe('system');
+        expect(state.focusPlaceId).toBeNull();
+        expect(state.focusSystemId).toBe('sistema_verne');
+    });
+
+    test('focusSystem and backToSector clear a lingering focusPlaceId', () => {
+        const { actions } = useUiStore.getState();
+        actions.focusPlace('porto_verne', 'sistema_verne');
+        actions.focusSystem('sistema_kappa');
+        expect(useUiStore.getState().focusPlaceId).toBeNull();
+
+        actions.focusPlace('rust_harbor', 'sistema_kappa');
+        actions.backToSector();
+        expect(useUiStore.getState().tier).toBe('sector');
+        expect(useUiStore.getState().focusPlaceId).toBeNull();
     });
 
     test('selection, panel tab and toggles', () => {

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -1073,6 +1073,109 @@ describe('scanWorldFolder — diario', () => {
     });
 });
 
+// ── musica/ → model.musica (world-level music) ──────────────────────────────
+
+describe('scanWorldFolder — musica', () => {
+    /** Minimal world plus a musica/ tree (the manifest keeps avisos small). */
+    function musicaTree(musica: FileTree): FileTree {
+        return { mundo: { 'mundo.md': FULL_MANIFEST, musica } };
+    }
+
+    test('root audio files become the BGM rotation, name-sorted', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    // Insertion order is deliberately unsorted.
+                    musica: {
+                        'viaje_nucleo.mp3': 'mp3-bytes',
+                        'ambiente_mundo.ogg': 'ogg-bytes',
+                        'viaje_corredor.mp3': 'mp3-bytes',
+                    },
+                },
+            })
+        );
+
+        expect(model.musica.bgm.map((t) => t.path)).toEqual([
+            'mundo/musica/ambiente_mundo.ogg',
+            'mundo/musica/viaje_corredor.mp3',
+            'mundo/musica/viaje_nucleo.mp3',
+        ]);
+        expect(model.musica.bgm.every((t) => t.type === 'audio')).toBe(true);
+        expect(model.musica.eventPlaylists).toEqual([]);
+    });
+
+    test('subfolders become named event playlists; empty ones are skipped', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                musicaTree({
+                    'viaje_nucleo.mp3': 'mp3-bytes',
+                    tension: { 'tension_creciente.mp3': 'mp3-bytes' },
+                    eventos_generales: {
+                        'evento_averia.mp3': 'mp3-bytes',
+                        'evento_alto.mp3': 'mp3-bytes',
+                    },
+                    vacia: {},
+                })
+            )
+        );
+
+        expect(model.musica.eventPlaylists.map((p) => p.id)).toEqual([
+            'eventos_generales',
+            'tension',
+        ]);
+        const [eventos, tension] = model.musica.eventPlaylists;
+        expect(eventos.name).toBe('Eventos Generales');
+        expect(eventos.tracks.map((t) => t.path)).toEqual([
+            'mundo/musica/eventos_generales/evento_alto.mp3',
+            'mundo/musica/eventos_generales/evento_averia.mp3',
+        ]);
+        expect(tension.name).toBe('Tension');
+        expect(tension.tracks.map((t) => t.path)).toEqual([
+            'mundo/musica/tension/tension_creciente.mp3',
+        ]);
+    });
+
+    test('markdown prompt docs and ignore rules (_ files, _/CAPS dirs) are skipped', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                musicaTree({
+                    '_instrucciones.md': '# qué generar y soltar aquí',
+                    'notas.md': '# apuntes del GM',
+                    '_maqueta.mp3': 'mp3-bytes',
+                    'viaje_frontera.mp3': 'mp3-bytes',
+                    _borradores: { 'wip.mp3': 'mp3-bytes' },
+                    ARCHIVO: { 'vieja.mp3': 'mp3-bytes' },
+                    eventos: { 'evento_pecio.mp3': 'mp3-bytes', 'leeme.md': 'doc' },
+                })
+            )
+        );
+
+        expect(model.musica.bgm.map((t) => t.path)).toEqual([
+            'mundo/musica/viaje_frontera.mp3',
+        ]);
+        expect(model.musica.eventPlaylists.map((p) => p.id)).toEqual(['eventos']);
+        expect(model.musica.eventPlaylists[0].tracks.map((t) => t.name)).toEqual([
+            'evento_pecio.mp3',
+        ]);
+        // The ignored content produced no diagnostics either.
+        expect(model.problemas.some((p) => p.archivo.includes('musica'))).toBe(false);
+    });
+
+    test('absent musica/ folder yields empty arrays and NO aviso (optional by design)', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', { mundo: { 'mundo.md': FULL_MANIFEST } })
+        );
+
+        expect(model.musica.bgm).toEqual([]);
+        expect(model.musica.eventPlaylists).toEqual([]);
+        expect(model.problemas.some((p) => p.archivo.includes('musica'))).toBe(false);
+        expect(model.problemas.some((p) => p.mensaje.includes('musica'))).toBe(false);
+    });
+});
+
 // ── Stores (headless zustand) ───────────────────────────────────────────────
 
 describe('worldStore', () => {

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -217,6 +217,45 @@ describe('scanWorldFolder — happy path', () => {
         expect(planet.playable).toBeUndefined();
     });
 
+    test('playable place with FLAT multi-act plan/: one Part per acto file, support on the first', async () => {
+        const tree = happyTree();
+        const mundo = tree.mundo as FileTree;
+        const lugares = mundo.lugares as FileTree;
+        const porto = lugares.porto_verne as FileTree;
+        porto.plan = {
+            'acto1_llegada.md': ':::leer\nLlegais.\n:::\n',
+            'acto2_el_mapa.md': ':::leer\nEl mapa se ilumina.\n:::\n',
+            'acto2b_desvio.md': ':::gm\nInterludio.\n:::\n',
+        };
+
+        const model = await scanWorldFolder(makeHandle('campaign', tree));
+        const config = (model.entidades.get('porto_verne') as PlaceEntity).playable!;
+
+        // one part per plan file, ordered by filename
+        expect(config.parts).toHaveLength(3);
+        expect(config.parts.map((p) => p.planFile?.path)).toEqual([
+            'mundo/lugares/porto_verne/plan/acto1_llegada.md',
+            'mundo/lugares/porto_verne/plan/acto2_el_mapa.md',
+            'mundo/lugares/porto_verne/plan/acto2b_desvio.md',
+        ]);
+        expect(config.parts.map((p) => p.name)).toEqual([
+            'Acto1 Llegada',
+            'Acto2 el Mapa',
+            'Acto2b Desvio',
+        ]);
+        // support content attaches to the FIRST part only (path-folder convention)
+        expect(config.parts[0].supportDocs.map((d) => d.path)).toContain(
+            'mundo/lugares/porto_verne/characters/kael.md'
+        );
+        expect(config.parts[0].bgmPlaylist).toHaveLength(1);
+        expect(config.parts[1].supportDocs).toHaveLength(0);
+        expect(config.parts[2].bgmPlaylist).toHaveLength(0);
+        // no plan file leaked into support docs
+        for (const part of config.parts) {
+            expect(part.supportDocs.every((d) => !d.path.includes('/plan/'))).toBe(true);
+        }
+    });
+
     test('parses eventos/ into model.tablas (M4), outside the entity map', async () => {
         const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
 
@@ -455,6 +494,30 @@ describe('scanWorldFolder — validation', () => {
         );
         expect(avisos).toHaveLength(1);
         expect(avisos[0].mensaje).toContain('huérfana');
+    });
+
+    test('no orphan aviso for a desconocido pnj ANCHORED via a resolving ubicacion', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    sistemas: {
+                        'base.md': '---\ncoordenadas: {x: 0, y: 0}\nconocimiento: visitado\n---\n',
+                    },
+                    pnjs: {
+                        // forward-seeded NPC: unknown to the party, waiting at a real place
+                        'agente_oculto.md':
+                            '---\nrol: comodin\nubicacion: base\nconocimiento: desconocido\n---\n',
+                        // truly dangling: unknown AND its ubicacion resolves nowhere
+                        'sin_ancla.md':
+                            '---\nrol: comodin\nubicacion: lugar_inexistente\nconocimiento: desconocido\n---\n',
+                    },
+                },
+            })
+        );
+
+        const orphanAvisos = model.problemas.filter((p) => p.mensaje.includes('huérfana'));
+        expect(orphanAvisos.map((p) => p.archivo)).toEqual(['mundo/pnjs/sin_ancla.md']);
     });
 
     test('missing mundo/ folder degrades into an error model', async () => {

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -1176,6 +1176,109 @@ describe('scanWorldFolder — musica', () => {
     });
 });
 
+// ── Entity profile images (imagenes/) ───────────────────────────────────────
+
+describe('scanWorldFolder — imagenes', () => {
+    /** happyTree plus a mundo/imagenes/ folder. */
+    function treeWithImages(imagenes: FileTree): FileTree {
+        const tree = happyTree();
+        (tree.mundo as FileTree).imagenes = imagenes;
+        return tree;
+    }
+
+    test('attaches imagen by id across entity kinds and extension variety', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                treeWithImages({
+                    'porto_verne.png': 'png-bytes',
+                    'sistema_verne.webp': 'webp-bytes',
+                    'kael_zara.jpeg': 'jpeg-bytes',
+                    'consorcio_tetrad.svg': '<svg xmlns="http://www.w3.org/2000/svg"/>',
+                })
+            )
+        );
+
+        expect(model.entidades.get('porto_verne')?.imagen).toEqual({
+            path: 'mundo/imagenes/porto_verne.png',
+            name: 'porto_verne.png',
+            type: 'image',
+        });
+        expect(model.entidades.get('sistema_verne')?.imagen?.path).toBe(
+            'mundo/imagenes/sistema_verne.webp'
+        );
+        expect(model.entidades.get('kael_zara')?.imagen?.path).toBe(
+            'mundo/imagenes/kael_zara.jpeg'
+        );
+        expect(model.entidades.get('consorcio_tetrad')?.imagen?.path).toBe(
+            'mundo/imagenes/consorcio_tetrad.svg'
+        );
+        // Entities without a matching file stay imagen-less.
+        expect(model.entidades.get('kovar_iii')?.imagen).toBeUndefined();
+        // Matching images add zero diagnostics (happyTree's own aviso aside).
+        expect(model.problemas.some((p) => p.mensaje.includes('Imagen sin entidad'))).toBe(false);
+    });
+
+    test('an image whose basename matches no entity id earns an aviso (probable typo)', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                treeWithImages({
+                    'porto_vern.png': 'png-bytes', // typo: missing final e
+                })
+            )
+        );
+
+        const aviso = model.problemas.find((p) => p.mensaje.includes('Imagen sin entidad'));
+        expect(aviso).toBeDefined();
+        expect(aviso!.nivel).toBe('aviso');
+        expect(aviso!.archivo).toBe('mundo/imagenes/porto_vern.png');
+        expect(aviso!.mensaje).toContain('"porto_vern.png"');
+        expect(model.entidades.get('porto_verne')?.imagen).toBeUndefined();
+    });
+
+    test('absent imagenes/ folder yields no imagen and NO aviso (optional by design)', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        for (const entity of model.entidades.values()) {
+            expect(entity.imagen).toBeUndefined();
+        }
+        expect(model.problemas.some((p) => p.archivo.includes('imagenes'))).toBe(false);
+        expect(model.problemas.some((p) => p.mensaje.includes('Imagen'))).toBe(false);
+    });
+
+    test('ignore rules and non-image files apply: no attach, no aviso', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                treeWithImages({
+                    '_porto_verne.png': 'png-bytes', // _-prefixed -> ignored
+                    'notas.md': '# no es una imagen', // wrong extension -> ignored
+                    'porto_verne.txt': 'tampoco', // wrong extension -> ignored
+                })
+            )
+        );
+
+        expect(model.entidades.get('porto_verne')?.imagen).toBeUndefined();
+        expect(model.problemas.some((p) => p.archivo.includes('imagenes'))).toBe(false);
+    });
+
+    test('duplicate basenames: the first in name-sorted order wins', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                treeWithImages({
+                    'porto_verne.svg': '<svg xmlns="http://www.w3.org/2000/svg"/>',
+                    'porto_verne.png': 'png-bytes',
+                })
+            )
+        );
+
+        // getFilesFromDirectory sorts by name: .png < .svg.
+        expect(model.entidades.get('porto_verne')?.imagen?.name).toBe('porto_verne.png');
+    });
+});
+
 // ── Stores (headless zustand) ───────────────────────────────────────────────
 
 describe('worldStore', () => {

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -17,7 +17,7 @@ calendario:
 viaje:
   dias_por_unidad: 2
   intrasistema_dias: 1
-  combustible_por_tramo: 1
+  combustible_cada_dias: 4
   viveres_cada_dias: 4
 medidores: [viveres, combustible, nave]
 regiones: [nucleo, frontera]
@@ -149,6 +149,7 @@ describe('scanWorldFolder — happy path', () => {
         expect(model.manifest.calendario.anoEpoca).toBe(1200);
         expect(model.manifest.calendario.meses).toEqual(['Alfa', 'Beta', 'Gamma']);
         expect(model.manifest.viaje.diasPorUnidad).toBe(2);
+        expect(model.manifest.viaje.combustibleCadaDias).toBe(4);
         expect(model.manifest.viaje.viveresCadaDias).toBe(4);
         expect(model.manifest.medidores).toEqual(['viveres', 'combustible', 'nave']);
         expect(model.manifest.regiones).toEqual(['nucleo', 'frontera']);
@@ -550,12 +551,66 @@ describe('scanWorldFolder — accionable + manifest defaults', () => {
         expect(model.manifest.viaje).toEqual({
             diasPorUnidad: 1,
             intrasistemaDias: 1,
-            combustiblePorTramo: 1,
+            combustibleCadaDias: 4,
             viveresCadaDias: 4,
         });
         expect(model.manifest.medidores).toEqual(['viveres', 'combustible', 'nave']);
         expect(model.manifest.regiones).toEqual([]);
         expect(model.manifest.calendario.diasPorMes).toBe(30);
+    });
+});
+
+// ── Migración del knob de combustible (combustible_por_tramo -> _cada_dias) ─
+
+describe('scanWorldFolder — migración combustible_cada_dias', () => {
+    function manifestTree(viajeYaml: string): FileTree {
+        return {
+            mundo: {
+                'mundo.md': `---\nnombre: Mig\ncalendario: {era: dG, ano_epoca: 1, dias_por_mes: 30, meses: [Uno]}\nviaje:\n${viajeYaml}\nmedidores: [viveres, combustible, nave]\nregiones: []\n---\n`,
+            },
+        };
+    }
+
+    const legacyAviso = (model: { problemas: { mensaje: string }[] }) =>
+        model.problemas.filter((p) => p.mensaje.includes('combustible_por_tramo'));
+
+    test('legacy key only: default cadence + aviso (never mapped numerically)', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', manifestTree('  dias_por_unidad: 1\n  combustible_por_tramo: 1'))
+        );
+        expect(model.manifest.viaje.combustibleCadaDias).toBe(4);
+        const avisos = legacyAviso(model);
+        expect(avisos).toHaveLength(1);
+        expect(avisos[0].mensaje).toContain('obsoleto');
+        expect(avisos[0].mensaje).toContain('(aplicado: 4)');
+    });
+
+    test('both keys: combustible_cada_dias wins, still with the aviso', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                manifestTree('  combustible_por_tramo: 1\n  combustible_cada_dias: 6')
+            )
+        );
+        expect(model.manifest.viaje.combustibleCadaDias).toBe(6);
+        expect(legacyAviso(model)).toHaveLength(1);
+        expect(legacyAviso(model)[0].mensaje).toContain('(aplicado: 6)');
+    });
+
+    test('neither key: silent default 4', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', manifestTree('  dias_por_unidad: 1'))
+        );
+        expect(model.manifest.viaje.combustibleCadaDias).toBe(4);
+        expect(legacyAviso(model)).toHaveLength(0);
+    });
+
+    test('new key only: parsed, no aviso', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', manifestTree('  combustible_cada_dias: 2'))
+        );
+        expect(model.manifest.viaje.combustibleCadaDias).toBe(2);
+        expect(legacyAviso(model)).toHaveLength(0);
     });
 });
 

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -1,0 +1,567 @@
+/// <reference types="bun-types" />
+import { test, expect, describe, beforeEach } from 'bun:test';
+import { makeHandle, FileTree } from '@/lib/testUtils/mockFs';
+import { hasWorld, scanWorldFolder } from './worldScanner';
+import { useWorldStore, useUiStore } from './stores';
+import { Lead, PlaceEntity, Trama } from '@/types/world';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const FULL_MANIFEST = `---
+nombre: Sector Verne
+calendario:
+  era: dG
+  ano_epoca: 1200
+  dias_por_mes: 30
+  meses: [Alfa, Beta, Gamma]
+viaje:
+  dias_por_unidad: 2
+  intrasistema_dias: 1
+  combustible_por_tramo: 1
+  viveres_cada_dias: 4
+medidores: [viveres, combustible, nave]
+regiones: [nucleo, frontera]
+---
+# Sector Verne
+`;
+
+/**
+ * Happy path: manifest + 2 sistemas + planet + station-with-en + deep-space nodo
+ * + playable lugar folder + faccion + pnj + 2 pistas + trama. Also exercises
+ * the ignore rules (_file, ALL-CAPS dir) and M1-skipped dirs.
+ */
+function happyTree(): FileTree {
+    return {
+        mundo: {
+            'mundo.md': FULL_MANIFEST,
+            'PROTOCOLO.md': '# instrucciones del agente',
+            PLANTILLAS: { 'lugar.md': '---\ntipo: plantilla\n---\n' },
+            sistemas: {
+                'sistema_verne.md':
+                    '---\ntipo: sistema\nnombre: Sistema Verne\ncoordenadas: {x: 10, y: 20}\nregion: nucleo\nconocimiento: visitado\n---\nSistema natal.\n',
+                'sistema_kovar.md':
+                    '---\ncoordenadas:\n  x: 40\n  y: 12\nregion: frontera\nconocimiento: conocido\n---\n',
+                '_borrador.md': '---\ncoordenadas: {x: 0, y: 0}\n---\n',
+            },
+            lugares: {
+                'kovar_iii.md':
+                    '---\ntipo: planeta\nen: sistema_kovar\norbita: 3\nconocimiento: conocido\nservicios: [mercado, casino]\n---\nPlaneta minero.\n',
+                'estacion_thal.md':
+                    '---\ntipo: estacion\nen: kovar_iii\nconocimiento: rumoreado\nfacciones:\n  - {faccion: consorcio_tetrad, nivel: dominante}\n---\n',
+                'nodo_sigma.md':
+                    '---\ntipo: nodo\ncoordenadas: {x: 55, y: 60}\nconocimiento: rumoreado\nacceso: portal\n---\n',
+                '_apuntes.md': '---\ntipo: nodo\n---\n',
+                BOCETOS: { 'idea.md': 'boceto suelto' },
+                porto_verne: {
+                    'lugar.md':
+                        '---\ntipo: estacion\nnombre: Porto Verne\nen: sistema_verne\norbita: 2\nconocimiento: visitado\nservicios: [repostaje, mercado]\n---\nLa base de la campana.\n',
+                    plan: {
+                        'acto1.md':
+                            ':::leer\nLlegais al muelle de atraque.\n:::\n\n:::gm\nNotas del acto.\n:::\n',
+                    },
+                    characters: { 'kael.md': '# Kael\n\nHP 30, AC 17\n' },
+                    music: { 'tema.mp3': 'mp3-bytes' },
+                },
+            },
+            facciones: {
+                'consorcio_tetrad.md':
+                    '---\nactitud: rival\npoder: 4\nobjetivos: [dominar las rutas]\nconocimiento: conocido\n---\n',
+            },
+            pnjs: {
+                'kael_zara.md':
+                    '---\nrol: contacto\nfaccion: consorcio_tetrad\nubicacion: porto_verne\nconocimiento: conocido\n---\n',
+            },
+            pistas: {
+                'deuda_kael.md':
+                    '---\nestado: activa\ntrama: la_red_despierta\ndonde: porto_verne\n---\nKael debe algo.\n',
+                'rumor_sigma.md': '---\nestado: rumor\n---\n',
+            },
+            tramas: {
+                'la_red_despierta.md':
+                    '---\nrol: principal\nestado: activa\nreloj: {actual: 1, max: 6}\nlugares_clave: [porto_verne, nodo_sigma]\nfacciones: [consorcio_tetrad]\n---\n',
+            },
+            eventos: { 'viaje_frontera.md': '---\ncontexto: viaje\n---\n## v01\n' },
+            estado: { 'grupo.md': '---\ncreditos: 100\n---\n' },
+            diario: { '2026-07-12_s08.md': '---\nsesion: 8\n---\n' },
+        },
+    };
+}
+
+// ── hasWorld ────────────────────────────────────────────────────────────────
+
+describe('hasWorld', () => {
+    test('true when mundo/mundo.md exists', async () => {
+        expect(await hasWorld(makeHandle('campaign', happyTree()))).toBe(true);
+    });
+
+    test('false without a mundo/ folder', async () => {
+        expect(await hasWorld(makeHandle('campaign', { sesion7: {} }))).toBe(false);
+    });
+
+    test('false when mundo/ exists but has no manifest', async () => {
+        expect(await hasWorld(makeHandle('campaign', { mundo: { sistemas: {} } }))).toBe(false);
+    });
+});
+
+// ── Happy path ──────────────────────────────────────────────────────────────
+
+describe('scanWorldFolder — happy path', () => {
+    test('loads every entity kind and skips ignored/M1 content', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        expect(model.sistemas.map((s) => s.id).sort()).toEqual(['sistema_kovar', 'sistema_verne']);
+        expect(model.lugares.map((l) => l.id).sort()).toEqual([
+            'estacion_thal',
+            'kovar_iii',
+            'nodo_sigma',
+            'porto_verne',
+        ]);
+        expect(model.facciones.map((f) => f.id)).toEqual(['consorcio_tetrad']);
+        expect(model.pnjs.map((p) => p.id)).toEqual(['kael_zara']);
+        expect(model.pistas.map((p) => p.id).sort()).toEqual(['deuda_kael', 'rumor_sigma']);
+        expect(model.tramas.map((t) => t.id)).toEqual(['la_red_despierta']);
+        expect(model.entidades.size).toBe(11);
+
+        // eventos/estado/diario contents never become entities in M1
+        expect(model.entidades.has('viaje_frontera')).toBe(false);
+        expect(model.entidades.has('grupo')).toBe(false);
+
+        // ignore rules: _files and ALL-CAPS dirs
+        expect(model.entidades.has('_borrador')).toBe(false);
+        expect(model.entidades.has('_apuntes')).toBe(false);
+        expect(model.problemas.some((p) => p.archivo.includes('BOCETOS'))).toBe(false);
+    });
+
+    test('parses the manifest', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        expect(model.manifest.nombre).toBe('Sector Verne');
+        expect(model.manifest.calendario.era).toBe('dG');
+        expect(model.manifest.calendario.anoEpoca).toBe(1200);
+        expect(model.manifest.calendario.meses).toEqual(['Alfa', 'Beta', 'Gamma']);
+        expect(model.manifest.viaje.diasPorUnidad).toBe(2);
+        expect(model.manifest.viaje.viveresCadaDias).toBe(4);
+        expect(model.manifest.medidores).toEqual(['viveres', 'combustible', 'nave']);
+        expect(model.manifest.regiones).toEqual(['nucleo', 'frontera']);
+    });
+
+    test('parses entity fields (coords, presence, estadoPista/estadoTrama split)', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        const verne = model.sistemas.find((s) => s.id === 'sistema_verne')!;
+        expect(verne.coordenadas).toEqual({ x: 10, y: 20 });
+        expect(verne.nombre).toBe('Sistema Verne');
+        expect(verne.conocimiento).toBe('visitado');
+
+        const kovar = model.entidades.get('sistema_kovar')!;
+        expect(kovar.nombre).toBe('Sistema Kovar'); // fallback from filename
+
+        const thal = model.entidades.get('estacion_thal') as PlaceEntity;
+        expect(thal.facciones).toEqual([{ faccion: 'consorcio_tetrad', nivel: 'dominante' }]);
+
+        const sigma = model.entidades.get('nodo_sigma') as PlaceEntity;
+        expect(sigma.acceso).toBe('portal');
+        expect(sigma.coordenadas).toEqual({ x: 55, y: 60 });
+        expect(sigma.en).toBeUndefined();
+
+        const pista = model.entidades.get('deuda_kael') as Lead;
+        expect(pista.estadoPista).toBe('activa');
+        expect(pista.estado).toBeUndefined(); // estado key is the workflow state, not prose
+        expect(pista.body).toContain('Kael debe algo.');
+
+        const trama = model.entidades.get('la_red_despierta') as Trama;
+        expect(trama.estadoTrama).toBe('activa');
+        expect(trama.reloj).toEqual({ actual: 1, max: 6 });
+        expect(trama.lugaresClave).toEqual(['porto_verne', 'nodo_sigma']);
+    });
+
+    test('only aviso: out-of-vocabulary servicio', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        expect(model.problemas).toHaveLength(1);
+        expect(model.problemas[0].nivel).toBe('aviso');
+        expect(model.problemas[0].archivo).toBe('mundo/lugares/kovar_iii.md');
+        expect(model.problemas[0].mensaje).toContain('"casino"');
+    });
+
+    test('playable place: SessionConfig with paths prefixed mundo/lugares/<id>/', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        const porto = model.entidades.get('porto_verne') as PlaceEntity;
+        expect(porto.filePath).toBe('mundo/lugares/porto_verne/lugar.md');
+        expect(porto.playable).toBeDefined();
+
+        const config = porto.playable!;
+        expect(config.folderName).toBe('porto_verne');
+        expect(config.parts).toHaveLength(1);
+        expect(config.parts[0].planFile?.path).toBe('mundo/lugares/porto_verne/plan/acto1.md');
+        expect(config.parts[0].supportDocs.map((d) => d.path)).toContain(
+            'mundo/lugares/porto_verne/characters/kael.md'
+        );
+        expect(config.parts[0].bgmPlaylist.map((t) => t.path)).toEqual([
+            'mundo/lugares/porto_verne/music/tema.mp3',
+        ]);
+
+        // plain places carry no playable config
+        const planet = model.entidades.get('kovar_iii') as PlaceEntity;
+        expect(planet.playable).toBeUndefined();
+    });
+
+    test('childrenOf: sistemas + deep-space roots, en-chains as children', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        expect(model.childrenOf.get('sistema_verne')).toEqual(['porto_verne']);
+        expect(model.childrenOf.get('sistema_kovar')).toEqual(['kovar_iii']);
+        expect(model.childrenOf.get('kovar_iii')).toEqual(['estacion_thal']);
+        expect(model.childrenOf.get('nodo_sigma')).toEqual([]); // deep-space root
+        expect(model.childrenOf.has('porto_verne')).toBe(false); // leaf, not a root
+    });
+
+    test('region inheritance walks the en-chain to the nearest ancestor', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        const planet = model.entidades.get('kovar_iii') as PlaceEntity;
+        const station = model.entidades.get('estacion_thal') as PlaceEntity;
+        const porto = model.entidades.get('porto_verne') as PlaceEntity;
+        const sigma = model.entidades.get('nodo_sigma') as PlaceEntity;
+
+        expect(planet.region).toBe('frontera'); // from sistema_kovar
+        expect(station.region).toBe('frontera'); // two hops up
+        expect(porto.region).toBe('nucleo'); // from sistema_verne
+        expect(sigma.region).toBeUndefined(); // root without region
+    });
+
+    test('accionable + trama grouping', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        const deuda = model.entidades.get('deuda_kael') as Lead;
+        const rumor = model.entidades.get('rumor_sigma') as Lead;
+        expect(deuda.accionable).toBe(true); // activa @ lugar visitado, sin requisitos
+        expect(rumor.accionable).toBe(false); // estado rumor
+
+        const trama = model.entidades.get('la_red_despierta') as Trama;
+        expect(trama.pistas.map((p) => p.id)).toEqual(['deuda_kael']);
+    });
+
+    test('reports batched progress up to (total, total)', async () => {
+        const calls: Array<[number, number]> = [];
+        await scanWorldFolder(makeHandle('campaign', happyTree()), (done, total) => {
+            calls.push([done, total]);
+        });
+
+        // 1 manifest + 2 sistemas + 1 faccion + 1 pnj + 2 pistas + 1 trama + 3 lugares + 1 carpeta
+        const total = 12;
+        expect(calls.length).toBeGreaterThan(0);
+        expect(calls[0]).toEqual([1, total]);
+        expect(calls[calls.length - 1]).toEqual([total, total]);
+        for (let i = 1; i < calls.length; i++) {
+            expect(calls[i][0]).toBeGreaterThanOrEqual(calls[i - 1][0]);
+            expect(calls[i][1]).toBe(total);
+        }
+    });
+});
+
+// ── Validation errors (world still loads) ───────────────────────────────────
+
+describe('scanWorldFolder — validation', () => {
+    test('duplicate id across dirs: first wins, second reported', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    sistemas: {
+                        'dup.md': '---\ncoordenadas: {x: 1, y: 1}\nconocimiento: conocido\n---\n',
+                    },
+                    lugares: {
+                        'dup.md': '---\ncoordenadas: {x: 2, y: 2}\nconocimiento: conocido\n---\n',
+                    },
+                },
+            })
+        );
+
+        const errors = model.problemas.filter((p) => p.nivel === 'error');
+        expect(errors).toHaveLength(1);
+        expect(errors[0].archivo).toBe('mundo/lugares/dup.md');
+        expect(errors[0].mensaje).toContain('id duplicado');
+        expect(model.entidades.get('dup')!.tipo).toBe('sistema');
+        expect(model.lugares).toHaveLength(0);
+    });
+
+    test('dangling en ref is an error', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    lugares: {
+                        'perdido.md': '---\nen: no_existe\nconocimiento: conocido\n---\n',
+                    },
+                },
+            })
+        );
+
+        const errors = model.problemas.filter((p) => p.nivel === 'error');
+        expect(errors).toHaveLength(1);
+        expect(errors[0].mensaje).toContain('"en"');
+        expect(errors[0].mensaje).toContain('"no_existe"');
+        expect(model.lugares).toHaveLength(1); // still loaded, degraded
+    });
+
+    test('sistema without coordenadas: error, entity kept at 0,0', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    sistemas: { 'sin_coords.md': '---\nconocimiento: conocido\n---\n' },
+                },
+            })
+        );
+
+        const errors = model.problemas.filter((p) => p.nivel === 'error');
+        expect(errors).toHaveLength(1);
+        expect(errors[0].mensaje).toBe('Sistema sin coordenadas');
+        expect(model.sistemas[0].coordenadas).toEqual({ x: 0, y: 0 });
+    });
+
+    test('lugar with neither en nor coordenadas is an error', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    lugares: { 'flotante.md': '---\nconocimiento: conocido\n---\n' },
+                },
+            })
+        );
+
+        const errors = model.problemas.filter((p) => p.nivel === 'error');
+        expect(errors).toHaveLength(1);
+        expect(errors[0].mensaje).toContain('sin "en" ni coordenadas');
+    });
+
+    test('lugares/ subfolder without lugar.md: error, no entity', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    lugares: {
+                        vacia: { plan: { 'acto1.md': ':::leer\nHola.\n:::\n' } },
+                    },
+                },
+            })
+        );
+
+        const errors = model.problemas.filter((p) => p.nivel === 'error');
+        expect(errors).toHaveLength(1);
+        expect(errors[0].archivo).toBe('mundo/lugares/vacia');
+        expect(errors[0].mensaje).toContain('lugar.md');
+        expect(model.lugares).toHaveLength(0);
+    });
+
+    test('malformed YAML: error reported, world still loads the rest', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    sistemas: {
+                        'bueno.md':
+                            '---\ncoordenadas: {x: 5, y: 5}\nconocimiento: conocido\n---\n',
+                        'roto.md': '---\nnombre: "sin cierre\n---\ncuerpo\n',
+                    },
+                },
+            })
+        );
+
+        expect(
+            model.problemas.some(
+                (p) =>
+                    p.nivel === 'error' &&
+                    p.archivo === 'mundo/sistemas/roto.md' &&
+                    p.mensaje.includes('YAML inválido')
+            )
+        ).toBe(true);
+        // the broken file still yields a degraded entity; the good one is intact
+        expect(model.sistemas).toHaveLength(2);
+        expect(model.entidades.get('bueno')!.conocimiento).toBe('conocido');
+    });
+
+    test('orphan aviso: unreferenced entity with conocimiento desconocido', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    sistemas: {
+                        'fantasma.md': '---\ncoordenadas: {x: 9, y: 9}\n---\n',
+                    },
+                },
+            })
+        );
+
+        const avisos = model.problemas.filter((p) => p.nivel === 'aviso');
+        expect(avisos).toHaveLength(1);
+        expect(avisos[0].archivo).toBe('mundo/sistemas/fantasma.md');
+        expect(avisos[0].mensaje).toContain('huérfana');
+    });
+
+    test('missing mundo/ folder degrades into an error model', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', {}));
+
+        expect(model.problemas.some((p) => p.nivel === 'error')).toBe(true);
+        expect(model.entidades.size).toBe(0);
+        expect(model.manifest.viaje.diasPorUnidad).toBe(1);
+    });
+});
+
+// ── Derivations: accionable + manifest defaults ─────────────────────────────
+
+describe('scanWorldFolder — accionable + manifest defaults', () => {
+    function derivationsTree(): FileTree {
+        return {
+            mundo: {
+                'mundo.md': '---\nnombre: Mini\n---\n',
+                sistemas: {
+                    'sys.md': '---\ncoordenadas: {x: 0, y: 0}\nconocimiento: visitado\n---\n',
+                },
+                lugares: {
+                    'sitio_conocido.md': '---\nen: sys\nconocimiento: conocido\n---\n',
+                    'sitio_oculto.md': '---\nen: sys\nconocimiento: desconocido\n---\n',
+                },
+                pistas: {
+                    'p_activa.md': '---\nestado: activa\ndonde: sitio_conocido\n---\n',
+                    'p_oculta.md': '---\nestado: activa\ndonde: sitio_oculto\n---\n',
+                    'p_manual.md': '---\nestado: en_curso\nrequisitos: [combustible<=2]\n---\n',
+                    'p_rumor.md': '---\nestado: rumor\n---\n',
+                    'p_resuelta.md': '---\nestado: resuelta\ndonde: sitio_conocido\n---\n',
+                },
+            },
+        };
+    }
+
+    test('accionable derivation per estado/donde/requisitos', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', derivationsTree()));
+        const accionableOf = (id: string) => (model.entidades.get(id) as Lead).accionable;
+
+        expect(accionableOf('p_activa')).toBe(true); // activa @ conocido
+        expect(accionableOf('p_oculta')).toBe(false); // donde desconocido
+        expect(accionableOf('p_manual')).toBe('manual'); // requisitos -> según GM (evalCondition llega en M4)
+        expect(accionableOf('p_rumor')).toBe(false); // estado rumor
+        expect(accionableOf('p_resuelta')).toBe(false); // estado terminal
+    });
+
+    test('aviso: pista activa at a desconocido place', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', derivationsTree()));
+
+        expect(
+            model.problemas.some(
+                (p) =>
+                    p.nivel === 'aviso' &&
+                    p.archivo === 'mundo/pistas/p_oculta.md' &&
+                    p.mensaje.includes('sitio_oculto')
+            )
+        ).toBe(true);
+    });
+
+    test('missing manifest fields: one aviso each + defaults applied', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', derivationsTree()));
+
+        const manifestAvisos = model.problemas.filter(
+            (p) => p.archivo === 'mundo/mundo.md' && p.nivel === 'aviso'
+        );
+        expect(manifestAvisos.map((p) => p.mensaje).sort()).toEqual([
+            'Falta "calendario" en el manifiesto — se usa el valor por defecto',
+            'Falta "medidores" en el manifiesto — se usa el valor por defecto',
+            'Falta "regiones" en el manifiesto — se usa el valor por defecto',
+            'Falta "viaje" en el manifiesto — se usa el valor por defecto',
+        ]);
+        expect(model.manifest.nombre).toBe('Mini');
+        expect(model.manifest.viaje).toEqual({
+            diasPorUnidad: 1,
+            intrasistemaDias: 1,
+            combustiblePorTramo: 1,
+            viveresCadaDias: 4,
+        });
+        expect(model.manifest.medidores).toEqual(['viveres', 'combustible', 'nave']);
+        expect(model.manifest.regiones).toEqual([]);
+        expect(model.manifest.calendario.diasPorMes).toBe(30);
+    });
+});
+
+// ── Stores (headless zustand) ───────────────────────────────────────────────
+
+describe('worldStore', () => {
+    beforeEach(() => {
+        useWorldStore.getState().actions.reset();
+    });
+
+    test('scan: idle -> scanning -> ready with model + fs + progress', async () => {
+        const store = useWorldStore;
+        expect(store.getState().status).toBe('idle');
+
+        const promise = store.getState().actions.scan(makeHandle('campaign', happyTree()));
+        expect(store.getState().status).toBe('scanning');
+        await promise;
+
+        const state = store.getState();
+        expect(state.status).toBe('ready');
+        expect(state.error).toBeNull();
+        expect(state.model).not.toBeNull();
+        expect(state.model!.entidades.size).toBe(11);
+        expect(state.fs).not.toBeNull();
+        expect(state.scanProgress.total).toBeGreaterThan(0);
+        expect(state.scanProgress.done).toBe(state.scanProgress.total);
+    });
+
+    test('reset returns to the initial state', async () => {
+        await useWorldStore.getState().actions.scan(makeHandle('campaign', happyTree()));
+        useWorldStore.getState().actions.reset();
+
+        const state = useWorldStore.getState();
+        expect(state.status).toBe('idle');
+        expect(state.model).toBeNull();
+        expect(state.fs).toBeNull();
+        expect(state.scanProgress).toEqual({ done: 0, total: 0 });
+    });
+});
+
+describe('uiStore', () => {
+    beforeEach(() => {
+        useUiStore.getState().actions.reset();
+    });
+
+    test('defaults', () => {
+        const state = useUiStore.getState();
+        expect(state.tier).toBe('sector');
+        expect(state.focusSystemId).toBeNull();
+        expect(state.selectedEntityId).toBeNull();
+        expect(state.panelTab).toBe('entidad');
+        expect(state.mapCollapsed).toBe(false);
+        expect(state.showUnknown).toBe(true);
+    });
+
+    test('focusSystem drills in; backToSector keeps the focus', () => {
+        const { actions } = useUiStore.getState();
+        actions.focusSystem('sistema_verne');
+        expect(useUiStore.getState().tier).toBe('system');
+        expect(useUiStore.getState().focusSystemId).toBe('sistema_verne');
+
+        actions.backToSector();
+        expect(useUiStore.getState().tier).toBe('sector');
+        expect(useUiStore.getState().focusSystemId).toBe('sistema_verne');
+    });
+
+    test('selection, panel tab and toggles', () => {
+        const { actions } = useUiStore.getState();
+        actions.selectEntity('porto_verne');
+        actions.setPanelTab('pistas');
+        actions.setMapCollapsed(true);
+        actions.setShowUnknown(false);
+
+        const state = useUiStore.getState();
+        expect(state.selectedEntityId).toBe('porto_verne');
+        expect(state.panelTab).toBe('pistas');
+        expect(state.mapCollapsed).toBe(true);
+        expect(state.showUnknown).toBe(false);
+
+        actions.reset();
+        expect(useUiStore.getState().selectedEntityId).toBeNull();
+        expect(useUiStore.getState().showUnknown).toBe(true);
+    });
+});

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -1279,6 +1279,163 @@ describe('scanWorldFolder — imagenes', () => {
     });
 });
 
+// ── Shops (lugares/<place>/tiendas/) → model.tiendas ────────────────────────
+
+describe('scanWorldFolder — tiendas', () => {
+    const SHOP_TALLER = `---
+tipo: tienda
+nombre: Taller de Bracca
+pnj: kael_zara
+etiquetas: [taller, repuestos]
+---
+Bracca repara casi cualquier cosa, si le pagas por adelantado.
+
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Célula de combustible | 120 | 4 | recargable |
+| Kit de reparación | 60 | - | ilimitado |
+| Blindaje ligero | 800 | 1 | única unidad |
+`;
+
+    /** happyTree with a tiendas/ subfolder inside the porto_verne place folder. */
+    function treeWithShops(tiendas: FileTree): FileTree {
+        const tree = happyTree();
+        ((tree.mundo as FileTree).lugares as FileTree).porto_verne = {
+            ...(((tree.mundo as FileTree).lugares as FileTree).porto_verne as FileTree),
+            tiendas,
+        };
+        return tree;
+    }
+
+    test('parses a shop with items; prices are numbers, "-" stock is null', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', treeWithShops({ 'taller.md': SHOP_TALLER }))
+        );
+
+        const shops = model.tiendas.get('porto_verne');
+        expect(shops).toBeDefined();
+        expect(shops!.length).toBe(1);
+        const shop = shops![0];
+        expect(shop.id).toBe('taller');
+        expect(shop.nombre).toBe('Taller de Bracca');
+        expect(shop.pnj).toBe('kael_zara');
+        expect(shop.etiquetas).toEqual(['taller', 'repuestos']);
+        expect(shop.body).toContain('Bracca repara');
+        expect(shop.filePath).toBe('mundo/lugares/porto_verne/tiendas/taller.md');
+
+        expect(shop.items).toEqual([
+            { articulo: 'Célula de combustible', precio: 120, stock: 4, nota: 'recargable' },
+            { articulo: 'Kit de reparación', precio: 60, stock: null, nota: 'ilimitado' },
+            { articulo: 'Blindaje ligero', precio: 800, stock: 1, nota: 'única unidad' },
+        ]);
+        // precio/stock are real numbers, not strings.
+        expect(typeof shop.items[0].precio).toBe('number');
+        expect(shop.items[1].stock).toBeNull();
+    });
+
+    test('a malformed row earns an aviso and is skipped, not a crash', async () => {
+        const badShop = `---
+tipo: tienda
+nombre: Mercadillo
+---
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Manzana | 5 | 10 | fresca |
+| Pera | no-es-numero | 3 | precio roto |
+| | 40 | 2 | sin nombre |
+| Naranja | 8 | - | ok |
+`;
+        const model = await scanWorldFolder(
+            makeHandle('campaign', treeWithShops({ 'mercadillo.md': badShop }))
+        );
+
+        const shop = model.tiendas.get('porto_verne')![0];
+        // Only the two well-formed rows survive.
+        expect(shop.items.map((i) => i.articulo)).toEqual(['Manzana', 'Naranja']);
+        const avisos = model.problemas.filter(
+            (p) => p.archivo.includes('mercadillo.md') && p.mensaje.includes('mal formada')
+        );
+        expect(avisos.length).toBe(2);
+        expect(avisos.every((p) => p.nivel === 'aviso')).toBe(true);
+    });
+
+    test('multiple shops under one place; a dangling pnj is an aviso', async () => {
+        const shopA = `---
+tipo: tienda
+nombre: Tienda A
+pnj: kael_zara
+---
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Cosa | 10 | 1 |  |
+`;
+        const shopB = `---
+tipo: tienda
+nombre: Tienda B
+pnj: pnj_inexistente
+---
+| articulo | precio | stock | nota |
+|---|---|---|---|
+| Otra | 20 | - |  |
+`;
+        const model = await scanWorldFolder(
+            makeHandle('campaign', treeWithShops({ 'a.md': shopA, 'b.md': shopB }))
+        );
+
+        const shops = model.tiendas.get('porto_verne')!;
+        // listEntries sorts by name: a.md < b.md.
+        expect(shops.map((s) => s.id)).toEqual(['a', 'b']);
+        const aviso = model.problemas.find(
+            (p) => p.archivo.includes('b.md') && p.mensaje.includes('pnj')
+        );
+        expect(aviso).toBeDefined();
+        expect(aviso!.nivel).toBe('aviso');
+        // The valid pnj (kael_zara) raises no dangling aviso.
+        expect(
+            model.problemas.some((p) => p.archivo.includes('a.md') && p.mensaje.includes('pnj'))
+        ).toBe(false);
+    });
+
+    test('a place without tiendas/ has no shops and no aviso', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+        expect(model.tiendas.size).toBe(0);
+        expect(model.problemas.some((p) => p.archivo.includes('tiendas'))).toBe(false);
+    });
+
+    test('tiendas/ ignore rules: _-prefixed shop files are skipped', async () => {
+        const model = await scanWorldFolder(
+            makeHandle(
+                'campaign',
+                treeWithShops({ '_borrador.md': SHOP_TALLER, 'real.md': SHOP_TALLER })
+            )
+        );
+        const shops = model.tiendas.get('porto_verne')!;
+        expect(shops.map((s) => s.id)).toEqual(['real']);
+    });
+});
+
+// ── Session recap (mundo/resumen.md) → model.resumen ────────────────────────
+
+describe('scanWorldFolder — resumen', () => {
+    test('reads mundo/resumen.md verbatim into model.resumen', async () => {
+        const tree = happyTree();
+        (tree.mundo as FileTree)['resumen.md'] =
+            '# Anteriormente\n\nEl grupo llegó a Porto Verne con la bodega vacía.';
+        const model = await scanWorldFolder(makeHandle('campaign', tree));
+        expect(model.resumen).toBe(
+            '# Anteriormente\n\nEl grupo llegó a Porto Verne con la bodega vacía.'
+        );
+        // It is never treated as an entity.
+        expect(model.entidades.has('resumen')).toBe(false);
+    });
+
+    test('absent resumen.md yields null and NO aviso (optional by design)', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+        expect(model.resumen).toBeNull();
+        expect(model.problemas.some((p) => p.archivo.includes('resumen'))).toBe(false);
+    });
+});
+
 // ── Stores (headless zustand) ───────────────────────────────────────────────
 
 describe('worldStore', () => {

--- a/lib/world/worldScanner.test.ts
+++ b/lib/world/worldScanner.test.ts
@@ -249,8 +249,9 @@ describe('scanWorldFolder — happy path', () => {
             calls.push([done, total]);
         });
 
-        // 1 manifest + 2 sistemas + 1 faccion + 1 pnj + 2 pistas + 1 trama + 3 lugares + 1 carpeta
-        const total = 12;
+        // 1 manifest + 1 estado/grupo.md + 2 sistemas + 1 faccion + 1 pnj + 2 pistas
+        // + 1 trama + 3 lugares + 1 carpeta
+        const total = 13;
         expect(calls.length).toBeGreaterThan(0);
         expect(calls[0]).toEqual([1, total]);
         expect(calls[calls.length - 1]).toEqual([total, total]);
@@ -395,9 +396,11 @@ describe('scanWorldFolder — validation', () => {
             })
         );
 
-        const avisos = model.problemas.filter((p) => p.nivel === 'aviso');
+        // Filtered by archivo: this tree has no estado/, whose absence adds its own aviso.
+        const avisos = model.problemas.filter(
+            (p) => p.nivel === 'aviso' && p.archivo === 'mundo/sistemas/fantasma.md'
+        );
         expect(avisos).toHaveLength(1);
-        expect(avisos[0].archivo).toBe('mundo/sistemas/fantasma.md');
         expect(avisos[0].mensaje).toContain('huérfana');
     });
 
@@ -481,6 +484,76 @@ describe('scanWorldFolder — accionable + manifest defaults', () => {
         expect(model.manifest.medidores).toEqual(['viveres', 'combustible', 'nave']);
         expect(model.manifest.regiones).toEqual([]);
         expect(model.manifest.calendario.diasPorMes).toBe(30);
+    });
+});
+
+// ── estado/grupo.md → model.estadoGrupo ─────────────────────────────────────
+
+describe('scanWorldFolder — estado del grupo', () => {
+    test('happy tree: estadoGrupo parsed with defaults for missing fields', async () => {
+        const model = await scanWorldFolder(makeHandle('campaign', happyTree()));
+
+        expect(model.estadoGrupo).not.toBeNull();
+        expect(model.estadoGrupo!.creditos).toBe(100);
+        expect(model.estadoGrupo!.filePath).toBe('mundo/estado/grupo.md');
+        expect(model.estadoGrupo!.sesionActiva).toBe(false);
+        expect(model.estadoGrupo!.diaMundo).toBe(1);
+        expect(model.estadoGrupo!.ubicacion).toBeNull();
+        expect(model.estadoGrupo!.medidores).toEqual({ viveres: 3, combustible: 3, nave: 3 });
+    });
+
+    test('missing estado/grupo.md: null model field + aviso', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', { mundo: { 'mundo.md': FULL_MANIFEST } })
+        );
+
+        expect(model.estadoGrupo).toBeNull();
+        const avisos = model.problemas.filter(
+            (p) => p.nivel === 'aviso' && p.archivo === 'mundo/estado/grupo.md'
+        );
+        expect(avisos).toHaveLength(1);
+        expect(avisos[0].mensaje).toContain('No se encontró');
+    });
+
+    test('dangling ubicacion and rumbo.destino: aviso each, refs kept', async () => {
+        const model = await scanWorldFolder(
+            makeHandle('campaign', {
+                mundo: {
+                    'mundo.md': FULL_MANIFEST,
+                    estado: {
+                        'grupo.md':
+                            '---\nubicacion: no_existe\nrumbo: {destino: tampoco, llegada_dia: 9}\n---\n',
+                    },
+                },
+            })
+        );
+
+        const avisos = model.problemas.filter(
+            (p) => p.nivel === 'aviso' && p.archivo === 'mundo/estado/grupo.md'
+        );
+        expect(avisos).toHaveLength(2);
+        expect(avisos[0].mensaje).toContain('"ubicacion"');
+        expect(avisos[0].mensaje).toContain('"no_existe"');
+        expect(avisos[1].mensaje).toContain('"rumbo.destino"');
+        expect(avisos[1].mensaje).toContain('"tampoco"');
+        // Degraded load: the refs stay readable for the UI even when dangling.
+        expect(model.estadoGrupo!.ubicacion).toBe('no_existe');
+        expect(model.estadoGrupo!.rumbo).toEqual({ destino: 'tampoco', llegadaDia: 9 });
+    });
+
+    test('resolving ubicacion/rumbo refs produces no avisos', async () => {
+        const tree = happyTree();
+        (tree.mundo as FileTree).estado = {
+            'grupo.md':
+                '---\nubicacion: porto_verne\nrumbo: {destino: sistema_kovar, llegada_dia: 12}\n---\n',
+        };
+        const model = await scanWorldFolder(makeHandle('campaign', tree));
+
+        expect(
+            model.problemas.some((p) => p.archivo === 'mundo/estado/grupo.md')
+        ).toBe(false);
+        expect(model.estadoGrupo!.ubicacion).toBe('porto_verne');
+        expect(model.estadoGrupo!.rumbo).toEqual({ destino: 'sistema_kovar', llegadaDia: 12 });
     });
 });
 

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -8,8 +8,10 @@
 
 import { FileReference, SessionConfig } from '@/types';
 import {
+    Conocimiento,
     FactionEntity,
     FactionPresence,
+    JournalDay,
     Lead,
     NpcEntity,
     PartyState,
@@ -23,6 +25,8 @@ import {
 } from '@/types/world';
 import { scanSessionFolder } from '@/lib/sessionScanner';
 import { fileNameToDisplayName, getSubdirectory, readFileContent } from '@/lib/fsScanUtils';
+import { parseJournal, parseLlegadaPayload, parseSabePayload } from './logEntries';
+import { ancestryChain } from './worldNav';
 import { parsePartyState } from './partyState';
 import {
     asCoords,
@@ -138,22 +142,54 @@ export async function scanWorldFolder(
     return assembleModel(manifest, records, problemas, estadoGrupo);
 }
 
+/** NotFoundError as thrown by the real FS Access API (DOMException) or the test mock. */
+function isNotFoundError(error: unknown): boolean {
+    if (typeof error === 'object' && error !== null && 'name' in error) {
+        if ((error as { name: unknown }).name === 'NotFoundError') return true;
+    }
+    return error instanceof Error && error.message.startsWith('NotFoundError');
+}
+
 /**
  * Reads + parses `estado/grupo.md`. An absent file (or absent `estado/` dir)
  * is a normal pre-M6 world: null model field plus an aviso, never an error.
+ * A file that EXISTS but cannot be read is a real error-level issue carrying
+ * the underlying message — never conflated with absence.
  */
 async function readPartyState(
     mundoDir: FileSystemDirectoryHandle,
     problemas: ValidationIssue[]
 ): Promise<PartyState | null> {
+    const readError = (error: unknown) => {
+        const detail = error instanceof Error ? error.message : String(error);
+        problemas.push({
+            nivel: 'error',
+            archivo: PARTY_STATE_PATH,
+            mensaje: `No se pudo leer ${ENTITY_DIRS.estado}/${PARTY_STATE_FILE}: ${detail}`,
+        });
+    };
+
     let content: string | null = null;
     const estadoDir = await getSubdirectory(mundoDir, ENTITY_DIRS.estado);
     if (estadoDir) {
+        let fileHandle: FileSystemFileHandle | null = null;
         try {
-            const fileHandle = await estadoDir.getFileHandle(PARTY_STATE_FILE);
-            content = await readFileContent(fileHandle);
-        } catch {
-            content = null;
+            fileHandle = await estadoDir.getFileHandle(PARTY_STATE_FILE);
+        } catch (error) {
+            if (!isNotFoundError(error)) {
+                readError(error);
+                return null;
+            }
+        }
+        if (fileHandle) {
+            // NOT readFileContent(): that helper swallows read failures as ''.
+            try {
+                const file = await fileHandle.getFile();
+                content = await file.text();
+            } catch (error) {
+                readError(error);
+                return null;
+            }
         }
     }
 
@@ -176,7 +212,8 @@ async function readPartyState(
 type EntityKind = 'sistema' | 'lugar' | 'faccion' | 'pnj' | 'pista' | 'trama';
 
 interface RawEntityFile {
-    kind: EntityKind;
+    /** 'diario' records become JournalDays, never entities. */
+    kind: EntityKind | 'diario';
     /** filename minus .md, or the folder name for playable place folders. */
     id: string;
     /** Path relative to the campaign folder. */
@@ -194,8 +231,9 @@ interface TaskResult {
 type ScanTask = () => Promise<TaskResult>;
 
 /**
- * Flat entity dirs scanned as `*.md` files. eventos/ and diario/ are still
- * skipped (M4/M3); estado/grupo.md is read separately via readPartyState.
+ * Flat entity dirs scanned as `*.md` files. eventos/ is still skipped (M4);
+ * diario/ is scanned separately below (journals, not entities) and
+ * estado/grupo.md is read via readPartyState.
  */
 const FLAT_KIND_DIRS: ReadonlyArray<{ kind: EntityKind; dir: string }> = [
     { kind: 'sistema', dir: ENTITY_DIRS.sistemas },
@@ -276,6 +314,24 @@ async function collectTasks(mundoDir: FileSystemDirectoryHandle): Promise<ScanTa
         }
         for (const dir of dirs) {
             tasks.push(() => scanPlaceFolder(dir.name, dir.handle));
+        }
+    }
+
+    // diario/: session journals (M3) — parsed into model.diario, not entities.
+    const diarioDir = await getSubdirectory(mundoDir, ENTITY_DIRS.diario);
+    if (diarioDir) {
+        const { files } = await listEntries(diarioDir);
+        for (const file of files) {
+            const filePath = `${WORLD_DIR}/${ENTITY_DIRS.diario}/${file.name}`;
+            tasks.push(async () => ({
+                record: {
+                    kind: 'diario',
+                    id: stripMd(file.name),
+                    filePath,
+                    content: await readFileContent(file.handle),
+                },
+                issues: [],
+            }));
         }
     }
 
@@ -727,8 +783,15 @@ function assembleModel(
     const pnjs: NpcEntity[] = [];
     const pistas: Lead[] = [];
     const tramas: Trama[] = [];
+    const diario: JournalDay[] = [];
 
     for (const record of records) {
+        // Journals are not entities: no id dedupe, own tolerant parser.
+        if (record.kind === 'diario') {
+            diario.push(parseJournal(record.content, record.filePath));
+            continue;
+        }
+
         const parsed = parseFrontmatter(record.content, record.filePath);
         if (parsed.issue) problemas.push(parsed.issue);
         const data = normalizeKeys(parsed.data);
@@ -784,16 +847,16 @@ function assembleModel(
         }
     }
 
+    sortDiario(diario);
+    warnStaleDiario(diario, problemas);
+
     checkDanglingRefs(entidades, lugares, pnjs, pistas, problemas);
     checkPartyStateRefs(entidades, estadoGrupo, problemas);
-    warnOrphans(entidades, sistemas, lugares, facciones, pnjs, pistas, tramas, problemas);
 
     const childrenOf = deriveChildrenOf(entidades, sistemas, lugares);
     deriveRegionInheritance(entidades, lugares);
-    deriveLeadActionability(entidades, pistas, problemas);
-    groupTramaPistas(tramas, pistas);
 
-    return {
+    const model: WorldModel = {
         manifest,
         entidades,
         sistemas,
@@ -805,7 +868,107 @@ function assembleModel(
         problemas,
         childrenOf,
         estadoGrupo,
+        diario,
     };
+
+    // Unprocessed journals re-overlay in-session knowledge BEFORE the
+    // knowledge-dependent derivations (orphans, accionable) run, so the GM
+    // sees the post-session world even before the agent maintenance loop.
+    overlayUnprocessedJournals(model);
+    warnOrphans(entidades, sistemas, lugares, facciones, pnjs, pistas, tramas, problemas);
+    deriveLeadActionability(entidades, pistas, problemas);
+    groupTramaPistas(tramas, pistas);
+
+    return model;
+}
+
+// ── Journal overlay (M3) ────────────────────────────────────────────────────
+
+/** Chronological: fecha_real (ISO strings sort lexically), then sesion. */
+function sortDiario(diario: JournalDay[]): void {
+    diario.sort((a, b) => {
+        if (a.fechaReal !== b.fechaReal) return a.fechaReal.localeCompare(b.fechaReal);
+        if (a.sesion !== b.sesion) return a.sesion - b.sesion;
+        return a.filePath.localeCompare(b.filePath);
+    });
+}
+
+/**
+ * An unprocessed journal older than the newest one means the agent
+ * maintenance loop was skipped after some earlier session.
+ */
+function warnStaleDiario(diario: JournalDay[], problemas: ValidationIssue[]): void {
+    let newest = '';
+    for (const day of diario) {
+        if (day.fechaReal > newest) newest = day.fechaReal;
+    }
+    for (const day of diario) {
+        if (!day.procesado && day.fechaReal < newest) {
+            problemas.push({
+                nivel: 'aviso',
+                archivo: day.filePath,
+                mensaje:
+                    'Diario sin procesar de una sesión anterior — falta el mantenimiento del agente',
+            });
+        }
+    }
+}
+
+const CONOCIMIENTO_RANK = new Map<Conocimiento, number>(
+    CONOCIMIENTOS.map((nivel, index) => [nivel, index])
+);
+
+/** Raises an entity's conocimiento to at least `minimo` — never lowers it. */
+function bumpConocimiento(
+    entidades: Map<string, WorldEntityBase>,
+    id: string,
+    minimo: Conocimiento
+): void {
+    const entity = entidades.get(id);
+    if (!entity) return;
+    const actual = CONOCIMIENTO_RANK.get(entity.conocimiento) ?? 0;
+    const objetivo = CONOCIMIENTO_RANK.get(minimo) ?? 0;
+    if (objetivo > actual) entity.conocimiento = minimo;
+}
+
+/**
+ * In-memory knowledge effect of arriving at a place: the destination is
+ * raised to at least `visitado` and every `en:` ancestor to at least
+ * `conocido` (knowledge never lowers). Shared by the journal overlay below
+ * and the live "Mover" action on /world (M3) — persistence to entity files
+ * remains the agent's job.
+ */
+export function applyLlegadaConocimiento(model: WorldModel, lugarId: string): void {
+    bumpConocimiento(model.entidades, lugarId, 'visitado');
+    for (const ancestorId of ancestryChain(model, lugarId).slice(1)) {
+        bumpConocimiento(model.entidades, ancestorId, 'conocido');
+    }
+}
+
+/**
+ * Re-derives the in-memory effects of journals the agent has not processed
+ * yet (procesado: false), in chronological order:
+ *   - sabe    -> raise the entity's conocimiento to the logged target level
+ *   - llegada -> destination at least visitado; `en:` ancestors at least
+ *                conocido (same ancestry logic as worldNav)
+ * Unknown ids and unparseable payloads are silently skipped — the journal is
+ * a log, not a validated source, and the agent will reconcile it later.
+ */
+function overlayUnprocessedJournals(model: WorldModel): void {
+    for (const day of model.diario) {
+        if (day.procesado) continue;
+        for (const entrada of day.entradas) {
+            if (entrada.tipo === 'sabe') {
+                const sabe = parseSabePayload(entrada.payload);
+                if (sabe && (CONOCIMIENTOS as readonly string[]).includes(sabe.to)) {
+                    bumpConocimiento(model.entidades, sabe.id, sabe.to as Conocimiento);
+                }
+            } else if (entrada.tipo === 'llegada') {
+                const llegada = parseLlegadaPayload(entrada.payload);
+                if (llegada) applyLlegadaConocimiento(model, llegada.lugarId);
+            }
+        }
+    }
 }
 
 /**
@@ -994,8 +1157,11 @@ function deriveRegionInheritance(
  * is absent-or-conocido/visitado. Any requisitos entry degrades the result to
  * 'manual' ("según GM") — evalCondition() arrives in M4; until then the app
  * cannot check condition strings against PartyState.
+ *
+ * Exported for /world (M3): live pista transitions re-run it on the touched
+ * lead (with a throwaway issues array) so `accionable` stays coherent.
  */
-function deriveLeadActionability(
+export function deriveLeadActionability(
     entidades: Map<string, WorldEntityBase>,
     pistas: Lead[],
     problemas: ValidationIssue[]

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -12,6 +12,7 @@ import {
     FactionPresence,
     Lead,
     NpcEntity,
+    PartyState,
     PlaceEntity,
     SystemEntity,
     Trama,
@@ -22,6 +23,7 @@ import {
 } from '@/types/world';
 import { scanSessionFolder } from '@/lib/sessionScanner';
 import { fileNameToDisplayName, getSubdirectory, readFileContent } from '@/lib/fsScanUtils';
+import { parsePartyState } from './partyState';
 import {
     asCoords,
     asNumber,
@@ -42,6 +44,7 @@ import {
     MANIFEST_DEFAULTS,
     MANIFEST_FILE,
     NIVELES_PRESENCIA,
+    PARTY_STATE_FILE,
     PLACE_FOLDER_FILE,
     ROLES_PNJ,
     ROLES_TRAMA,
@@ -58,6 +61,8 @@ export type ScanProgressCallback = (done: number, total: number) => void;
 const READ_BATCH_SIZE = 25;
 
 const MANIFEST_PATH = `${WORLD_DIR}/${MANIFEST_FILE}`;
+
+const PARTY_STATE_PATH = `${WORLD_DIR}/${ENTITY_DIRS.estado}/${PARTY_STATE_FILE}`;
 
 // ── Public API ──────────────────────────────────────────────────────────────
 
@@ -92,12 +97,12 @@ export async function scanWorldFolder(
             mensaje: `No se encontró la carpeta "${WORLD_DIR}/" en la carpeta de campaña`,
         });
         onProgress?.(1, 1);
-        return assembleModel(defaultManifest(), [], problemas);
+        return assembleModel(defaultManifest(), [], problemas, null);
     }
 
     // Enumerate first (cheap directory listings), then read contents in batches.
     const tasks = await collectTasks(mundoDir);
-    const totalReads = 1 + tasks.length; // +1 = the manifest itself
+    const totalReads = 2 + tasks.length; // +2 = manifest + estado/grupo.md
     let done = 0;
 
     // Manifest read
@@ -109,6 +114,11 @@ export async function scanWorldFolder(
         manifestContent = null;
     }
     done = 1;
+    onProgress?.(done, totalReads);
+
+    // Party state read (estado/grupo.md)
+    const estadoGrupo = await readPartyState(mundoDir, problemas);
+    done = 2;
     onProgress?.(done, totalReads);
 
     // Entity reads, batched
@@ -125,7 +135,40 @@ export async function scanWorldFolder(
     }
 
     const manifest = parseManifest(manifestContent, problemas);
-    return assembleModel(manifest, records, problemas);
+    return assembleModel(manifest, records, problemas, estadoGrupo);
+}
+
+/**
+ * Reads + parses `estado/grupo.md`. An absent file (or absent `estado/` dir)
+ * is a normal pre-M6 world: null model field plus an aviso, never an error.
+ */
+async function readPartyState(
+    mundoDir: FileSystemDirectoryHandle,
+    problemas: ValidationIssue[]
+): Promise<PartyState | null> {
+    let content: string | null = null;
+    const estadoDir = await getSubdirectory(mundoDir, ENTITY_DIRS.estado);
+    if (estadoDir) {
+        try {
+            const fileHandle = await estadoDir.getFileHandle(PARTY_STATE_FILE);
+            content = await readFileContent(fileHandle);
+        } catch {
+            content = null;
+        }
+    }
+
+    if (content === null) {
+        problemas.push({
+            nivel: 'aviso',
+            archivo: PARTY_STATE_PATH,
+            mensaje: `No se encontró ${ENTITY_DIRS.estado}/${PARTY_STATE_FILE} — no hay estado del grupo`,
+        });
+        return null;
+    }
+
+    const { state, issues } = parsePartyState(content, PARTY_STATE_PATH);
+    problemas.push(...issues);
+    return state;
 }
 
 // ── Enumeration + batched reads ─────────────────────────────────────────────
@@ -150,7 +193,10 @@ interface TaskResult {
 
 type ScanTask = () => Promise<TaskResult>;
 
-/** Flat entity dirs scanned as `*.md` files. eventos/estado/diario are skipped in M1. */
+/**
+ * Flat entity dirs scanned as `*.md` files. eventos/ and diario/ are still
+ * skipped (M4/M3); estado/grupo.md is read separately via readPartyState.
+ */
 const FLAT_KIND_DIRS: ReadonlyArray<{ kind: EntityKind; dir: string }> = [
     { kind: 'sistema', dir: ENTITY_DIRS.sistemas },
     { kind: 'faccion', dir: ENTITY_DIRS.facciones },
@@ -671,7 +717,8 @@ function buildTrama(
 function assembleModel(
     manifest: WorldManifest,
     records: RawEntityFile[],
-    problemas: ValidationIssue[]
+    problemas: ValidationIssue[],
+    estadoGrupo: PartyState | null
 ): WorldModel {
     const entidades = new Map<string, WorldEntityBase>();
     const sistemas: SystemEntity[] = [];
@@ -738,6 +785,7 @@ function assembleModel(
     }
 
     checkDanglingRefs(entidades, lugares, pnjs, pistas, problemas);
+    checkPartyStateRefs(entidades, estadoGrupo, problemas);
     warnOrphans(entidades, sistemas, lugares, facciones, pnjs, pistas, tramas, problemas);
 
     const childrenOf = deriveChildrenOf(entidades, sistemas, lugares);
@@ -756,7 +804,36 @@ function assembleModel(
         tramas,
         problemas,
         childrenOf,
+        estadoGrupo,
     };
+}
+
+/**
+ * Party-state refs pointing at entities that don't exist are AVISOS (not
+ * errors): grupo.md is app/agent-written state, and a half-built world must
+ * still load with its party readout intact.
+ */
+function checkPartyStateRefs(
+    entidades: Map<string, WorldEntityBase>,
+    estadoGrupo: PartyState | null,
+    problemas: ValidationIssue[]
+): void {
+    if (!estadoGrupo || estadoGrupo.filePath === null) return;
+
+    const dangling = (campo: string, target: string) => {
+        problemas.push({
+            nivel: 'aviso',
+            archivo: estadoGrupo.filePath!,
+            mensaje: `Referencia colgante en "${campo}": "${target}" no existe`,
+        });
+    };
+
+    if (estadoGrupo.ubicacion !== null && !entidades.has(estadoGrupo.ubicacion)) {
+        dangling('ubicacion', estadoGrupo.ubicacion);
+    }
+    if (estadoGrupo.rumbo !== null && !entidades.has(estadoGrupo.rumbo.destino)) {
+        dangling('rumbo.destino', estadoGrupo.rumbo.destino);
+    }
 }
 
 function checkDanglingRefs(

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -8,7 +8,9 @@
 
 import { FileReference, SessionConfig } from '@/types';
 import {
+    CondContext,
     Conocimiento,
+    EventTable,
     FactionEntity,
     FactionPresence,
     JournalDay,
@@ -25,9 +27,11 @@ import {
 } from '@/types/world';
 import { scanSessionFolder } from '@/lib/sessionScanner';
 import { fileNameToDisplayName, getSubdirectory, readFileContent } from '@/lib/fsScanUtils';
+import { buildCondContext, evalConditions, isParseableCondition } from './conditions';
+import { parseEventTable } from './eventEngine';
 import { parseJournal, parseLlegadaPayload, parseSabePayload } from './logEntries';
 import { ancestryChain } from './worldNav';
-import { parsePartyState } from './partyState';
+import { defaultPartyState, parsePartyState } from './partyState';
 import {
     asCoords,
     asNumber,
@@ -212,8 +216,8 @@ async function readPartyState(
 type EntityKind = 'sistema' | 'lugar' | 'faccion' | 'pnj' | 'pista' | 'trama';
 
 interface RawEntityFile {
-    /** 'diario' records become JournalDays, never entities. */
-    kind: EntityKind | 'diario';
+    /** 'diario' records become JournalDays and 'evento' records EventTables — never entities. */
+    kind: EntityKind | 'diario' | 'evento';
     /** filename minus .md, or the folder name for playable place folders. */
     id: string;
     /** Path relative to the campaign folder. */
@@ -231,8 +235,8 @@ interface TaskResult {
 type ScanTask = () => Promise<TaskResult>;
 
 /**
- * Flat entity dirs scanned as `*.md` files. eventos/ is still skipped (M4);
- * diario/ is scanned separately below (journals, not entities) and
+ * Flat entity dirs scanned as `*.md` files. eventos/ and diario/ are scanned
+ * separately below (event tables and journals, not entities) and
  * estado/grupo.md is read via readPartyState.
  */
 const FLAT_KIND_DIRS: ReadonlyArray<{ kind: EntityKind; dir: string }> = [
@@ -314,6 +318,24 @@ async function collectTasks(mundoDir: FileSystemDirectoryHandle): Promise<ScanTa
         }
         for (const dir of dirs) {
             tasks.push(() => scanPlaceFolder(dir.name, dir.handle));
+        }
+    }
+
+    // eventos/: event tables (M4) — parsed into model.tablas, not entities.
+    const eventosDir = await getSubdirectory(mundoDir, ENTITY_DIRS.eventos);
+    if (eventosDir) {
+        const { files } = await listEntries(eventosDir);
+        for (const file of files) {
+            const filePath = `${WORLD_DIR}/${ENTITY_DIRS.eventos}/${file.name}`;
+            tasks.push(async () => ({
+                record: {
+                    kind: 'evento',
+                    id: stripMd(file.name),
+                    filePath,
+                    content: await readFileContent(file.handle),
+                },
+                issues: [],
+            }));
         }
     }
 
@@ -465,6 +487,22 @@ function parseManifest(content: string | null, problemas: ValidationIssue[]): Wo
     if (data.medidores === undefined) missing('medidores');
     if (data.regiones === undefined) missing('regiones');
 
+    const medidores =
+        data.medidores === undefined ? [...fallback.medidores] : asStringArray(data.medidores);
+    // Whitespace would break the strict `medidor <nombre> A->B` journal
+    // payload grammar (the name parses as \S+) AND the condition grammar.
+    for (const nombre of medidores) {
+        if (/\s/.test(nombre)) {
+            problemas.push({
+                nivel: 'aviso',
+                archivo: MANIFEST_PATH,
+                mensaje:
+                    `Nombre de medidor con espacios: "${nombre}" — ` +
+                    'no funciona en las entradas "medidor" del diario ni en condiciones',
+            });
+        }
+    }
+
     return {
         nombre: nombre ?? fallback.nombre,
         calendario: {
@@ -483,8 +521,7 @@ function parseManifest(content: string | null, problemas: ValidationIssue[]): Wo
             viveresCadaDias:
                 asNumber(viaje?.viveres_cada_dias) ?? fallback.viaje.viveresCadaDias,
         },
-        medidores:
-            data.medidores === undefined ? fallback.medidores : asStringArray(data.medidores),
+        medidores,
         regiones: data.regiones === undefined ? fallback.regiones : asStringArray(data.regiones),
     };
 }
@@ -783,12 +820,23 @@ function assembleModel(
     const pnjs: NpcEntity[] = [];
     const pistas: Lead[] = [];
     const tramas: Trama[] = [];
+    const tablas: EventTable[] = [];
     const diario: JournalDay[] = [];
 
     for (const record of records) {
         // Journals are not entities: no id dedupe, own tolerant parser.
         if (record.kind === 'diario') {
             diario.push(parseJournal(record.content, record.filePath));
+            continue;
+        }
+
+        // Event tables live in model.tablas only (drawn from the EventDrawer,
+        // never selected on the map) — like journals, they stay out of the
+        // entity map and its global id dedupe.
+        if (record.kind === 'evento') {
+            const parsedTable = parseEventTable(record.content, record.filePath, record.id);
+            problemas.push(...parsedTable.issues);
+            tablas.push(parsedTable.table);
             continue;
         }
 
@@ -865,6 +913,7 @@ function assembleModel(
         pnjs,
         pistas,
         tramas,
+        tablas,
         problemas,
         childrenOf,
         estadoGrupo,
@@ -876,7 +925,7 @@ function assembleModel(
     // sees the post-session world even before the agent maintenance loop.
     overlayUnprocessedJournals(model);
     warnOrphans(entidades, sistemas, lugares, facciones, pnjs, pistas, tramas, problemas);
-    deriveLeadActionability(entidades, pistas, problemas);
+    deriveLeadActionability(model, pistas, problemas);
     groupTramaPistas(tramas, pistas);
 
     return model;
@@ -1152,21 +1201,57 @@ function deriveRegionInheritance(
     }
 }
 
+/** `manual: <texto>` requisito — the app never evaluates it, the GM does. */
+const MANUAL_REQUISITO = /^manual\s*:/;
+
 /**
- * Lead.accionable (derived, never stored): estadoPista activa/en_curso AND donde
- * is absent-or-conocido/visitado. Any requisitos entry degrades the result to
- * 'manual' ("según GM") — evalCondition() arrives in M4; until then the app
- * cannot check condition strings against PartyState.
+ * Lead.accionable (derived, never stored): estadoPista activa/en_curso AND
+ * donde absent-or-conocido/visitado AND requisitos satisfied (M4):
+ *   - all conditions true            -> true
+ *   - any `manual:` entry OR any condition null (unparseable/unevaluable)
+ *                                    -> 'manual' ("según GM" — the GM decides,
+ *                                       so null/manual dominate a false)
+ *   - otherwise (some condition false) -> false
+ * Conditions evaluate through evalConditions against a CondContext built from
+ * estado/grupo.md (party defaults when the file is absent, lugarActual =
+ * estadoGrupo.ubicacion). Syntactically bad requisitos also earn an aviso.
  *
- * Exported for /world (M3): live pista transitions re-run it on the touched
- * lead (with a throwaway issues array) so `accionable` stays coherent.
+ * Exported for /world: live pista transitions re-run it on the touched lead
+ * (with a throwaway issues array). SIGNATURE CHANGED IN M4: takes the whole
+ * WorldModel (was the entidades map) because the context needs ancestry +
+ * estadoGrupo; pass `ctx` to evaluate against LIVE party numbers instead of
+ * the scan-frozen estadoGrupo (the page builds it via buildCondContext).
  */
 export function deriveLeadActionability(
-    entidades: Map<string, WorldEntityBase>,
+    model: WorldModel,
     pistas: Lead[],
-    problemas: ValidationIssue[]
+    problemas: ValidationIssue[],
+    ctx?: CondContext
 ): void {
+    const entidades = model.entidades;
+    const context =
+        ctx ??
+        buildCondContext(
+            model,
+            model.estadoGrupo ?? defaultPartyState(),
+            model.estadoGrupo?.ubicacion ?? null
+        );
+
     for (const pista of pistas) {
+        const manual = pista.requisitos.some((req) => MANUAL_REQUISITO.test(req.trim()));
+        const condiciones = pista.requisitos.filter((req) => !MANUAL_REQUISITO.test(req.trim()));
+
+        // File-content validation — independent of the party's current state.
+        for (const cond of condiciones) {
+            if (!isParseableCondition(cond)) {
+                problemas.push({
+                    nivel: 'aviso',
+                    archivo: pista.filePath,
+                    mensaje: `Requisito no interpretable: "${cond}" — la pista queda "según GM"`,
+                });
+            }
+        }
+
         const estadoOk = pista.estadoPista === 'activa' || pista.estadoPista === 'en_curso';
 
         let dondeOk = true;
@@ -1190,11 +1275,10 @@ export function deriveLeadActionability(
 
         if (!estadoOk || !dondeOk) {
             pista.accionable = false;
-        } else if (pista.requisitos.length > 0) {
-            pista.accionable = 'manual';
-        } else {
-            pista.accionable = true;
+            continue;
         }
+        const cumplidas = evalConditions(condiciones, context); // [] -> true
+        pista.accionable = manual || cumplidas === null ? 'manual' : cumplidas;
     }
 }
 

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -26,7 +26,14 @@ import {
     WorldModel,
 } from '@/types/world';
 import { scanSessionFolder } from '@/lib/sessionScanner';
-import { fileNameToDisplayName, getSubdirectory, readFileContent } from '@/lib/fsScanUtils';
+import {
+    createAudioFile,
+    fileNameToDisplayName,
+    getFilesFromDirectory,
+    getSubdirectory,
+    readFileContent,
+} from '@/lib/fsScanUtils';
+import { SUPPORTED_AUDIO_EXTENSIONS } from '@/lib/fileSystem';
 import { buildCondContext, evalConditions, isParseableCondition } from './conditions';
 import { parseEventTable } from './eventEngine';
 import { parseJournal, parseLlegadaPayload, parseSabePayload } from './logEntries';
@@ -51,6 +58,7 @@ import {
     ESTADOS_TRAMA,
     MANIFEST_DEFAULTS,
     MANIFEST_FILE,
+    MUSIC_DIR,
     NIVELES_PRESENCIA,
     PARTY_STATE_FILE,
     PLACE_FOLDER_FILE,
@@ -105,7 +113,7 @@ export async function scanWorldFolder(
             mensaje: `No se encontró la carpeta "${WORLD_DIR}/" en la carpeta de campaña`,
         });
         onProgress?.(1, 1);
-        return assembleModel(defaultManifest(), [], problemas, null);
+        return assembleModel(defaultManifest(), [], problemas, null, emptyMusica());
     }
 
     // Enumerate first (cheap directory listings), then read contents in batches.
@@ -129,6 +137,10 @@ export async function scanWorldFolder(
     done = 2;
     onProgress?.(done, totalReads);
 
+    // World-level music (musica/): directory listings only, never file reads,
+    // so it stays outside the read-progress accounting.
+    const musica = await scanWorldMusic(mundoDir);
+
     // Entity reads, batched
     const records: RawEntityFile[] = [];
     for (let i = 0; i < tasks.length; i += READ_BATCH_SIZE) {
@@ -143,7 +155,73 @@ export async function scanWorldFolder(
     }
 
     const manifest = parseManifest(manifestContent, problemas);
-    return assembleModel(manifest, records, problemas, estadoGrupo);
+    return assembleModel(manifest, records, problemas, estadoGrupo, musica);
+}
+
+// ── World-level music (musica/) ─────────────────────────────────────────────
+
+function emptyMusica(): WorldModel['musica'] {
+    return { bgm: [], eventPlaylists: [] };
+}
+
+/**
+ * Scans the OPTIONAL `mundo/musica/` folder: audio files at its root are the
+ * world BGM rotation (generic ambient/travel beds), each subfolder a named
+ * event playlist (folder name -> display name, files inside -> its tracks).
+ * Markdown prompt docs living there are excluded by the audio-extension
+ * filter; the usual ignore rules apply on top (`_`-prefixed files/dirs,
+ * ALL-CAPS dirs). An absent folder yields empty arrays and NO aviso — the
+ * folder is optional by design. Paths arrive prefixed `mundo/musica/...` so
+ * the world fs manager (campaign root) resolves them directly.
+ */
+async function scanWorldMusic(
+    mundoDir: FileSystemDirectoryHandle
+): Promise<WorldModel['musica']> {
+    const musica = emptyMusica();
+    const musicaDir = await getSubdirectory(mundoDir, MUSIC_DIR);
+    if (!musicaDir) return musica;
+
+    const basePath = `${WORLD_DIR}/${MUSIC_DIR}`;
+    const rootFiles = await getFilesFromDirectory(
+        musicaDir,
+        basePath,
+        SUPPORTED_AUDIO_EXTENSIONS
+    );
+    musica.bgm = rootFiles
+        .filter((file) => !isIgnoredFile(file.name))
+        .map((file) => createAudioFile(file));
+
+    // Subfolders (same dir ignore rules as listEntries), name-sorted so the
+    // playlist order is stable across scans and platforms.
+    const subdirs: Array<{ name: string; handle: FileSystemDirectoryHandle }> = [];
+    for await (const [name, entryHandle] of musicaDir.entries()) {
+        if (entryHandle.kind !== 'directory') continue;
+        if (isIgnoredDir(name) || name.startsWith('_')) continue;
+        subdirs.push({ name, handle: entryHandle as FileSystemDirectoryHandle });
+    }
+    subdirs.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const subdir of subdirs) {
+        const tracks = await getFilesFromDirectory(
+            subdir.handle,
+            `${basePath}/${subdir.name}`,
+            SUPPORTED_AUDIO_EXTENSIONS
+        );
+        const kept = tracks
+            .filter((file) => !isIgnoredFile(file.name))
+            .map((file) => createAudioFile(file));
+        // Empty subfolders never become playlists (same rule as sessionScanner),
+        // and the folder name doubles as a stable, deterministic playlist id.
+        if (kept.length > 0) {
+            musica.eventPlaylists.push({
+                id: subdir.name,
+                name: fileNameToDisplayName(subdir.name),
+                tracks: kept,
+            });
+        }
+    }
+
+    return musica;
 }
 
 /** NotFoundError as thrown by the real FS Access API (DOMException) or the test mock. */
@@ -869,7 +947,8 @@ function assembleModel(
     manifest: WorldManifest,
     records: RawEntityFile[],
     problemas: ValidationIssue[],
-    estadoGrupo: PartyState | null
+    estadoGrupo: PartyState | null,
+    musica: WorldModel['musica']
 ): WorldModel {
     const entidades = new Map<string, WorldEntityBase>();
     const sistemas: SystemEntity[] = [];
@@ -976,6 +1055,7 @@ function assembleModel(
         childrenOf,
         estadoGrupo,
         diario,
+        musica,
     };
 
     // Unprocessed journals re-overlay in-session knowledge BEFORE the

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -918,6 +918,8 @@ function buildLugar(
         en,
         coordenadas,
         orbita: asNumber(data.orbita),
+        // Local Plano coords (0..100); malformed -> undefined, never throws.
+        poi: asCoords(data.poi),
         region: asString(data.region),
         servicios,
         facciones: parseFactionPresences(data.facciones, record.filePath, problemas),

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -28,12 +28,13 @@ import {
 import { scanSessionFolder } from '@/lib/sessionScanner';
 import {
     createAudioFile,
+    createFileReference,
     fileNameToDisplayName,
     getFilesFromDirectory,
     getSubdirectory,
     readFileContent,
 } from '@/lib/fsScanUtils';
-import { SUPPORTED_AUDIO_EXTENSIONS } from '@/lib/fileSystem';
+import { SUPPORTED_AUDIO_EXTENSIONS, SUPPORTED_IMAGE_EXTENSIONS } from '@/lib/fileSystem';
 import { buildCondContext, evalConditions, isParseableCondition } from './conditions';
 import { parseEventTable } from './eventEngine';
 import { parseJournal, parseLlegadaPayload, parseSabePayload } from './logEntries';
@@ -55,6 +56,7 @@ import {
     DEFAULT_CONOCIMIENTO,
     ENTITY_DIRS,
     ESTADOS_PISTA,
+    IMAGES_DIR,
     ESTADOS_TRAMA,
     MANIFEST_DEFAULTS,
     MANIFEST_FILE,
@@ -113,7 +115,7 @@ export async function scanWorldFolder(
             mensaje: `No se encontró la carpeta "${WORLD_DIR}/" en la carpeta de campaña`,
         });
         onProgress?.(1, 1);
-        return assembleModel(defaultManifest(), [], problemas, null, emptyMusica());
+        return assembleModel(defaultManifest(), [], problemas, null, emptyMusica(), new Map());
     }
 
     // Enumerate first (cheap directory listings), then read contents in batches.
@@ -141,6 +143,9 @@ export async function scanWorldFolder(
     // so it stays outside the read-progress accounting.
     const musica = await scanWorldMusic(mundoDir);
 
+    // Entity profile images (imagenes/): one directory listing, never read.
+    const imagenes = await scanEntityImages(mundoDir);
+
     // Entity reads, batched
     const records: RawEntityFile[] = [];
     for (let i = 0; i < tasks.length; i += READ_BATCH_SIZE) {
@@ -155,7 +160,40 @@ export async function scanWorldFolder(
     }
 
     const manifest = parseManifest(manifestContent, problemas);
-    return assembleModel(manifest, records, problemas, estadoGrupo, musica);
+    return assembleModel(manifest, records, problemas, estadoGrupo, musica, imagenes);
+}
+
+// ── Entity profile images (imagenes/) ───────────────────────────────────────
+
+/**
+ * Lists the OPTIONAL `mundo/imagenes/` folder ONCE (directory listing only —
+ * image bytes are never read; the page resolves object URLs lazily): a file
+ * `<entity_id>.<ext>` with a supported image extension becomes the profile
+ * image of the entity with that id, whatever its kind. The usual ignore rules
+ * apply (`_`-prefixed files); an absent folder yields an empty map and NO
+ * aviso — the folder is optional by design. When two files share a basename
+ * (e.g. `kovar_iii.png` + `kovar_iii.svg`) the first in name-sorted order
+ * wins, deterministically. Basenames matching no entity id are flagged in
+ * assembleModel (probable typo) once the entity map exists.
+ */
+async function scanEntityImages(
+    mundoDir: FileSystemDirectoryHandle
+): Promise<Map<string, FileReference>> {
+    const byId = new Map<string, FileReference>();
+    const imagenesDir = await getSubdirectory(mundoDir, IMAGES_DIR);
+    if (!imagenesDir) return byId;
+
+    const files = await getFilesFromDirectory(
+        imagenesDir,
+        `${WORLD_DIR}/${IMAGES_DIR}`,
+        SUPPORTED_IMAGE_EXTENSIONS
+    );
+    for (const file of files) {
+        if (isIgnoredFile(file.name)) continue;
+        const id = file.name.replace(/\.[^.]+$/, '');
+        if (!byId.has(id)) byId.set(id, createFileReference(file, 'image'));
+    }
+    return byId;
 }
 
 // ── World-level music (musica/) ─────────────────────────────────────────────
@@ -948,7 +986,8 @@ function assembleModel(
     records: RawEntityFile[],
     problemas: ValidationIssue[],
     estadoGrupo: PartyState | null,
-    musica: WorldModel['musica']
+    musica: WorldModel['musica'],
+    imagenes: Map<string, FileReference>
 ): WorldModel {
     const entidades = new Map<string, WorldEntityBase>();
     const sistemas: SystemEntity[] = [];
@@ -1034,6 +1073,22 @@ function assembleModel(
 
     sortDiario(diario);
     warnStaleDiario(diario, problemas);
+
+    // Profile images attach to ANY entity kind by id; a basename matching no
+    // entity is almost always a typo in the filename — surface it as an aviso
+    // so the GM finds out why the portrait never shows.
+    for (const [id, ref] of imagenes) {
+        const entity = entidades.get(id);
+        if (entity) {
+            entity.imagen = ref;
+        } else {
+            problemas.push({
+                nivel: 'aviso',
+                archivo: ref.path,
+                mensaje: `Imagen sin entidad: "${ref.name}" no coincide con ningún id (posible errata)`,
+            });
+        }
+    }
 
     checkDanglingRefs(entidades, lugares, pnjs, pistas, problemas);
     checkPartyStateRefs(entidades, estadoGrupo, problemas);

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -18,6 +18,7 @@ import {
     NpcEntity,
     PartyState,
     PlaceEntity,
+    Shop,
     SystemEntity,
     Trama,
     ValidationIssue,
@@ -38,6 +39,7 @@ import { SUPPORTED_AUDIO_EXTENSIONS, SUPPORTED_IMAGE_EXTENSIONS } from '@/lib/fi
 import { buildCondContext, evalConditions, isParseableCondition } from './conditions';
 import { parseEventTable } from './eventEngine';
 import { parseJournal, parseLlegadaPayload, parseSabePayload } from './logEntries';
+import { parseShop } from './shops';
 import { ancestryChain } from './worldNav';
 import { defaultPartyState, parsePartyState } from './partyState';
 import {
@@ -64,9 +66,11 @@ import {
     NIVELES_PRESENCIA,
     PARTY_STATE_FILE,
     PLACE_FOLDER_FILE,
+    RESUMEN_FILE,
     ROLES_PNJ,
     ROLES_TRAMA,
     SERVICIOS,
+    TIENDAS_DIR,
     TIPOS_LUGAR,
     WORLD_DIR,
     isIgnoredDir,
@@ -115,7 +119,7 @@ export async function scanWorldFolder(
             mensaje: `No se encontró la carpeta "${WORLD_DIR}/" en la carpeta de campaña`,
         });
         onProgress?.(1, 1);
-        return assembleModel(defaultManifest(), [], problemas, null, emptyMusica(), new Map());
+        return assembleModel(defaultManifest(), [], problemas, null, emptyMusica(), new Map(), null);
     }
 
     // Enumerate first (cheap directory listings), then read contents in batches.
@@ -146,6 +150,10 @@ export async function scanWorldFolder(
     // Entity profile images (imagenes/): one directory listing, never read.
     const imagenes = await scanEntityImages(mundoDir);
 
+    // Session recap (resumen.md): one optional read, like the manifest — plain
+    // markdown, null when absent, never an entity and never an aviso.
+    const resumen = await readResumen(mundoDir);
+
     // Entity reads, batched
     const records: RawEntityFile[] = [];
     for (let i = 0; i < tasks.length; i += READ_BATCH_SIZE) {
@@ -160,7 +168,22 @@ export async function scanWorldFolder(
     }
 
     const manifest = parseManifest(manifestContent, problemas);
-    return assembleModel(manifest, records, problemas, estadoGrupo, musica, imagenes);
+    return assembleModel(manifest, records, problemas, estadoGrupo, musica, imagenes, resumen);
+}
+
+/**
+ * Reads the OPTIONAL `mundo/resumen.md` recap. Returns its whole text, or null
+ * when the file is absent (or unreadable) — the recap is optional by design,
+ * so absence is silent (no aviso), exactly like an empty musica/ folder.
+ */
+async function readResumen(mundoDir: FileSystemDirectoryHandle): Promise<string | null> {
+    try {
+        const handle = await mundoDir.getFileHandle(RESUMEN_FILE);
+        const file = await handle.getFile();
+        return await file.text();
+    } catch {
+        return null;
+    }
 }
 
 // ── Entity profile images (imagenes/) ───────────────────────────────────────
@@ -341,6 +364,8 @@ interface RawEntityFile {
     content: string;
     /** Set for playable place folders with session content. */
     playable?: SessionConfig;
+    /** Parsed shops from the place folder's optional `tiendas/` subfolder. */
+    tiendas?: Shop[];
 }
 
 interface TaskResult {
@@ -517,6 +542,8 @@ async function scanPlaceFolder(
         });
     }
 
+    const tiendas = await scanShops(dirHandle, folderPath, issues);
+
     return {
         record: {
             kind: 'lugar',
@@ -524,9 +551,37 @@ async function scanPlaceFolder(
             filePath: `${folderPath}/${PLACE_FOLDER_FILE}`,
             content,
             playable,
+            tiendas,
         },
         issues,
     };
+}
+
+/**
+ * Reads the OPTIONAL `tiendas/` subfolder of a place folder: each `*.md`
+ * (ignore rules apply — `_`-prefixed files, ALL-CAPS dirs) parses into one
+ * Shop via parseShop. An absent folder yields [] and NO aviso (optional by
+ * design). Shopkeeper `pnj` refs are validated later in assembleModel, once
+ * the entity map exists.
+ */
+async function scanShops(
+    dirHandle: FileSystemDirectoryHandle,
+    folderPath: string,
+    issues: ValidationIssue[]
+): Promise<Shop[]> {
+    const tiendasDir = await getSubdirectory(dirHandle, TIENDAS_DIR);
+    if (!tiendasDir) return [];
+
+    const { files } = await listEntries(tiendasDir);
+    const shops: Shop[] = [];
+    for (const file of files) {
+        const filePath = `${folderPath}/${TIENDAS_DIR}/${file.name}`;
+        const content = await readFileContent(file.handle);
+        const { shop, issues: shopIssues } = parseShop(content, filePath, stripMd(file.name));
+        issues.push(...shopIssues);
+        shops.push(shop);
+    }
+    return shops;
 }
 
 /**
@@ -987,7 +1042,8 @@ function assembleModel(
     problemas: ValidationIssue[],
     estadoGrupo: PartyState | null,
     musica: WorldModel['musica'],
-    imagenes: Map<string, FileReference>
+    imagenes: Map<string, FileReference>,
+    resumen: string | null
 ): WorldModel {
     const entidades = new Map<string, WorldEntityBase>();
     const sistemas: SystemEntity[] = [];
@@ -998,6 +1054,9 @@ function assembleModel(
     const tramas: Trama[] = [];
     const tablas: EventTable[] = [];
     const diario: JournalDay[] = [];
+    // Shops keyed by place id. Collected from the lugar records as we parse
+    // them; pnj refs are validated once the entity map is complete (below).
+    const tiendas = new Map<string, Shop[]>();
 
     for (const record of records) {
         // Journals are not entities: no id dedupe, own tolerant parser.
@@ -1042,6 +1101,9 @@ function assembleModel(
                 const entity = buildLugar(record, data, parsed.body, problemas);
                 lugares.push(entity);
                 entidades.set(entity.id, entity);
+                if (record.tiendas && record.tiendas.length > 0) {
+                    tiendas.set(entity.id, record.tiendas);
+                }
                 break;
             }
             case 'faccion': {
@@ -1092,6 +1154,7 @@ function assembleModel(
 
     checkDanglingRefs(entidades, lugares, pnjs, pistas, problemas);
     checkPartyStateRefs(entidades, estadoGrupo, problemas);
+    checkShopRefs(entidades, tiendas, problemas);
 
     const childrenOf = deriveChildrenOf(entidades, sistemas, lugares);
     deriveRegionInheritance(entidades, lugares);
@@ -1111,6 +1174,8 @@ function assembleModel(
         estadoGrupo,
         diario,
         musica,
+        tiendas,
+        resumen,
     };
 
     // Unprocessed journals re-overlay in-session knowledge BEFORE the
@@ -1250,6 +1315,29 @@ function checkPartyStateRefs(
     }
     if (estadoGrupo.rumbo !== null && !entidades.has(estadoGrupo.rumbo.destino)) {
         dangling('rumbo.destino', estadoGrupo.rumbo.destino);
+    }
+}
+
+/**
+ * A shop's `pnj` (shopkeeper) pointing at an entity that doesn't exist is an
+ * AVISO, not an error: the shop still works keeper-less, and a half-built world
+ * must load. Shops with no `pnj` are skipped.
+ */
+function checkShopRefs(
+    entidades: Map<string, WorldEntityBase>,
+    tiendas: Map<string, Shop[]>,
+    problemas: ValidationIssue[]
+): void {
+    for (const shops of tiendas.values()) {
+        for (const shop of shops) {
+            if (shop.pnj !== undefined && !entidades.has(shop.pnj)) {
+                problemas.push({
+                    nivel: 'aviso',
+                    archivo: shop.filePath,
+                    mensaje: `Referencia colgante en "pnj": "${shop.pnj}" no existe`,
+                });
+            }
+        }
     }
 }
 

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -1002,6 +1002,18 @@ export function applyLlegadaConocimiento(model: WorldModel, lugarId: string): vo
  *                conocido (same ancestry logic as worldNav)
  * Unknown ids and unparseable payloads are silently skipped — the journal is
  * a log, not a validated source, and the agent will reconcile it later.
+ *
+ * TODO(M6) — DELIBERATE ASYMMETRY: `pista` entries are NOT overlaid. Only
+ * knowledge is monotonic (it never lowers, so replaying it is always safe);
+ * pista estados move in both directions and can be corrected mid-journal, so
+ * an overlay would need real replay semantics the scanner doesn't have. The
+ * consequence the GM sees: a pista transitioned live during a session reverts
+ * to its FILE estado on reload until the agent maintenance runs. PROTOCOLO.md
+ * (M6) must therefore instruct the agent to process pista entries promptly
+ * after every session; whether this overlay should learn pista replay is an
+ * M6 decision — do not bolt it on here without deciding the undo/ordering
+ * semantics first. (Same note lives in app/world/page.tsx "SCAN-OVERLAY
+ * ASYMMETRY".)
  */
 function overlayUnprocessedJournals(model: WorldModel): void {
     for (const day of model.diario) {

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -1,0 +1,965 @@
+/**
+ * World scanner: materializes a campaign folder's `mundo/` tree into a WorldModel.
+ *
+ * NEVER throws on bad content — every problem degrades into a ValidationIssue in
+ * `problemas` (nivel 'error' | 'aviso') so the world always loads, however broken.
+ * Reads are batched (Promise.all in chunks of 25) with an optional progress callback.
+ */
+
+import { FileReference, SessionConfig } from '@/types';
+import {
+    FactionEntity,
+    FactionPresence,
+    Lead,
+    NpcEntity,
+    PlaceEntity,
+    SystemEntity,
+    Trama,
+    ValidationIssue,
+    WorldEntityBase,
+    WorldManifest,
+    WorldModel,
+} from '@/types/world';
+import { scanSessionFolder } from '@/lib/sessionScanner';
+import { fileNameToDisplayName, getSubdirectory, readFileContent } from '@/lib/fsScanUtils';
+import {
+    asCoords,
+    asNumber,
+    asString,
+    asStringArray,
+    normalizeKeys,
+    parseFrontmatter,
+} from './frontmatter';
+import {
+    ACCESOS,
+    ACTITUDES,
+    CONOCIMIENTOS,
+    DEFAULT_ACCESO,
+    DEFAULT_CONOCIMIENTO,
+    ENTITY_DIRS,
+    ESTADOS_PISTA,
+    ESTADOS_TRAMA,
+    MANIFEST_DEFAULTS,
+    MANIFEST_FILE,
+    NIVELES_PRESENCIA,
+    PLACE_FOLDER_FILE,
+    ROLES_PNJ,
+    ROLES_TRAMA,
+    SERVICIOS,
+    TIPOS_LUGAR,
+    WORLD_DIR,
+    isIgnoredDir,
+    isIgnoredFile,
+} from './constants';
+
+export type ScanProgressCallback = (done: number, total: number) => void;
+
+/** Files read per Promise.all batch. */
+const READ_BATCH_SIZE = 25;
+
+const MANIFEST_PATH = `${WORLD_DIR}/${MANIFEST_FILE}`;
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/** Cheap probe: does the campaign folder contain `mundo/mundo.md`? */
+export async function hasWorld(handle: FileSystemDirectoryHandle): Promise<boolean> {
+    const mundoDir = await getSubdirectory(handle, WORLD_DIR);
+    if (!mundoDir) return false;
+    try {
+        await mundoDir.getFileHandle(MANIFEST_FILE);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Scans `mundo/` under the campaign folder handle into a WorldModel.
+ * Degrades every problem into `problemas`; only infrastructure failures
+ * outside the scanned content could ever throw.
+ */
+export async function scanWorldFolder(
+    handle: FileSystemDirectoryHandle,
+    onProgress?: ScanProgressCallback
+): Promise<WorldModel> {
+    const problemas: ValidationIssue[] = [];
+
+    const mundoDir = await getSubdirectory(handle, WORLD_DIR);
+    if (!mundoDir) {
+        problemas.push({
+            nivel: 'error',
+            archivo: WORLD_DIR,
+            mensaje: `No se encontró la carpeta "${WORLD_DIR}/" en la carpeta de campaña`,
+        });
+        onProgress?.(1, 1);
+        return assembleModel(defaultManifest(), [], problemas);
+    }
+
+    // Enumerate first (cheap directory listings), then read contents in batches.
+    const tasks = await collectTasks(mundoDir);
+    const totalReads = 1 + tasks.length; // +1 = the manifest itself
+    let done = 0;
+
+    // Manifest read
+    let manifestContent: string | null = null;
+    try {
+        const manifestHandle = await mundoDir.getFileHandle(MANIFEST_FILE);
+        manifestContent = await readFileContent(manifestHandle);
+    } catch {
+        manifestContent = null;
+    }
+    done = 1;
+    onProgress?.(done, totalReads);
+
+    // Entity reads, batched
+    const records: RawEntityFile[] = [];
+    for (let i = 0; i < tasks.length; i += READ_BATCH_SIZE) {
+        const chunk = tasks.slice(i, i + READ_BATCH_SIZE);
+        const results = await Promise.all(chunk.map((task) => task()));
+        for (const result of results) {
+            problemas.push(...result.issues);
+            if (result.record) records.push(result.record);
+        }
+        done += chunk.length;
+        onProgress?.(done, totalReads);
+    }
+
+    const manifest = parseManifest(manifestContent, problemas);
+    return assembleModel(manifest, records, problemas);
+}
+
+// ── Enumeration + batched reads ─────────────────────────────────────────────
+
+type EntityKind = 'sistema' | 'lugar' | 'faccion' | 'pnj' | 'pista' | 'trama';
+
+interface RawEntityFile {
+    kind: EntityKind;
+    /** filename minus .md, or the folder name for playable place folders. */
+    id: string;
+    /** Path relative to the campaign folder. */
+    filePath: string;
+    content: string;
+    /** Set for playable place folders with session content. */
+    playable?: SessionConfig;
+}
+
+interface TaskResult {
+    record: RawEntityFile | null;
+    issues: ValidationIssue[];
+}
+
+type ScanTask = () => Promise<TaskResult>;
+
+/** Flat entity dirs scanned as `*.md` files. eventos/estado/diario are skipped in M1. */
+const FLAT_KIND_DIRS: ReadonlyArray<{ kind: EntityKind; dir: string }> = [
+    { kind: 'sistema', dir: ENTITY_DIRS.sistemas },
+    { kind: 'faccion', dir: ENTITY_DIRS.facciones },
+    { kind: 'pnj', dir: ENTITY_DIRS.pnjs },
+    { kind: 'pista', dir: ENTITY_DIRS.pistas },
+    { kind: 'trama', dir: ENTITY_DIRS.tramas },
+];
+
+function stripMd(name: string): string {
+    return name.replace(/\.md$/i, '');
+}
+
+function isMarkdownFile(name: string): boolean {
+    return name.toLowerCase().endsWith('.md');
+}
+
+async function listEntries(
+    dir: FileSystemDirectoryHandle
+): Promise<{ files: Array<{ name: string; handle: FileSystemFileHandle }>; dirs: Array<{ name: string; handle: FileSystemDirectoryHandle }> }> {
+    const files: Array<{ name: string; handle: FileSystemFileHandle }> = [];
+    const dirs: Array<{ name: string; handle: FileSystemDirectoryHandle }> = [];
+
+    for await (const [name, entryHandle] of dir.entries()) {
+        if (entryHandle.kind === 'file') {
+            if (isMarkdownFile(name) && !isIgnoredFile(name)) {
+                files.push({ name, handle: entryHandle as FileSystemFileHandle });
+            }
+        } else {
+            if (!isIgnoredDir(name) && !name.startsWith('_')) {
+                dirs.push({ name, handle: entryHandle as FileSystemDirectoryHandle });
+            }
+        }
+    }
+
+    files.sort((a, b) => a.name.localeCompare(b.name));
+    dirs.sort((a, b) => a.name.localeCompare(b.name));
+    return { files, dirs };
+}
+
+async function collectTasks(mundoDir: FileSystemDirectoryHandle): Promise<ScanTask[]> {
+    const tasks: ScanTask[] = [];
+
+    // Flat dirs: sistemas/, facciones/, pnjs/, pistas/, tramas/
+    for (const { kind, dir } of FLAT_KIND_DIRS) {
+        const dirHandle = await getSubdirectory(mundoDir, dir);
+        if (!dirHandle) continue;
+        const { files } = await listEntries(dirHandle);
+        for (const file of files) {
+            const filePath = `${WORLD_DIR}/${dir}/${file.name}`;
+            tasks.push(async () => ({
+                record: {
+                    kind,
+                    id: stripMd(file.name),
+                    filePath,
+                    content: await readFileContent(file.handle),
+                },
+                issues: [],
+            }));
+        }
+    }
+
+    // lugares/: flat *.md files PLUS playable subfolders (lugar.md + session categories)
+    const lugaresDir = await getSubdirectory(mundoDir, ENTITY_DIRS.lugares);
+    if (lugaresDir) {
+        const { files, dirs } = await listEntries(lugaresDir);
+        for (const file of files) {
+            const filePath = `${WORLD_DIR}/${ENTITY_DIRS.lugares}/${file.name}`;
+            tasks.push(async () => ({
+                record: {
+                    kind: 'lugar',
+                    id: stripMd(file.name),
+                    filePath,
+                    content: await readFileContent(file.handle),
+                },
+                issues: [],
+            }));
+        }
+        for (const dir of dirs) {
+            tasks.push(() => scanPlaceFolder(dir.name, dir.handle));
+        }
+    }
+
+    return tasks;
+}
+
+/**
+ * A playable place folder `lugares/<id>/`: `lugar.md` is the entity; the rest of
+ * the folder is scanned with the EXISTING scanSessionFolder() (classic session
+ * layout) and every FileReference path is re-based onto the campaign folder.
+ */
+async function scanPlaceFolder(
+    id: string,
+    dirHandle: FileSystemDirectoryHandle
+): Promise<TaskResult> {
+    const folderPath = `${WORLD_DIR}/${ENTITY_DIRS.lugares}/${id}`;
+    const issues: ValidationIssue[] = [];
+
+    let placeFileHandle: FileSystemFileHandle;
+    try {
+        placeFileHandle = await dirHandle.getFileHandle(PLACE_FOLDER_FILE);
+    } catch {
+        issues.push({
+            nivel: 'error',
+            archivo: folderPath,
+            mensaje: `Carpeta de lugar sin ${PLACE_FOLDER_FILE}`,
+        });
+        return { record: null, issues };
+    }
+
+    const content = await readFileContent(placeFileHandle);
+
+    let playable: SessionConfig | undefined;
+    try {
+        const config = await scanSessionFolder(dirHandle);
+        // A folder with lugar.md but no session content is just a plain place.
+        if (config.parts.length > 0) {
+            playable = prefixSessionConfigPaths(config, `${folderPath}/`);
+        }
+    } catch {
+        issues.push({
+            nivel: 'aviso',
+            archivo: folderPath,
+            mensaje: 'No se pudo escanear el contenido jugable de la carpeta',
+        });
+    }
+
+    return {
+        record: {
+            kind: 'lugar',
+            id,
+            filePath: `${folderPath}/${PLACE_FOLDER_FILE}`,
+            content,
+            playable,
+        },
+        issues,
+    };
+}
+
+function prefixFileReference<T extends FileReference>(ref: T, prefix: string): T {
+    return { ...ref, path: `${prefix}${ref.path}` };
+}
+
+/** Re-bases every FileReference in a SessionConfig onto the campaign folder root. */
+function prefixSessionConfigPaths(config: SessionConfig, prefix: string): SessionConfig {
+    return {
+        ...config,
+        parts: config.parts.map((part) => ({
+            ...part,
+            planFile: part.planFile ? prefixFileReference(part.planFile, prefix) : null,
+            images: part.images.map((ref) => prefixFileReference(ref, prefix)),
+            supportDocs: part.supportDocs.map((ref) => prefixFileReference(ref, prefix)),
+            bgmPlaylist: part.bgmPlaylist.map((ref) => prefixFileReference(ref, prefix)),
+            eventPlaylists: part.eventPlaylists.map((playlist) => ({
+                ...playlist,
+                tracks: playlist.tracks.map((ref) => prefixFileReference(ref, prefix)),
+            })),
+        })),
+    };
+}
+
+// ── Manifest ────────────────────────────────────────────────────────────────
+
+function defaultManifest(): WorldManifest {
+    return {
+        nombre: 'Mundo',
+        calendario: { era: '', anoEpoca: 0, diasPorMes: 30, meses: [] },
+        viaje: { ...MANIFEST_DEFAULTS.viaje },
+        medidores: [...MANIFEST_DEFAULTS.medidores],
+        regiones: [],
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseManifest(content: string | null, problemas: ValidationIssue[]): WorldManifest {
+    const fallback = defaultManifest();
+
+    if (content === null) {
+        problemas.push({
+            nivel: 'aviso',
+            archivo: MANIFEST_PATH,
+            mensaje: `No se encontró ${MANIFEST_FILE} — se usan los valores por defecto`,
+        });
+        return fallback;
+    }
+
+    const parsed = parseFrontmatter(content, MANIFEST_PATH);
+    if (parsed.issue) problemas.push(parsed.issue);
+    const data = normalizeKeys(parsed.data);
+
+    const missing = (campo: string) => {
+        problemas.push({
+            nivel: 'aviso',
+            archivo: MANIFEST_PATH,
+            mensaje: `Falta "${campo}" en el manifiesto — se usa el valor por defecto`,
+        });
+    };
+
+    const nombre = asString(data.nombre);
+    if (nombre === undefined) missing('nombre');
+
+    const cal = isRecord(data.calendario) ? data.calendario : undefined;
+    if (cal === undefined) missing('calendario');
+
+    const viaje = isRecord(data.viaje) ? data.viaje : undefined;
+    if (viaje === undefined) missing('viaje');
+
+    if (data.medidores === undefined) missing('medidores');
+    if (data.regiones === undefined) missing('regiones');
+
+    return {
+        nombre: nombre ?? fallback.nombre,
+        calendario: {
+            era: asString(cal?.era) ?? fallback.calendario.era,
+            anoEpoca:
+                asNumber(cal?.ano_epoca ?? cal?.['año_epoca']) ?? fallback.calendario.anoEpoca,
+            diasPorMes: asNumber(cal?.dias_por_mes) ?? fallback.calendario.diasPorMes,
+            meses: cal?.meses === undefined ? fallback.calendario.meses : asStringArray(cal.meses),
+        },
+        viaje: {
+            diasPorUnidad: asNumber(viaje?.dias_por_unidad) ?? fallback.viaje.diasPorUnidad,
+            intrasistemaDias:
+                asNumber(viaje?.intrasistema_dias) ?? fallback.viaje.intrasistemaDias,
+            combustiblePorTramo:
+                asNumber(viaje?.combustible_por_tramo) ?? fallback.viaje.combustiblePorTramo,
+            viveresCadaDias:
+                asNumber(viaje?.viveres_cada_dias) ?? fallback.viaje.viveresCadaDias,
+        },
+        medidores:
+            data.medidores === undefined ? fallback.medidores : asStringArray(data.medidores),
+        regiones: data.regiones === undefined ? fallback.regiones : asStringArray(data.regiones),
+    };
+}
+
+// ── Entity building ─────────────────────────────────────────────────────────
+
+/**
+ * Validates a value against a closed vocabulary. A missing value silently gets
+ * the fallback; an out-of-vocabulary value gets the fallback plus an aviso.
+ */
+function vocabOrDefault<T extends string>(
+    value: unknown,
+    vocab: readonly T[],
+    fallbackValue: T,
+    campo: string,
+    archivo: string,
+    problemas: ValidationIssue[]
+): T {
+    const str = asString(value);
+    if (str === undefined) return fallbackValue;
+    if ((vocab as readonly string[]).includes(str)) return str as T;
+    problemas.push({
+        nivel: 'aviso',
+        archivo,
+        mensaje: `Valor fuera de vocabulario en "${campo}": "${str}" — se usa "${fallbackValue}"`,
+    });
+    return fallbackValue;
+}
+
+function buildBase(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    defaultTipo: string,
+    problemas: ValidationIssue[],
+    options: { estadoIsProse: boolean }
+): WorldEntityBase {
+    return {
+        id: record.id,
+        tipo: asString(data.tipo) ?? defaultTipo,
+        nombre: asString(data.nombre) ?? fileNameToDisplayName(record.id),
+        filePath: record.filePath,
+        conocimiento: vocabOrDefault(
+            data.conocimiento,
+            CONOCIMIENTOS,
+            DEFAULT_CONOCIMIENTO,
+            'conocimiento',
+            record.filePath,
+            problemas
+        ),
+        etiquetas: asStringArray(data.etiquetas),
+        resumen: asString(data.resumen),
+        // For pistas/tramas the `estado:` key holds the workflow state, not prose.
+        estado: options.estadoIsProse ? asString(data.estado) : undefined,
+        raw: data,
+        body,
+    };
+}
+
+function buildSistema(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    problemas: ValidationIssue[]
+): SystemEntity {
+    const coordenadas = asCoords(data.coordenadas);
+    if (coordenadas === undefined) {
+        problemas.push({
+            nivel: 'error',
+            archivo: record.filePath,
+            mensaje: 'Sistema sin coordenadas',
+        });
+    }
+    return {
+        ...buildBase(record, data, body, 'sistema', problemas, { estadoIsProse: true }),
+        tipo: 'sistema',
+        coordenadas: coordenadas ?? { x: 0, y: 0 },
+        region: asString(data.region),
+    };
+}
+
+function parseFactionPresences(
+    value: unknown,
+    archivo: string,
+    problemas: ValidationIssue[]
+): FactionPresence[] {
+    if (value === undefined) return [];
+    if (!Array.isArray(value)) {
+        problemas.push({
+            nivel: 'aviso',
+            archivo,
+            mensaje: '"facciones" debe ser una lista de {faccion, nivel} — se ignora',
+        });
+        return [];
+    }
+
+    const presences: FactionPresence[] = [];
+    for (const item of value) {
+        if (!isRecord(item)) continue;
+        const faccion = asString(item.faccion);
+        if (faccion === undefined) {
+            problemas.push({
+                nivel: 'aviso',
+                archivo,
+                mensaje: 'Entrada de "facciones" sin campo "faccion" — se omite',
+            });
+            continue;
+        }
+        presences.push({
+            faccion,
+            nivel: vocabOrDefault(
+                item.nivel,
+                NIVELES_PRESENCIA,
+                'presente',
+                'facciones.nivel',
+                archivo,
+                problemas
+            ),
+        });
+    }
+    return presences;
+}
+
+function buildLugar(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    problemas: ValidationIssue[]
+): PlaceEntity {
+    const base = buildBase(record, data, body, 'lugar', problemas, { estadoIsProse: true });
+
+    // TIPOS_LUGAR is an open (recommended) list: keep the value, warn once.
+    const tipoRaw = asString(data.tipo);
+    if (tipoRaw !== undefined && !TIPOS_LUGAR.includes(tipoRaw)) {
+        problemas.push({
+            nivel: 'aviso',
+            archivo: record.filePath,
+            mensaje: `Valor fuera de vocabulario en "tipo": "${tipoRaw}"`,
+        });
+    }
+
+    const servicios = asStringArray(data.servicios);
+    for (const servicio of servicios) {
+        if (!SERVICIOS.includes(servicio)) {
+            problemas.push({
+                nivel: 'aviso',
+                archivo: record.filePath,
+                mensaje: `Valor fuera de vocabulario en "servicios": "${servicio}"`,
+            });
+        }
+    }
+
+    const en = asString(data.en);
+    const coordenadas = asCoords(data.coordenadas);
+    if (en === undefined && coordenadas === undefined) {
+        problemas.push({
+            nivel: 'error',
+            archivo: record.filePath,
+            mensaje: 'Lugar sin "en" ni coordenadas',
+        });
+    }
+
+    return {
+        ...base,
+        en,
+        coordenadas,
+        orbita: asNumber(data.orbita),
+        region: asString(data.region),
+        servicios,
+        facciones: parseFactionPresences(data.facciones, record.filePath, problemas),
+        acceso: vocabOrDefault(
+            data.acceso,
+            ACCESOS,
+            DEFAULT_ACCESO,
+            'acceso',
+            record.filePath,
+            problemas
+        ),
+        peligro: asNumber(data.peligro),
+        playable: record.playable,
+    };
+}
+
+function buildFaccion(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    problemas: ValidationIssue[]
+): FactionEntity {
+    return {
+        ...buildBase(record, data, body, 'faccion', problemas, { estadoIsProse: true }),
+        actitud: vocabOrDefault(
+            data.actitud,
+            ACTITUDES,
+            'neutral',
+            'actitud',
+            record.filePath,
+            problemas
+        ),
+        poder: asNumber(data.poder),
+        objetivos: asStringArray(data.objetivos),
+    };
+}
+
+function buildPnj(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    problemas: ValidationIssue[]
+): NpcEntity {
+    return {
+        ...buildBase(record, data, body, 'pnj', problemas, { estadoIsProse: true }),
+        faccion: asString(data.faccion),
+        rol: vocabOrDefault(data.rol, ROLES_PNJ, 'neutral', 'rol', record.filePath, problemas),
+        ubicacion: asString(data.ubicacion),
+    };
+}
+
+function buildPista(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    problemas: ValidationIssue[]
+): Lead {
+    return {
+        ...buildBase(record, data, body, 'pista', problemas, { estadoIsProse: false }),
+        estadoPista: vocabOrDefault(
+            data.estado,
+            ESTADOS_PISTA,
+            'rumor',
+            'estado',
+            record.filePath,
+            problemas
+        ),
+        trama: asString(data.trama),
+        donde: asString(data.donde),
+        origen: asString(data.origen),
+        plazo: asNumber(data.plazo),
+        requisitos: asStringArray(data.requisitos),
+        recompensa: asString(data.recompensa),
+        accionable: false, // derived below in deriveLeadActionability
+    };
+}
+
+function asReloj(value: unknown): { actual: number; max: number } | undefined {
+    if (!isRecord(value)) return undefined;
+    const actual = asNumber(value.actual);
+    const max = asNumber(value.max);
+    if (actual === undefined || max === undefined) return undefined;
+    return { actual, max };
+}
+
+function buildTrama(
+    record: RawEntityFile,
+    data: Record<string, unknown>,
+    body: string,
+    problemas: ValidationIssue[]
+): Trama {
+    return {
+        ...buildBase(record, data, body, 'trama', problemas, { estadoIsProse: false }),
+        rol: vocabOrDefault(
+            data.rol,
+            ROLES_TRAMA,
+            'secundaria',
+            'rol',
+            record.filePath,
+            problemas
+        ),
+        estadoTrama: vocabOrDefault(
+            data.estado,
+            ESTADOS_TRAMA,
+            'latente',
+            'estado',
+            record.filePath,
+            problemas
+        ),
+        reloj: asReloj(data.reloj),
+        lugaresClave: asStringArray(data.lugares_clave),
+        facciones: asStringArray(data.facciones),
+        pistas: [], // grouped below in groupTramaPistas
+    };
+}
+
+// ── Assembly: parse records, cross-validate, derive ─────────────────────────
+
+function assembleModel(
+    manifest: WorldManifest,
+    records: RawEntityFile[],
+    problemas: ValidationIssue[]
+): WorldModel {
+    const entidades = new Map<string, WorldEntityBase>();
+    const sistemas: SystemEntity[] = [];
+    const lugares: PlaceEntity[] = [];
+    const facciones: FactionEntity[] = [];
+    const pnjs: NpcEntity[] = [];
+    const pistas: Lead[] = [];
+    const tramas: Trama[] = [];
+
+    for (const record of records) {
+        const parsed = parseFrontmatter(record.content, record.filePath);
+        if (parsed.issue) problemas.push(parsed.issue);
+        const data = normalizeKeys(parsed.data);
+
+        // ids are globally unique across all of mundo/: first occurrence wins.
+        const existing = entidades.get(record.id);
+        if (existing) {
+            problemas.push({
+                nivel: 'error',
+                archivo: record.filePath,
+                mensaje: `id duplicado: "${record.id}" ya está definido en ${existing.filePath}`,
+            });
+            continue;
+        }
+
+        switch (record.kind) {
+            case 'sistema': {
+                const entity = buildSistema(record, data, parsed.body, problemas);
+                sistemas.push(entity);
+                entidades.set(entity.id, entity);
+                break;
+            }
+            case 'lugar': {
+                const entity = buildLugar(record, data, parsed.body, problemas);
+                lugares.push(entity);
+                entidades.set(entity.id, entity);
+                break;
+            }
+            case 'faccion': {
+                const entity = buildFaccion(record, data, parsed.body, problemas);
+                facciones.push(entity);
+                entidades.set(entity.id, entity);
+                break;
+            }
+            case 'pnj': {
+                const entity = buildPnj(record, data, parsed.body, problemas);
+                pnjs.push(entity);
+                entidades.set(entity.id, entity);
+                break;
+            }
+            case 'pista': {
+                const entity = buildPista(record, data, parsed.body, problemas);
+                pistas.push(entity);
+                entidades.set(entity.id, entity);
+                break;
+            }
+            case 'trama': {
+                const entity = buildTrama(record, data, parsed.body, problemas);
+                tramas.push(entity);
+                entidades.set(entity.id, entity);
+                break;
+            }
+        }
+    }
+
+    checkDanglingRefs(entidades, lugares, pnjs, pistas, problemas);
+    warnOrphans(entidades, sistemas, lugares, facciones, pnjs, pistas, tramas, problemas);
+
+    const childrenOf = deriveChildrenOf(entidades, sistemas, lugares);
+    deriveRegionInheritance(entidades, lugares);
+    deriveLeadActionability(entidades, pistas, problemas);
+    groupTramaPistas(tramas, pistas);
+
+    return {
+        manifest,
+        entidades,
+        sistemas,
+        lugares,
+        facciones,
+        pnjs,
+        pistas,
+        tramas,
+        problemas,
+        childrenOf,
+    };
+}
+
+function checkDanglingRefs(
+    entidades: Map<string, WorldEntityBase>,
+    lugares: PlaceEntity[],
+    pnjs: NpcEntity[],
+    pistas: Lead[],
+    problemas: ValidationIssue[]
+): void {
+    const dangling = (archivo: string, campo: string, target: string) => {
+        problemas.push({
+            nivel: 'error',
+            archivo,
+            mensaje: `Referencia colgante en "${campo}": "${target}" no existe`,
+        });
+    };
+
+    for (const lugar of lugares) {
+        if (lugar.en !== undefined && !entidades.has(lugar.en)) {
+            dangling(lugar.filePath, 'en', lugar.en);
+        }
+        for (const presence of lugar.facciones) {
+            if (!entidades.has(presence.faccion)) {
+                dangling(lugar.filePath, 'facciones', presence.faccion);
+            }
+        }
+    }
+    for (const pnj of pnjs) {
+        if (pnj.faccion !== undefined && !entidades.has(pnj.faccion)) {
+            dangling(pnj.filePath, 'faccion', pnj.faccion);
+        }
+    }
+    for (const pista of pistas) {
+        if (pista.trama !== undefined && !entidades.has(pista.trama)) {
+            dangling(pista.filePath, 'trama', pista.trama);
+        }
+        if (pista.donde !== undefined && !entidades.has(pista.donde)) {
+            dangling(pista.filePath, 'donde', pista.donde);
+        }
+    }
+}
+
+/**
+ * Orphan aviso: nothing references the entity AND its conocimiento is
+ * desconocido (unreachable content). Scoped to sistemas/lugares/facciones/pnjs —
+ * pistas and tramas are reference SOURCES (nothing points at a pista by design).
+ */
+function warnOrphans(
+    entidades: Map<string, WorldEntityBase>,
+    sistemas: SystemEntity[],
+    lugares: PlaceEntity[],
+    facciones: FactionEntity[],
+    pnjs: NpcEntity[],
+    pistas: Lead[],
+    tramas: Trama[],
+    problemas: ValidationIssue[]
+): void {
+    const referenced = new Set<string>();
+    for (const lugar of lugares) {
+        if (lugar.en !== undefined) referenced.add(lugar.en);
+        for (const presence of lugar.facciones) referenced.add(presence.faccion);
+    }
+    for (const pnj of pnjs) {
+        if (pnj.faccion !== undefined) referenced.add(pnj.faccion);
+        if (pnj.ubicacion !== undefined) referenced.add(pnj.ubicacion);
+    }
+    for (const pista of pistas) {
+        if (pista.trama !== undefined) referenced.add(pista.trama);
+        if (pista.donde !== undefined) referenced.add(pista.donde);
+        if (pista.origen !== undefined) referenced.add(pista.origen);
+    }
+    for (const trama of tramas) {
+        for (const id of trama.lugaresClave) referenced.add(id);
+        for (const id of trama.facciones) referenced.add(id);
+    }
+
+    for (const entity of [...sistemas, ...lugares, ...facciones, ...pnjs]) {
+        if (entity.conocimiento === 'desconocido' && !referenced.has(entity.id)) {
+            problemas.push({
+                nivel: 'aviso',
+                archivo: entity.filePath,
+                mensaje: 'Entidad huérfana: nada la referencia y su conocimiento es "desconocido"',
+            });
+        }
+    }
+}
+
+/**
+ * childrenOf: parent id -> child ids (inverse of `en:`). Sistemas are always
+ * roots (entry present even when childless); deep-space lugares (coordenadas,
+ * no `en:`) are roots too. Children sort by orbita, then id.
+ */
+function deriveChildrenOf(
+    entidades: Map<string, WorldEntityBase>,
+    sistemas: SystemEntity[],
+    lugares: PlaceEntity[]
+): Map<string, string[]> {
+    const childrenOf = new Map<string, string[]>();
+
+    for (const sistema of sistemas) {
+        childrenOf.set(sistema.id, []);
+    }
+    for (const lugar of lugares) {
+        if (lugar.en === undefined && lugar.coordenadas !== undefined) {
+            childrenOf.set(lugar.id, childrenOf.get(lugar.id) ?? []);
+        }
+    }
+    for (const lugar of lugares) {
+        if (lugar.en === undefined || !entidades.has(lugar.en)) continue;
+        const siblings = childrenOf.get(lugar.en);
+        if (siblings) {
+            siblings.push(lugar.id);
+        } else {
+            childrenOf.set(lugar.en, [lugar.id]);
+        }
+    }
+
+    const orbitaOf = (id: string): number => {
+        const entity = entidades.get(id) as PlaceEntity | undefined;
+        return entity?.orbita ?? Number.POSITIVE_INFINITY;
+    };
+    for (const children of childrenOf.values()) {
+        children.sort((a, b) => {
+            const delta = orbitaOf(a) - orbitaOf(b);
+            if (delta !== 0 && !Number.isNaN(delta)) return delta;
+            return a.localeCompare(b);
+        });
+    }
+
+    return childrenOf;
+}
+
+/** A lugar without region inherits from the nearest ancestor (via `en:`) that has one. */
+function deriveRegionInheritance(
+    entidades: Map<string, WorldEntityBase>,
+    lugares: PlaceEntity[]
+): void {
+    for (const lugar of lugares) {
+        if (lugar.region !== undefined) continue;
+
+        const visited = new Set<string>([lugar.id]);
+        let parentId = lugar.en;
+        while (parentId !== undefined && !visited.has(parentId)) {
+            visited.add(parentId);
+            const parent = entidades.get(parentId) as SystemEntity | PlaceEntity | undefined;
+            if (!parent) break;
+            if (parent.region !== undefined) {
+                lugar.region = parent.region;
+                break;
+            }
+            parentId = (parent as PlaceEntity).en;
+        }
+    }
+}
+
+/**
+ * Lead.accionable (derived, never stored): estadoPista activa/en_curso AND donde
+ * is absent-or-conocido/visitado. Any requisitos entry degrades the result to
+ * 'manual' ("según GM") — evalCondition() arrives in M4; until then the app
+ * cannot check condition strings against PartyState.
+ */
+function deriveLeadActionability(
+    entidades: Map<string, WorldEntityBase>,
+    pistas: Lead[],
+    problemas: ValidationIssue[]
+): void {
+    for (const pista of pistas) {
+        const estadoOk = pista.estadoPista === 'activa' || pista.estadoPista === 'en_curso';
+
+        let dondeOk = true;
+        if (pista.donde !== undefined) {
+            const target = entidades.get(pista.donde);
+            dondeOk =
+                target !== undefined &&
+                (target.conocimiento === 'conocido' || target.conocimiento === 'visitado');
+            if (
+                pista.estadoPista === 'activa' &&
+                target !== undefined &&
+                target.conocimiento === 'desconocido'
+            ) {
+                problemas.push({
+                    nivel: 'aviso',
+                    archivo: pista.filePath,
+                    mensaje: `Pista activa en un lugar desconocido: "${pista.donde}"`,
+                });
+            }
+        }
+
+        if (!estadoOk || !dondeOk) {
+            pista.accionable = false;
+        } else if (pista.requisitos.length > 0) {
+            pista.accionable = 'manual';
+        } else {
+            pista.accionable = true;
+        }
+    }
+}
+
+/** Pistas point at their trama (child -> parent); the scanner groups them. */
+function groupTramaPistas(tramas: Trama[], pistas: Lead[]): void {
+    const tramaById = new Map(tramas.map((trama) => [trama.id, trama]));
+    for (const pista of pistas) {
+        if (pista.trama === undefined) continue;
+        tramaById.get(pista.trama)?.pistas.push(pista);
+    }
+}

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -611,6 +611,7 @@ function splitFlatPlanParts(config: SessionConfig): SessionConfig {
         name: fileNameToDisplayName(ref.name),
         planFile: ref,
         images: i === 0 ? part.images : [],
+        battlemaps: i === 0 ? part.battlemaps : [],
         supportDocs: i === 0 ? otherDocs : [],
         bgmPlaylist: i === 0 ? part.bgmPlaylist : [],
         eventPlaylists: i === 0 ? part.eventPlaylists : [],
@@ -630,6 +631,7 @@ function prefixSessionConfigPaths(config: SessionConfig, prefix: string): Sessio
             ...part,
             planFile: part.planFile ? prefixFileReference(part.planFile, prefix) : null,
             images: part.images.map((ref) => prefixFileReference(ref, prefix)),
+            battlemaps: part.battlemaps.map((ref) => prefixFileReference(ref, prefix)),
             supportDocs: part.supportDocs.map((ref) => prefixFileReference(ref, prefix)),
             bgmPlaylist: part.bgmPlaylist.map((ref) => prefixFileReference(ref, prefix)),
             eventPlaylists: part.eventPlaylists.map((playlist) => ({

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -451,6 +451,31 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/**
+ * `viaje.combustible_cada_dias` with legacy-knob migration: the pre-economy
+ * `combustible_por_tramo` (flat units per jump) is dimensionally different
+ * from per-day cadence, so it is NEVER mapped numerically — a manifest still
+ * carrying it gets the default cadence plus an aviso (and when both keys are
+ * present, `combustible_cada_dias` wins, still with the aviso).
+ */
+function parseCombustibleCadaDias(
+    viaje: Record<string, unknown> | undefined,
+    fallback: WorldManifest,
+    problemas: ValidationIssue[]
+): number {
+    const cada = asNumber(viaje?.combustible_cada_dias) ?? fallback.viaje.combustibleCadaDias;
+    if (viaje !== undefined && viaje.combustible_por_tramo !== undefined) {
+        problemas.push({
+            nivel: 'aviso',
+            archivo: MANIFEST_PATH,
+            mensaje:
+                '«viaje.combustible_por_tramo» está obsoleto — usa «combustible_cada_dias» ' +
+                `(aplicado: ${cada})`,
+        });
+    }
+    return cada;
+}
+
 function parseManifest(content: string | null, problemas: ValidationIssue[]): WorldManifest {
     const fallback = defaultManifest();
 
@@ -516,8 +541,7 @@ function parseManifest(content: string | null, problemas: ValidationIssue[]): Wo
             diasPorUnidad: asNumber(viaje?.dias_por_unidad) ?? fallback.viaje.diasPorUnidad,
             intrasistemaDias:
                 asNumber(viaje?.intrasistema_dias) ?? fallback.viaje.intrasistemaDias,
-            combustiblePorTramo:
-                asNumber(viaje?.combustible_por_tramo) ?? fallback.viaje.combustiblePorTramo,
+            combustibleCadaDias: parseCombustibleCadaDias(viaje, fallback, problemas),
             viveresCadaDias:
                 asNumber(viaje?.viveres_cada_dias) ?? fallback.viaje.viveresCadaDias,
         },

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -13,6 +13,7 @@ import {
     EventTable,
     FactionEntity,
     FactionPresence,
+    Guia,
     JournalDay,
     Lead,
     NpcEntity,
@@ -58,6 +59,7 @@ import {
     DEFAULT_CONOCIMIENTO,
     ENTITY_DIRS,
     ESTADOS_PISTA,
+    GUIA_FILES,
     IMAGES_DIR,
     ESTADOS_TRAMA,
     MANIFEST_DEFAULTS,
@@ -119,7 +121,16 @@ export async function scanWorldFolder(
             mensaje: `No se encontró la carpeta "${WORLD_DIR}/" en la carpeta de campaña`,
         });
         onProgress?.(1, 1);
-        return assembleModel(defaultManifest(), [], problemas, null, emptyMusica(), new Map(), null);
+        return assembleModel(
+            defaultManifest(),
+            [],
+            problemas,
+            null,
+            emptyMusica(),
+            new Map(),
+            null,
+            []
+        );
     }
 
     // Enumerate first (cheap directory listings), then read contents in batches.
@@ -154,6 +165,10 @@ export async function scanWorldFolder(
     // markdown, null when absent, never an entity and never an aviso.
     const resumen = await readResumen(mundoDir);
 
+    // GM play-aid sheets (GUIA_FILES allowlist): a handful of optional reads at
+    // the mundo/ root, each tolerant like the recap — absent files are skipped.
+    const guias = await readGuias(mundoDir);
+
     // Entity reads, batched
     const records: RawEntityFile[] = [];
     for (let i = 0; i < tasks.length; i += READ_BATCH_SIZE) {
@@ -168,7 +183,16 @@ export async function scanWorldFolder(
     }
 
     const manifest = parseManifest(manifestContent, problemas);
-    return assembleModel(manifest, records, problemas, estadoGrupo, musica, imagenes, resumen);
+    return assembleModel(
+        manifest,
+        records,
+        problemas,
+        estadoGrupo,
+        musica,
+        imagenes,
+        resumen,
+        guias
+    );
 }
 
 /**
@@ -184,6 +208,41 @@ async function readResumen(mundoDir: FileSystemDirectoryHandle): Promise<string 
     } catch {
         return null;
     }
+}
+
+/**
+ * Reads the curated GUIA_FILES allowlist at the `mundo/` root — the GM play-aid
+ * sheets (run of show, thread map, cast). Each read is tolerant like readResumen
+ * (absent → skip, unreadable → skip, never throws); the allowlist keeps design
+ * docs out of the header menu. The display title prefers the file's first
+ * markdown `# heading`, falling back to the mapping's `titulo`. Returns the
+ * present guías in allowlist order (empty array when none exist).
+ */
+async function readGuias(mundoDir: FileSystemDirectoryHandle): Promise<Guia[]> {
+    const guias: Guia[] = [];
+    for (const { file, titulo } of GUIA_FILES) {
+        try {
+            const handle = await mundoDir.getFileHandle(file);
+            const content = await (await handle.getFile()).text();
+            guias.push({
+                id: file.replace(/\.md$/i, ''),
+                titulo: firstHeading(content) ?? titulo,
+                content,
+            });
+        } catch {
+            // Absent or unreadable — skip silently (each guía is optional).
+        }
+    }
+    return guias;
+}
+
+/** First markdown `# heading` text (single leading `#`), or null when none. */
+function firstHeading(markdown: string): string | null {
+    for (const line of markdown.split('\n')) {
+        const match = /^#\s+(.+?)\s*$/.exec(line);
+        if (match) return match[1];
+    }
+    return null;
 }
 
 // ── Entity profile images (imagenes/) ───────────────────────────────────────
@@ -1047,7 +1106,8 @@ function assembleModel(
     estadoGrupo: PartyState | null,
     musica: WorldModel['musica'],
     imagenes: Map<string, FileReference>,
-    resumen: string | null
+    resumen: string | null,
+    guias: Guia[]
 ): WorldModel {
     const entidades = new Map<string, WorldEntityBase>();
     const sistemas: SystemEntity[] = [];
@@ -1180,6 +1240,7 @@ function assembleModel(
         musica,
         tiendas,
         resumen,
+        guias,
     };
 
     // Unprocessed journals re-overlay in-session knowledge BEFORE the

--- a/lib/world/worldScanner.ts
+++ b/lib/world/worldScanner.ts
@@ -391,7 +391,7 @@ async function scanPlaceFolder(
         const config = await scanSessionFolder(dirHandle);
         // A folder with lugar.md but no session content is just a plain place.
         if (config.parts.length > 0) {
-            playable = prefixSessionConfigPaths(config, `${folderPath}/`);
+            playable = prefixSessionConfigPaths(splitFlatPlanParts(config), `${folderPath}/`);
         }
     } catch {
         issues.push({
@@ -411,6 +411,40 @@ async function scanPlaceFolder(
         },
         issues,
     };
+}
+
+/**
+ * Splits the legacy single-part fallback of scanSessionFolder into one Part per
+ * plan/*.md file. A playable PLACE keeps its acts as flat files (plan/acto2.md,
+ * plan/acto2b.md, ...) and scanForSinglePart would bundle them into one "Part 1"
+ * with the extra acts demoted to support docs — wrong for the ActRunner, where
+ * each act must be its own selectable part with its own timer.
+ *
+ * Classic session mode is untouched: this transform runs only on world playable
+ * places, only on the exact single-part fallback shape, and support content
+ * (characters/threats/maps/music/images) stays attached to the FIRST part —
+ * the same convention branching path folders use.
+ */
+function splitFlatPlanParts(config: SessionConfig): SessionConfig {
+    if (config.parts.length !== 1) return config;
+    const [part] = config.parts;
+    if (!part.planFile || !part.planFile.path.startsWith('plan/')) return config;
+
+    const planDocs = part.supportDocs.filter((doc) => doc.path.startsWith('plan/'));
+    if (planDocs.length === 0) return config;
+    const otherDocs = part.supportDocs.filter((doc) => !doc.path.startsWith('plan/'));
+
+    const actFiles = [part.planFile, ...planDocs].sort((a, b) => a.path.localeCompare(b.path));
+    const parts = actFiles.map((ref, i) => ({
+        id: `${part.id}-acto${i}`,
+        name: fileNameToDisplayName(ref.name),
+        planFile: ref,
+        images: i === 0 ? part.images : [],
+        supportDocs: i === 0 ? otherDocs : [],
+        bgmPlaylist: i === 0 ? part.bgmPlaylist : [],
+        eventPlaylists: i === 0 ? part.eventPlaylists : [],
+    }));
+    return { ...config, parts };
 }
 
 function prefixFileReference<T extends FileReference>(ref: T, prefix: string): T {
@@ -1158,8 +1192,22 @@ function warnOrphans(
         for (const id of trama.facciones) referenced.add(id);
     }
 
+    // A pnj whose ubicacion resolves is ANCHORED to the map through its place —
+    // deliberately forward-seeded NPCs (unknown to the party, waiting at a
+    // not-yet-visited place) are not orphans and should not add Diagnóstico noise.
+    const anchoredPnjs = new Set<string>();
+    for (const pnj of pnjs) {
+        if (pnj.ubicacion !== undefined && entidades.has(pnj.ubicacion)) {
+            anchoredPnjs.add(pnj.id);
+        }
+    }
+
     for (const entity of [...sistemas, ...lugares, ...facciones, ...pnjs]) {
-        if (entity.conocimiento === 'desconocido' && !referenced.has(entity.id)) {
+        if (
+            entity.conocimiento === 'desconocido' &&
+            !referenced.has(entity.id) &&
+            !anchoredPnjs.has(entity.id)
+        ) {
             problemas.push({
                 nivel: 'aviso',
                 archivo: entity.filePath,

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -47,6 +47,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         musica: { bgm: [], eventPlaylists: [] },
         tiendas: new Map(),
         resumen: null,
+        guias: [],
     };
 }
 

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -26,7 +26,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
             viaje: {
                 diasPorUnidad: 1,
                 intrasistemaDias: 1,
-                combustiblePorTramo: 1,
+                combustibleCadaDias: 4,
                 viveresCadaDias: 4,
             },
             medidores: ['viveres', 'combustible', 'nave'],

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -42,6 +42,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         problemas: [],
         childrenOf: new Map(),
         estadoGrupo: null,
+        diario: [],
     };
 }
 

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -45,6 +45,8 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         estadoGrupo: null,
         diario: [],
         musica: { bgm: [], eventPlaylists: [] },
+        tiendas: new Map(),
+        resumen: null,
     };
 }
 

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -1,0 +1,174 @@
+/// <reference types="bun-types" />
+import { test, expect, describe } from 'bun:test';
+import { WorldEntityBase, WorldModel } from '@/types/world';
+import { buildWorldSearchIndex } from './worldSearch';
+
+// ── In-memory model builders (plain literals — no scanner involved) ─────────
+
+function makeEntity(
+    overrides: Pick<WorldEntityBase, 'id' | 'tipo' | 'nombre'> & Partial<WorldEntityBase>
+): WorldEntityBase {
+    return {
+        filePath: `mundo/lugares/${overrides.id}.md`,
+        conocimiento: 'conocido',
+        etiquetas: [],
+        raw: {},
+        body: '',
+        ...overrides,
+    };
+}
+
+function makeModel(entities: WorldEntityBase[]): WorldModel {
+    return {
+        manifest: {
+            nombre: 'Sector Prueba',
+            calendario: { era: 'dG', anoEpoca: 3, diasPorMes: 30, meses: ['uno', 'dos'] },
+            viaje: {
+                diasPorUnidad: 1,
+                intrasistemaDias: 1,
+                combustiblePorTramo: 1,
+                viveresCadaDias: 4,
+            },
+            medidores: ['viveres', 'combustible', 'nave'],
+            regiones: [],
+        },
+        entidades: new Map(entities.map((entity) => [entity.id, entity])),
+        sistemas: [],
+        lugares: [],
+        facciones: [],
+        pnjs: [],
+        pistas: [],
+        tramas: [],
+        problemas: [],
+        childrenOf: new Map(),
+        estadoGrupo: null,
+    };
+}
+
+const FIXTURE = makeModel([
+    makeEntity({
+        id: 'porto_verne',
+        tipo: 'estacion',
+        nombre: 'Porto Verne',
+        resumen: 'Puerto franco en el borde del sector.',
+        body: '# Porto Verne\n\nUn **astillero clandestino** opera en los muelles bajos.',
+    }),
+    makeEntity({
+        id: 'kovar_iii',
+        tipo: 'planeta',
+        nombre: 'Kovar III',
+        estado: 'Bloqueo orbital tras el incidente minero.',
+        body: 'Mundo desertico. Nada menciona puertos aqui.',
+    }),
+    makeEntity({
+        id: 'estacion_sigma',
+        tipo: 'nodo',
+        nombre: 'Estación Sigma',
+        body: 'Nodo de la red con acceso por portal.',
+    }),
+    makeEntity({
+        id: 'zara_velk',
+        tipo: 'pnj',
+        nombre: 'Zara Velk',
+        resumen: 'Contrabandista con deudas.',
+        body: 'Frecuenta el astillero de Porto Verne.',
+    }),
+]);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('buildWorldSearchIndex', () => {
+    test('indexes every entity in the model', () => {
+        expect(buildWorldSearchIndex(FIXTURE).size).toBe(4);
+    });
+
+    test('search by nombre hits', () => {
+        const results = buildWorldSearchIndex(FIXTURE).search('verne');
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0].id).toBe('porto_verne');
+    });
+
+    test('search by body content hits', () => {
+        const results = buildWorldSearchIndex(FIXTURE).search('clandestino');
+        expect(results.map((r) => r.id)).toContain('porto_verne');
+    });
+
+    test('search by resumen and estado content hits', () => {
+        const index = buildWorldSearchIndex(FIXTURE);
+        expect(index.search('deudas').map((r) => r.id)).toContain('zara_velk');
+        expect(index.search('bloqueo').map((r) => r.id)).toContain('kovar_iii');
+    });
+
+    test('nombre match outranks body-only match', () => {
+        // "verne" is in porto_verne's nombre (boost 10) and only in
+        // zara_velk's body — the station must come first.
+        const results = buildWorldSearchIndex(FIXTURE).search('verne');
+        const ids = results.map((r) => r.id);
+        expect(ids.indexOf('porto_verne')).toBeLessThan(ids.indexOf('zara_velk'));
+    });
+
+    // Accent behavior: lunr's DEFAULT pipeline is accent-sensitive (tokens
+    // keep diacritics, so "estacion" would NOT match "Estación"). worldSearch
+    // folds diacritics on both index and query sides to get the reasonable,
+    // accent-INSENSITIVE behavior Spanish content needs. Documented here.
+    describe('accent insensitivity (diacritic folding over lunr default)', () => {
+        test('unaccented query matches accented nombre', () => {
+            const results = buildWorldSearchIndex(FIXTURE).search('estacion');
+            expect(results.map((r) => r.id)).toContain('estacion_sigma');
+        });
+
+        test('accented query matches too, and original accents survive in results', () => {
+            const results = buildWorldSearchIndex(FIXTURE).search('estación');
+            const sigma = results.find((r) => r.id === 'estacion_sigma');
+            expect(sigma).toBeDefined();
+            expect(sigma!.nombre).toBe('Estación Sigma');
+        });
+
+        test('accented query matches unaccented content', () => {
+            const results = buildWorldSearchIndex(FIXTURE).search('desértico');
+            expect(results.map((r) => r.id)).toContain('kovar_iii');
+        });
+    });
+
+    test('result shape is the WorldSearchResult adapter {id, nombre, tipo, snippet}', () => {
+        const [result] = buildWorldSearchIndex(FIXTURE).search('clandestino');
+        expect(Object.keys(result).sort()).toEqual(['id', 'nombre', 'snippet', 'tipo']);
+        expect(result.id).toBe('porto_verne');
+        expect(result.nombre).toBe('Porto Verne');
+        expect(result.tipo).toBe('estacion');
+        // Snippet centers on the match with markdown stripped.
+        expect(result.snippet).toContain('astillero clandestino');
+        expect(result.snippet).not.toContain('**');
+    });
+
+    test('nombre-only match falls back to a body-start snippet', () => {
+        const results = buildWorldSearchIndex(FIXTURE).search('kovar');
+        const kovar = results.find((r) => r.id === 'kovar_iii');
+        expect(kovar).toBeDefined();
+        expect(kovar!.snippet).toContain('Bloqueo orbital');
+    });
+
+    test('prefix matching: partial term hits while typing', () => {
+        const results = buildWorldSearchIndex(FIXTURE).search('vern');
+        expect(results.map((r) => r.id)).toContain('porto_verne');
+    });
+
+    test('respects maxResults', () => {
+        const results = buildWorldSearchIndex(FIXTURE).search('porto', 1);
+        expect(results.length).toBe(1);
+    });
+
+    test('empty and garbage queries return [] without throwing', () => {
+        const index = buildWorldSearchIndex(FIXTURE);
+        expect(index.search('')).toEqual([]);
+        expect(index.search('   ')).toEqual([]);
+        expect(index.search('~^: *')).toEqual([]);
+        expect(index.search('xyzzy_no_existe')).toEqual([]);
+    });
+
+    test('empty model builds an index that returns []', () => {
+        const index = buildWorldSearchIndex(makeModel([]));
+        expect(index.size).toBe(0);
+        expect(index.search('verne')).toEqual([]);
+    });
+});

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -39,6 +39,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         pnjs: [],
         pistas: [],
         tramas: [],
+        tablas: [],
         problemas: [],
         childrenOf: new Map(),
         estadoGrupo: null,

--- a/lib/world/worldSearch.test.ts
+++ b/lib/world/worldSearch.test.ts
@@ -44,6 +44,7 @@ function makeModel(entities: WorldEntityBase[]): WorldModel {
         childrenOf: new Map(),
         estadoGrupo: null,
         diario: [],
+        musica: { bgm: [], eventPlaylists: [] },
     };
 }
 

--- a/lib/world/worldSearch.ts
+++ b/lib/world/worldSearch.ts
@@ -1,0 +1,164 @@
+/**
+ * World-mode entity search (plan M2).
+ *
+ * Mirrors the lunr setup pattern of lib/search.ts (SearchManager) but as a
+ * standalone builder: SearchManager is Part-coupled (FileReference paths,
+ * partId/partName, path filters) while the world index refs entity ids, so
+ * composition beats subclassing here. The result shape is the small adapter
+ * type WorldSearchResult the world SearchDialog consumes.
+ *
+ * Accent handling: lunr's default pipeline is accent-SENSITIVE (tokens keep
+ * their diacritics), which is unusable for Spanish content — the GM types
+ * "estacion" for "Estación" half the time. We therefore fold diacritics
+ * (NFD-decompose + strip combining marks) on BOTH the indexed text and the
+ * query, so matching is accent-insensitive while results keep the original
+ * accented strings for display.
+ */
+
+import lunr from 'lunr';
+import { WorldModel } from '@/types/world';
+
+export interface WorldSearchResult {
+    /** Entity id (= filename), usable directly as selectedEntityId. */
+    id: string;
+    nombre: string;
+    tipo: string;
+    /** Markdown-stripped context around the first match (may be ''). */
+    snippet: string;
+}
+
+export interface WorldSearchIndex {
+    /** Number of indexed entities. */
+    size: number;
+    /**
+     * Searches indexed entities. Each whitespace-separated term matches
+     * exactly OR as a prefix (trailing wildcard), so results appear while
+     * typing; exact matches rank higher. Returns [] for empty/garbage
+     * queries — never throws.
+     */
+    search: (query: string, maxResults?: number) => WorldSearchResult[];
+}
+
+/** Strips diacritics: "Estación" -> "Estacion", "ñ" -> "n". */
+function foldDiacritics(text: string): string {
+    return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/** Strips light markdown so snippets read as prose (same rules as SearchManager). */
+function cleanMarkdown(content: string): string {
+    return content
+        .replace(/#{1,6}\s/g, '')
+        .replace(/\*\*(.+?)\*\*/g, '$1')
+        .replace(/\*(.+?)\*/g, '$1')
+        .replace(/\[(.+?)\]\(.+?\)/g, '$1')
+        .replace(/`(.+?)`/g, '$1');
+}
+
+/**
+ * Extracts a snippet centered on the first folded-term match.
+ * `content` must be NFC-normalized so folded indices line up with the
+ * original string (precomposed accents fold 1:1 in length).
+ */
+function extractSnippet(content: string, foldedTerms: string[], contextLength: number = 150): string {
+    const clean = cleanMarkdown(content);
+    const foldedClean = foldDiacritics(clean).toLowerCase();
+
+    let matchIndex = -1;
+    for (const term of foldedTerms) {
+        matchIndex = foldedClean.indexOf(term);
+        if (matchIndex !== -1) break;
+    }
+
+    if (matchIndex === -1) {
+        // Match was in nombre/tipo only — show the start of the body as context.
+        return clean.length > contextLength
+            ? clean.substring(0, contextLength).trim() + '...'
+            : clean.trim();
+    }
+
+    const start = Math.max(0, matchIndex - contextLength / 2);
+    const end = Math.min(clean.length, matchIndex + contextLength / 2);
+
+    let snippet = clean.substring(start, end);
+    if (start > 0) snippet = '...' + snippet;
+    if (end < clean.length) snippet = snippet + '...';
+    return snippet.trim();
+}
+
+/**
+ * Builds an in-memory search index over every entity of a WorldModel.
+ * Fields: nombre (boost 10), tipo (boost 5), content (resumen + estado + body).
+ * Pure/synchronous — rebuild after each world rescan (models are
+ * immutable-after-scan, so the index never goes stale within a scan).
+ */
+export function buildWorldSearchIndex(model: WorldModel): WorldSearchIndex {
+    const docs = new Map<string, { nombre: string; tipo: string; content: string }>();
+
+    for (const entity of model.entidades.values()) {
+        const content = [entity.resumen, entity.estado, entity.body]
+            .filter((part): part is string => typeof part === 'string' && part.trim() !== '')
+            .join('\n\n')
+            .normalize('NFC');
+        docs.set(entity.id, {
+            nombre: entity.nombre,
+            tipo: entity.tipo,
+            content,
+        });
+    }
+
+    const index = lunr(function () {
+        this.ref('id');
+        this.field('nombre', { boost: 10 });
+        this.field('tipo', { boost: 5 });
+        this.field('content');
+
+        for (const [id, doc] of docs) {
+            this.add({
+                id,
+                nombre: foldDiacritics(doc.nombre),
+                tipo: foldDiacritics(doc.tipo),
+                content: foldDiacritics(doc.content),
+            });
+        }
+    });
+
+    return {
+        size: docs.size,
+
+        search(query: string, maxResults: number = 10): WorldSearchResult[] {
+            const terms = foldDiacritics(query.toLowerCase())
+                .split(/\s+/)
+                // Strip lunr query syntax (: ^ ~ + - *) and any other symbol;
+                // ids are snake_case ASCII and Spanish text folds to a-z0-9.
+                .map((term) => term.replace(/[^a-z0-9_]/g, ''))
+                .filter((term) => term.length > 0);
+            if (terms.length === 0) return [];
+
+            // Exact clause + trailing-wildcard clause per term: prefixes hit
+            // while typing, exact matches score both clauses and rank higher.
+            const lunrQuery = terms.map((term) => `${term} ${term}*`).join(' ');
+
+            let hits: lunr.Index.Result[];
+            try {
+                hits = index.search(lunrQuery);
+            } catch (error) {
+                console.error('World search error:', error);
+                return [];
+            }
+
+            const results: WorldSearchResult[] = [];
+            for (const hit of hits) {
+                const doc = docs.get(hit.ref);
+                if (!doc) continue;
+                results.push({
+                    id: hit.ref,
+                    nombre: doc.nombre,
+                    tipo: doc.tipo,
+                    snippet: extractSnippet(doc.content, terms),
+                });
+                if (results.length >= maxResults) break;
+            }
+            return results;
+        },
+    };
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "test": "bun test",
+    "test": "bun test --path-ignore-patterns='**/e2e/**'",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "start": "next start"
+    "start": "next start",
+    "test": "bun test",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -18,6 +20,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "idb-keyval": "^6.2.6",
     "lucide-react": "^1.7.0",
     "lunr": "^2.3.9",
     "next": "16.2.9",
@@ -26,7 +29,10 @@
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.3.1"
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.3.1",
+    "yaml": "^2.9.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/file-system-access.d.ts
+++ b/types/file-system-access.d.ts
@@ -5,6 +5,12 @@ interface FileSystemHandle {
   readonly kind: 'file' | 'directory';
   readonly name: string;
   isSameEntry(other: FileSystemHandle): Promise<boolean>;
+  queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+  requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+}
+
+interface FileSystemHandlePermissionDescriptor {
+  mode?: 'read' | 'readwrite';
 }
 
 interface FileSystemFileHandle extends FileSystemHandle {

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,6 +18,7 @@ export interface Part {
   name: string;
   planFile: FileReference | null;
   images: FileReference[];
+  battlemaps: FileReference[]; // gridded battlemap IMAGES from maps/ (markdown maps stay in supportDocs)
   supportDocs: FileReference[];
   bgmPlaylist: AudioFile[];
   eventPlaylists: EventPlaylist[];

--- a/types/world.ts
+++ b/types/world.ts
@@ -221,6 +221,13 @@ export interface PartyState {
   creditos: number;
   /** Gauge name -> value 0-5 (`medidores`), e.g. viveres/combustible/nave. */
   medidores: Record<string, number>;
+  /**
+   * Party PC names (`personajes`) — the roster fed to the cockpit initiative
+   * tracker. Agent/GM-owned data the app never mutates via the log, but the
+   * app-owned frontmatter rewrite MUST round-trip it so a session write never
+   * drops the roster. Default [] when absent.
+   */
+  personajes: string[];
   /** Agent-owned markdown body below the frontmatter, byte-for-byte. */
   bodyMd: string;
   /** Path relative to the campaign folder; null when estado/grupo.md is absent. */

--- a/types/world.ts
+++ b/types/world.ts
@@ -118,6 +118,29 @@ export interface WorldManifest {
   regiones: string[];
 }
 
+/**
+ * Party state from `estado/grupo.md` (plan Part A): frontmatter is app-owned
+ * (written by the app during active sessions from M3 on), body is agent-owned
+ * prose and must be preserved byte-for-byte on every rewrite.
+ */
+export interface PartyState {
+  /** Session lock (`sesion_activa`): true while a live session holds the file. */
+  sesionActiva: boolean;
+  /** Canonical in-world time as integer day count; day 1 = epoch start. */
+  diaMundo: number;
+  /** Lugar/sistema id where the party is; null when unknown/not set. */
+  ubicacion: string | null;
+  /** In-transit heading (`rumbo`); null when the party is not travelling. */
+  rumbo: { destino: string; llegadaDia: number } | null;
+  creditos: number;
+  /** Gauge name -> value 0-5 (`medidores`), e.g. viveres/combustible/nave. */
+  medidores: Record<string, number>;
+  /** Agent-owned markdown body below the frontmatter, byte-for-byte. */
+  bodyMd: string;
+  /** Path relative to the campaign folder; null when estado/grupo.md is absent. */
+  filePath: string | null;
+}
+
 export interface ValidationIssue {
   nivel: 'error' | 'aviso';
   /** Path relative to the campaign folder. */
@@ -137,4 +160,6 @@ export interface WorldModel {
   problemas: ValidationIssue[];
   /** Parent id -> child entity ids (inverse of `en:`). */
   childrenOf: Map<string, string[]>;
+  /** Party state from `estado/grupo.md`; null when the file is absent. */
+  estadoGrupo: PartyState | null;
 }

--- a/types/world.ts
+++ b/types/world.ts
@@ -105,6 +105,38 @@ export interface Trama extends WorldEntityBase {
 }
 
 /**
+ * One row of a shop's price table (feature — shop system). `stock` null means
+ * unlimited (the market never runs out); a number counts down as the party
+ * buys. `nota` is an optional free-text column.
+ */
+export interface ShopItem {
+  articulo: string;
+  precio: number;
+  stock: number | null;
+  nota?: string;
+}
+
+/**
+ * A shop parsed from `mundo/lugares/<place>/tiendas/<shop_id>.md` (frontmatter
+ * `tipo: tienda`, then GM prose, then a `| articulo | precio | stock | nota |`
+ * table). Multiple shops can live under one place; the scanner keys them by
+ * place id in WorldModel.tiendas.
+ */
+export interface Shop {
+  /** id = shop filename without extension. */
+  id: string;
+  nombre: string;
+  /** Optional shopkeeper pnj id (`pnj:`); validated against the entity map. */
+  pnj?: string;
+  etiquetas: string[];
+  items: ShopItem[];
+  /** GM prose above the table. */
+  body: string;
+  /** Path relative to the campaign folder. */
+  filePath: string;
+}
+
+/**
  * One `:::efecto` line of an event (M4). Same shape semantics as ActField:
  * `key` is the field name (gasto/ganancia/medidor/sabe/pista/nota), `value`
  * the raw value part. The cockpit converts these to journal entries.
@@ -334,4 +366,16 @@ export interface WorldModel {
    * an aviso.
    */
   musica: { bgm: AudioFile[]; eventPlaylists: EventPlaylist[] };
+  /**
+   * Shops keyed by their place id (`mundo/lugares/<place>/tiendas/<shop>.md`).
+   * A place with no `tiendas/` folder has no entry; the map is empty when no
+   * place has shops. Multiple shops per place are possible.
+   */
+  tiendas: Map<string, Shop[]>;
+  /**
+   * Whole text of the OPTIONAL `mundo/resumen.md` session recap (plain
+   * markdown, read like the manifest — one read, never an entity); null when
+   * the file is absent.
+   */
+  resumen: string | null;
 }

--- a/types/world.ts
+++ b/types/world.ts
@@ -141,6 +141,74 @@ export interface PartyState {
   filePath: string | null;
 }
 
+/**
+ * Journal entry types (M3, plan Part A). One per quick-log action; `nota` is
+ * freeform (payload empty, text in `comentario`). Line grammar per type lives
+ * in the plan table and lib/world/logEntries.ts.
+ */
+export type JournalEntryType =
+  | 'inicio'
+  | 'fin'
+  | 'rumbo'
+  | 'llegada'
+  | 'gasto'
+  | 'ganancia'
+  | 'medidor'
+  | 'pista'
+  | 'sabe'
+  | 'evento'
+  | 'descanso'
+  | 'dia'
+  | 'nota';
+
+/** One journal line: `- [HH:MM] tipo: payload | comentario` (comentario optional). */
+export interface JournalEntry {
+  /** Wall-clock time of the entry, HH:MM. */
+  hora: string;
+  tipo: JournalEntryType;
+  /** Strict machine-parseable payload per the plan's per-type grammar. */
+  payload: string;
+  /** Freeform GM comment after the `|` separator. */
+  comentario?: string;
+}
+
+/** A parsed `diario/AAAA-MM-DD_sNN.md` file. */
+export interface JournalDay {
+  /** Path relative to the campaign folder. */
+  filePath: string;
+  sesion: number;
+  /** Real-world session date, YYYY-MM-DD. */
+  fechaReal: string;
+  diaInicio: number | null;
+  /** Null until the session closes. */
+  diaFin: number | null;
+  /** Agent flips to true after the maintenance loop. */
+  procesado: boolean;
+  entradas: JournalEntry[];
+}
+
+/** Point-in-time copy of the mutable party fields, taken at session start (undo replays over it). */
+export type PartySnapshot = {
+  diaMundo: number;
+  ubicacion: string | null;
+  rumbo: { destino: string; llegadaDia: number } | null;
+  creditos: number;
+  medidores: Record<string, number>;
+};
+
+/** Live session bookkeeping held by the party store (never persisted as-is). */
+export interface SessionRuntime {
+  active: boolean;
+  /** Path of the journal being written, relative to the campaign folder. */
+  journalPath: string | null;
+  /** Epoch ms when the session started. */
+  startedAt: number | null;
+  entries: JournalEntry[];
+  /** Party state at session start; base for replay-undo. */
+  snapshot: PartySnapshot | null;
+  writeStatus: 'ok' | 'pending' | 'denied';
+}
+
 export interface ValidationIssue {
   nivel: 'error' | 'aviso';
   /** Path relative to the campaign folder. */
@@ -162,4 +230,6 @@ export interface WorldModel {
   childrenOf: Map<string, string[]>;
   /** Party state from `estado/grupo.md`; null when the file is absent. */
   estadoGrupo: PartyState | null;
+  /** Parsed journals from `diario/` (M3); unprocessed ones re-overlay state at scan. */
+  diario: JournalDay[];
 }

--- a/types/world.ts
+++ b/types/world.ts
@@ -52,6 +52,12 @@ export interface PlaceEntity extends WorldEntityBase {
   coordenadas?: { x: number; y: number };
   /** Orbital ordering within the parent system. */
   orbita?: number;
+  /**
+   * Local floor-plan coordinates (0..100 on each axis) within the parent
+   * place's Plano (spatial place tier). Present only on POI lugares — child
+   * places whose parent renders a spatial interior; absent otherwise.
+   */
+  poi?: { x: number; y: number };
   region?: string;
   servicios: string[];
   facciones: FactionPresence[];

--- a/types/world.ts
+++ b/types/world.ts
@@ -98,6 +98,75 @@ export interface Trama extends WorldEntityBase {
   pistas: Lead[];
 }
 
+/**
+ * One `:::efecto` line of an event (M4). Same shape semantics as ActField:
+ * `key` is the field name (gasto/ganancia/medidor/sabe/pista/nota), `value`
+ * the raw value part. The cockpit converts these to journal entries.
+ */
+export interface EventEffect {
+  key: string;
+  value: string;
+}
+
+/** One `##` section of an event table (M4). */
+export interface WorldEvent {
+  id: string;
+  titulo: string;
+  peso: number;
+  /** Per-event gate conditions (condition grammar; all must hold). */
+  si: string[];
+  etiquetas: string[];
+  /** Markdown body (`:::leer/:::gm/:::accion` render through parseAct). */
+  cuerpo: string;
+  efectos: EventEffect[];
+}
+
+/** An `eventos/*.md` table (M4). */
+export interface EventTable extends WorldEntityBase {
+  contexto: 'viaje' | 'estancia' | 'ambas';
+  regiones: string[];
+  /** Conditional weight modifiers: when `si` holds, matching etiquetas gain `peso`. */
+  sesgos: { si: string; etiquetas: string[]; peso: number }[];
+  eventos: WorldEvent[];
+}
+
+/** One route segment of a travel plan (M4). */
+export interface TravelLeg {
+  fromId: string;
+  toId: string;
+  dias: number;
+  combustible: number;
+  viveres: number;
+}
+
+/** Full route proposal shown in the TravelDialog (M4). */
+export interface TravelPlan {
+  legs: TravelLeg[];
+  totalDias: number;
+  totalCombustible: number;
+  totalViveres: number;
+  warnings: string[];
+  /** Destination is `acceso: portal` — no route calc applies. */
+  portal: boolean;
+}
+
+/**
+ * Evaluation context for the condition grammar (M4): pista `requisitos`,
+ * event `si` and table `sesgos` all evaluate against this via evalCondition.
+ */
+export interface CondContext {
+  creditos: number;
+  medidores: Record<string, number>;
+  diaMundo: number;
+  regionActual: string | null;
+  etiquetasActuales: string[];
+  faccionesActuales: string[];
+  /** Lead id -> its estadoPista; null when the pista does not exist. */
+  pistaEstado: (id: string) => string | null;
+  /** Lugar id -> its conocimiento; null when the lugar does not exist. */
+  lugarConocimiento: (id: string) => string | null;
+}
+
 export interface WorldManifest {
   nombre: string;
   calendario: {
@@ -225,6 +294,8 @@ export interface WorldModel {
   pnjs: NpcEntity[];
   pistas: Lead[];
   tramas: Trama[];
+  /** Event tables from `eventos/` (M4). */
+  tablas: EventTable[];
   problemas: ValidationIssue[];
   /** Parent id -> child entity ids (inverse of `en:`). */
   childrenOf: Map<string, string[]>;

--- a/types/world.ts
+++ b/types/world.ts
@@ -1,4 +1,4 @@
-import { SessionConfig } from '@/types';
+import { AudioFile, EventPlaylist, SessionConfig } from '@/types';
 
 /**
  * World-mode domain types (M1).
@@ -308,4 +308,11 @@ export interface WorldModel {
   estadoGrupo: PartyState | null;
   /** Parsed journals from `diario/` (M3); unprocessed ones re-overlay state at scan. */
   diario: JournalDay[];
+  /**
+   * World-level music from `mundo/musica/` (optional folder): root audio
+   * files = the generic ambient/travel BGM rotation, each subfolder = a named
+   * event playlist. Empty arrays when the folder is absent — by design, never
+   * an aviso.
+   */
+  musica: { bgm: AudioFile[]; eventPlaylists: EventPlaylist[] };
 }

--- a/types/world.ts
+++ b/types/world.ts
@@ -1,0 +1,140 @@
+import { SessionConfig } from '@/types';
+
+/**
+ * World-mode domain types (M1).
+ * Entities live as markdown files with YAML frontmatter under `mundo/`;
+ * the scanner (lib/world/worldScanner.ts) materializes them into these shapes.
+ * Field names are Spanish (matching the file conventions); code identifiers stay English.
+ */
+
+/** Party knowledge level of an entity. Ordered: desconocido < rumoreado < conocido < visitado. */
+export type Conocimiento = 'desconocido' | 'rumoreado' | 'conocido' | 'visitado';
+
+export interface WorldEntityBase {
+  /** id = filename without extension (snake_case ASCII, globally unique). */
+  id: string;
+  /** Entity type (`tipo:` frontmatter); open string — TIPOS_LUGAR is only a recommended list. */
+  tipo: string;
+  nombre: string;
+  /** Path relative to the campaign folder, e.g. `mundo/lugares/porto_verne/lugar.md`. */
+  filePath: string;
+  conocimiento: Conocimiento;
+  etiquetas: string[];
+  resumen?: string;
+  /** Agent-updated situation blurb (`estado: >`). */
+  estado?: string;
+  /** Normalized frontmatter as parsed — escape hatch for fields not modeled here. */
+  raw: Record<string, unknown>;
+  /** Markdown body below the frontmatter fence. */
+  body: string;
+}
+
+export interface SystemEntity extends WorldEntityBase {
+  tipo: 'sistema';
+  coordenadas: { x: number; y: number };
+  region?: string;
+}
+
+export interface FactionPresence {
+  faccion: string;
+  nivel: 'dominante' | 'fuerte' | 'presente' | 'encubierta';
+}
+
+export interface PlaceEntity extends WorldEntityBase {
+  /** Parent entity id (`en:`); deep-space places have `coordenadas` instead. */
+  en?: string;
+  coordenadas?: { x: number; y: number };
+  /** Orbital ordering within the parent system. */
+  orbita?: number;
+  region?: string;
+  servicios: string[];
+  facciones: FactionPresence[];
+  acceso: 'normal' | 'portal' | 'restringido';
+  /** 0-5. */
+  peligro?: number;
+  /** Present when the place is a playable folder (lugar.md + plan/ characters/ ...). */
+  playable?: SessionConfig;
+}
+
+export interface FactionEntity extends WorldEntityBase {
+  actitud: 'hostil' | 'rival' | 'neutral' | 'aliada';
+  /** 0-5. */
+  poder?: number;
+  objetivos: string[];
+}
+
+export interface NpcEntity extends WorldEntityBase {
+  faccion?: string;
+  rol: 'villano' | 'aliado' | 'comodin' | 'contacto' | 'neutral';
+  /** Lugar id or 'desconocida'. */
+  ubicacion?: string;
+}
+
+export interface Lead extends WorldEntityBase {
+  /** `estado:` in pista frontmatter (renamed: base `estado` keeps the prose blurb). */
+  estadoPista: 'rumor' | 'activa' | 'en_curso' | 'resuelta' | 'fallida';
+  /** Parent trama id. */
+  trama?: string;
+  /** Lugar id where the lead is actionable; absent = anywhere. */
+  donde?: string;
+  origen?: string;
+  /** Expiry as absolute dia_mundo. */
+  plazo?: number;
+  /** Condition grammar strings; `manual: <texto>` renders "según GM". */
+  requisitos: string[];
+  recompensa?: string;
+  /** DERIVED (never stored): estado activa/en_curso + donde known + requisitos met; 'manual' = GM decides. */
+  accionable: boolean | 'manual';
+}
+
+export interface Trama extends WorldEntityBase {
+  rol: 'principal' | 'secundaria' | 'ambiental';
+  /** `estado:` in trama frontmatter (renamed: base `estado` keeps the prose blurb). */
+  estadoTrama: 'latente' | 'activa' | 'cerrada';
+  reloj?: { actual: number; max: number };
+  lugaresClave: string[];
+  facciones: string[];
+  /** Child pistas pointing at this trama (grouped by the scanner). */
+  pistas: Lead[];
+}
+
+export interface WorldManifest {
+  nombre: string;
+  calendario: {
+    era: string;
+    anoEpoca: number;
+    diasPorMes: number;
+    meses: string[];
+  };
+  viaje: {
+    /** 1 map unit = N days. */
+    diasPorUnidad: number;
+    intrasistemaDias: number;
+    /** Consumption suggestions — app proposes, GM confirms. */
+    combustiblePorTramo: number;
+    viveresCadaDias: number;
+  };
+  medidores: string[];
+  regiones: string[];
+}
+
+export interface ValidationIssue {
+  nivel: 'error' | 'aviso';
+  /** Path relative to the campaign folder. */
+  archivo: string;
+  mensaje: string;
+}
+
+export interface WorldModel {
+  manifest: WorldManifest;
+  entidades: Map<string, WorldEntityBase>;
+  sistemas: SystemEntity[];
+  lugares: PlaceEntity[];
+  facciones: FactionEntity[];
+  pnjs: NpcEntity[];
+  pistas: Lead[];
+  tramas: Trama[];
+  problemas: ValidationIssue[];
+  /** Parent id -> child entity ids (inverse of `en:`). */
+  childrenOf: Map<string, string[]>;
+}

--- a/types/world.ts
+++ b/types/world.ts
@@ -122,6 +122,12 @@ export interface WorldEvent {
   /** Per-event gate conditions (condition grammar; all must hold). */
   si: string[];
   etiquetas: string[];
+  /**
+   * Once-only flag (`unico` bare token in the header attrs). A unico event
+   * that already appears in the journal is HARD-excluded from future draws;
+   * non-unico events only decay by seen-count. Default false.
+   */
+  unico: boolean;
   /** Markdown body (`:::leer/:::gm/:::accion` render through parseAct). */
   cuerpo: string;
   efectos: EventEffect[];

--- a/types/world.ts
+++ b/types/world.ts
@@ -1,4 +1,4 @@
-import { AudioFile, EventPlaylist, SessionConfig } from '@/types';
+import { AudioFile, EventPlaylist, FileReference, SessionConfig } from '@/types';
 
 /**
  * World-mode domain types (M1).
@@ -27,6 +27,12 @@ export interface WorldEntityBase {
   raw: Record<string, unknown>;
   /** Markdown body below the frontmatter fence. */
   body: string;
+  /**
+   * Profile image by convention: `mundo/imagenes/<id>.<ext>` (any supported
+   * image extension) is the entity's portrait/banner. Attached by the scanner
+   * for ANY entity kind (lugares, sistemas, pnjs, facciones, ...).
+   */
+  imagen?: FileReference;
 }
 
 export interface SystemEntity extends WorldEntityBase {

--- a/types/world.ts
+++ b/types/world.ts
@@ -384,4 +384,22 @@ export interface WorldModel {
    * the file is absent.
    */
   resumen: string | null;
+  /**
+   * Curated GM play-aid sheets ("guías") read from the `mundo/` root via the
+   * GUIA_FILES allowlist (each plain markdown, one read, never an entity).
+   * Empty array when none of the allowlisted files are present.
+   */
+  guias: Guia[];
+}
+
+/**
+ * One GM play-aid sheet surfaced by the header "Guías" menu. `titulo` is the
+ * file's first `# heading` when present, else the GUIA_FILES fallback; `content`
+ * is the whole markdown, rendered read-only through MarkdownViewer.
+ */
+export interface Guia {
+  /** Stable id (the allowlisted filename without its `.md` extension). */
+  id: string;
+  titulo: string;
+  content: string;
 }

--- a/types/world.ts
+++ b/types/world.ts
@@ -179,8 +179,13 @@ export interface WorldManifest {
     /** 1 map unit = N days. */
     diasPorUnidad: number;
     intrasistemaDias: number;
-    /** Consumption suggestions — app proposes, GM confirms. */
-    combustiblePorTramo: number;
+    /**
+     * Consumption suggestions — app proposes, GM confirms.
+     * combustible: 1 unit per `combustible_cada_dias` SECTOR-leg days
+     * (ceil per leg); viveres: 1 ration per `viveres_cada_dias` calendar
+     * days, anchored on `dia_mundo` (travel, descanso — any day advance).
+     */
+    combustibleCadaDias: number;
     viveresCadaDias: number;
   };
   medidores: string[];


### PR DESCRIPTION
## What

A new **/world** mode turning the app into a GM operating system for a worldbuilding-first sandbox campaign. Files stay the database (`mundo/` markdown + YAML frontmatter); the app is **viewer + cockpit + recorder**; the between-sessions AI agent is the world engine.

### World viewer
- `mundo/` auto-detection + scanner: entities (sistemas/lugares/facciones/pnjs/pistas/tramas/eventos), playable places reuse `scanSessionFolder()` verbatim, full validation with degraded load (never throws), Diagnóstico panel + "Copiar informe"
- Hand-rolled SVG semantic-zoom starmap (no new render deps): sector → system orbital → site-list tiers, knowledge-state encoding (desconocido/rumoreado/conocido/visitado), faction rings, leads badges, party marker with rollup, `?e=` deep links, Ctrl+K accent-folded search

### Play cockpit
- Party status bar (in-world calendar, credits, manifest-driven gauges)
- Quick-log bar: every action ≤2 taps (audited), sonner toasts
- Travel: route planner (euclidean legs, portal handling), consumption preview + GM override, per-day stepper with travel events
- Event engine: condition grammar (`evalCondition`), weighted draws with sesgos, `:::efecto` one-tap journal buttons
- LeadsBoard: derived-never-stored accionable, trama grouping, plazo chips
- ActRunner: plays a place's `:::` acts fullscreen reusing ActPanels/Audio/Timer/Initiative unmodified

### Session recorder
- Journal write path (FS Access readwrite, scoped to `diario/` + `estado/`): strict parseable line format, serialized coalescing rewrites, replay-based undo, crash mirror + recovery, `sesion_activa` lock, byte-preserved estado body

## Verification
- **381 unit tests / 1073 expects · 74 e2e ×2 runs zero flakes · tsc clean · static export**
- Classic session mode **byte-identical** (only the plan-mandated helper extraction; verified per-function)
- OPFS e2e seam exercises the real write path; console-hygiene test locks zero errors/warnings
- Adversarially verified per milestone (independent verify agents fixed 9 real bugs along the way)
- Real campaign `mundo/` folder validated end-to-end: 0 errores, 0 avisos

Built per the approved M0–M6 plan; M6 (campaign-side `mundo/` skeleton) lives in the campaign repo.